### PR TITLE
Feature/37 init frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,32 @@
-# Database Configuration (REQUIRED)
+# ─── Database (PostGIS) ───────────────────────────────────────────────────────
+# Local dev (docker-compose.infra.yml): DB_HOST=localhost
+# Full Docker stack (docker-compose.yml):  DB_HOST=db
 DB_NAME=the_hive_db
 DB_USER=postgres
-DB_PASSWORD=your_secure_password_here
-DB_HOST=db
+DB_PASSWORD=postgres123
+DB_HOST=localhost
+DB_PORT=5432
 
-# Django Settings (REQUIRED for production)
+# ─── Redis ────────────────────────────────────────────────────────────────────
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# ─── Django ───────────────────────────────────────────────────────────────────
+# Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 SECRET_KEY=your-secret-key-here-MUST-CHANGE
-DEBUG=False
-ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
-CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost,http://localhost:5173,http://localhost:3000
 
-# Throttling (optional)
-# If you have a small/private deployment and want to avoid occasional "Request was throttled" messages:
-# - THROTTLE_RELAXED keeps throttling enabled but raises limits significantly.
-# - DISABLE_THROTTLING disables throttling entirely (use carefully).
+# ─── Throttling ───────────────────────────────────────────────────────────────
+# THROTTLE_RELAXED=True   → raise limits but keep throttling enabled
+# DISABLE_THROTTLING=True → disable throttling entirely (local dev only)
 THROTTLE_RELAXED=True
 DISABLE_THROTTLING=False
 
-# Frontend Configuration
-VITE_API_URL=https://yourdomain.com/api
+# ─── Frontend ─────────────────────────────────────────────────────────────────
+# Used by docker-compose.yml / docker-compose.prod.yml
+VITE_API_URL=http://localhost/api
 FRONTEND_PORT=5173
 BACKEND_PORT=8000
-
-# Generate SECRET_KEY with:
-# python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
-# Optional: Email Configuration (for production)
 

--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,17 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Frontend
+frontend/node_modules/
+frontend/dist/
+frontend/.env
+frontend/.env.local
+frontend/.env.production
+
+# Docker / local env
+.env
+.env.local
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,140 +1,58 @@
 # Deployment Guide
 
-This document covers all supported ways to run **The Hive** — from a quick local development setup to a production server deployment.
+Three ways to run The Hive. All use **Docker Compose v2** (`docker compose`).
 
 ---
 
-## Table of Contents
+## Option 1 — Local Dev (recommended)
 
-- [Prerequisites](#prerequisites)
-- [Option 1 — Local Dev (infra in Docker, code runs natively)](#option-1--local-dev-infra-in-docker-code-runs-natively)
-- [Option 2 — Full Docker (local)](#option-2--full-docker-local)
-- [Option 3 — Production](#option-3--production)
-- [Environment Variables Reference](#environment-variables-reference)
-- [Useful Commands](#useful-commands)
-
----
-
-## Prerequisites
-
-| Tool | Minimum Version | Notes |
-|------|----------------|-------|
-| Docker Desktop | 4.x | Required for all options |
-| Docker Compose | v2 (included with Docker Desktop) | |
-| Python | 3.11+ | Option 1 only |
-| Node.js | 20.19+ or 22.12+ | Option 1 only |
-| make | any | Convenience wrapper |
-
-> **macOS (Apple Silicon):** GDAL and GEOS must be installed for the Django backend to run natively.
-> ```bash
-> brew install gdal geos
-> ```
-
----
-
-## Option 1 — Local Dev (infra in Docker, code runs natively)
-
-This is the recommended setup for day-to-day development. PostgreSQL/PostGIS and Redis run in Docker; the Django backend and Vite frontend run directly on your machine for the best hot-reload experience.
-
-### Architecture
+Infra runs in Docker; backend and frontend run natively for the best DX.
 
 ```
-localhost:5173  ←  Vite dev server  (native)
-localhost:8000  ←  Django runserver (native, .venv)
-localhost:5432  ←  PostGIS          (Docker)
-localhost:6379  ←  Redis            (Docker)
+localhost:5173  ←  Vite dev server
+localhost:8000  ←  Django runserver
+localhost:5432  ←  PostGIS  (Docker)
+localhost:6379  ←  Redis    (Docker)
 ```
 
-### First-time setup
+**Prerequisites:** Docker Desktop, Python 3.11+, Node.js 20.19+  
+**macOS only:** `brew install gdal geos`
 
 ```bash
-# From the project root
+# First-time setup (run once)
 make dev-setup
-```
 
-This single command will:
-1. Create `backend/.venv` (Python virtual environment) if it doesn't exist
-2. Install all Python dependencies from `backend/requirements.txt`
-3. Create `backend/.env` from `.env.example` (sets `DB_HOST=127.0.0.1`, generates a random `SECRET_KEY`)
-4. Start PostGIS and Redis via `docker-compose.infra.yml`
-5. Wait for the database to be ready, then run Django migrations
-6. Install frontend npm dependencies
-7. Seed the database with demo users and services
-
-> **Note:** If `backend/.env` already exists, it will not be overwritten. Edit it manually if needed.
-
-### Start development servers
-
-```bash
+# Daily start — Ctrl+C stops everything
 make dev
+
+# Stop infra containers
+make dev-stop
 ```
 
-Both processes start in the same terminal with coloured prefixes (`[backend]` / `[frontend]`). Press **Ctrl+C** to stop both.
+`make dev-setup` handles: venv creation → pip install → `.env` generation → infra up → `migrate` → npm install → demo seed.
+
+**Demo accounts** (password: `demo123`): `elif@demo.com`, `cem@demo.com`, `moderator@demo.com` (admin)
 
 | URL | Service |
 |-----|---------|
-| http://localhost:5173 | Frontend (Vite) |
-| http://localhost:8000/api/ | Django REST API |
+| http://localhost:5173 | Frontend |
+| http://localhost:8000/api/ | REST API |
 | http://localhost:8000/api/docs/ | Swagger UI |
-| http://localhost:8000/django-admin/ | Django admin |
-
-### Demo accounts 
-
-| Email | Role | Balance |
-|-------|------|---------|
-| `moderator@demo.com` | Admin | — |
-| `elif@demo.com` | User | 6.5 h |
-| `cem@demo.com` | User | 4.0 h |
-| `ayse@demo.com` | User | 7.0 h |
-| `mehmet@demo.com` | User | 8.5 h |
-| `zeynep@demo.com` | User | 9.0 h |
-
-### Stop infra
-
-```bash
-make dev-stop          # stop containers, keep volumes
-docker compose -f docker-compose.infra.yml down -v   # also delete data
-```
-
-### Re-seed demo data
-
-```bash
-cd backend && .venv/bin/python setup_demo.py
-```
 
 ---
 
 ## Option 2 — Full Docker (local)
 
-All services run inside Docker containers behind an Nginx reverse proxy. No local Python or Node.js installation required.
-
-### Architecture
-
-```
-http://localhost:80
-       │
-    Nginx (nginx/nginx.dev.conf)
-    ├── /api/*, /ws/*, /django-admin/, /media/  →  backend:8000
-    └── /*                                       →  frontend:5173 (Vite dev)
-```
-
-### Setup
+Everything runs in containers behind Nginx on port 80.
 
 ```bash
-# Copy and edit the root .env (optional — defaults work for local use)
-cp .env.example .env
+cp .env.example .env          # defaults work as-is for local use
 
-# Build images and start all services
 docker compose up -d --build
 
-# Run migrations
 docker compose exec backend python manage.py migrate
-
-# Seed demo data
 docker compose exec backend python setup_demo.py
 ```
-
-### Access
 
 | URL | Service |
 |-----|---------|
@@ -143,177 +61,76 @@ docker compose exec backend python setup_demo.py
 | http://localhost/api/docs/ | Swagger UI |
 | http://localhost/django-admin/ | Django admin |
 
-### Common commands
-
-```bash
-docker compose logs -f backend     # tail backend logs
-docker compose logs -f frontend    # tail frontend logs
-docker compose restart backend     # restart a single service
-docker compose down                # stop and remove containers (keeps volumes)
-docker compose down -v             # also remove volumes (⚠ deletes all data)
-```
-
 ---
 
 ## Option 3 — Production
 
-The production stack uses:
-- **multi-stage Docker build** for the frontend (static assets served directly by Nginx)
-- **Gunicorn/Daphne** ASGI server for the backend
-- **Nginx** as reverse proxy, serving static files and media
-- Health checks on all services
+Uses multi-stage frontend build, Daphne ASGI, and `docker-compose.prod.yml`.
 
-### Architecture
-
-```
-https://yourdomain.com
-       │
-    Nginx (nginx/nginx.prod.conf)
-    ├── /api/*, /ws/*, /django-admin/, /media/  →  backend:8000
-    └── /*                                       →  /usr/share/nginx/html (static build)
-```
-
-### 1. Provision the server
-
-Any Linux server (Ubuntu 22.04 LTS recommended) with:
-- Docker Engine + Docker Compose plugin
-- Port 80 (and 443 if using HTTPS) open in the firewall
+**Requirements:** Linux server with Docker Engine, ports 80/443 open.
 
 ```bash
-# Install Docker on Ubuntu
-curl -fsSL https://get.docker.com | sh
-sudo usermod -aG docker $USER   # log out and back in
+git clone <repo-url> /opt/thehive && cd /opt/thehive
+
+cp .env.example .env   # edit before continuing
 ```
 
-### 2. Clone the repository
-
-```bash
-git clone <repo-url> /opt/thehive
-cd /opt/thehive
-```
-
-### 3. Create the production `.env`
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` and set **all** of the following:
+Mandatory `.env` values for production:
 
 ```dotenv
-# Database
-DB_NAME=the_hive_db
-DB_USER=hive_user
-DB_PASSWORD=<strong-random-password>
-
-# Django
+DB_PASSWORD=<strong-password>
 SECRET_KEY=<run: python -c "import secrets; print(secrets.token_urlsafe(50))">
 DEBUG=False
-ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
-CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
-
-# Throttling (keep enabled in production)
-THROTTLE_RELAXED=False
-DISABLE_THROTTLING=False
+ALLOWED_HOSTS=yourdomain.com
+CORS_ALLOWED_ORIGINS=https://yourdomain.com
 ```
-
-> **Never** set `DEBUG=True` in production. Never commit `.env` to version control.
-
-### 4. (Optional) Configure HTTPS
-
-Place your TLS certificates in `nginx/certs/` and update `nginx/nginx.prod.conf` to enable the HTTPS server block. Using [Certbot](https://certbot.eff.org/) with the Nginx plugin is the recommended approach.
-
-### 5. Build and start
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d --build
-```
 
-### 6. Run migrations and collect static files
-
-```bash
 docker compose -f docker-compose.prod.yml exec backend python manage.py migrate
 docker compose -f docker-compose.prod.yml exec backend python manage.py collectstatic --no-input
 ```
 
-### 7. (Optional) Seed demo data
-
-```bash
-docker compose -f docker-compose.prod.yml exec backend python setup_demo.py
-```
-
-### 8. Verify health
-
-```bash
-# All services should show "healthy" or "running"
-docker compose -f docker-compose.prod.yml ps
-
-# Check API
-curl http://yourdomain.com/api/health/
-```
-
-### Updating the application
-
+**Update:**
 ```bash
 git pull
-
-# Rebuild only changed services
 docker compose -f docker-compose.prod.yml up -d --build backend frontend
-
-# Apply any new migrations
 docker compose -f docker-compose.prod.yml exec backend python manage.py migrate
 ```
 
-### Logs
+---
 
-```bash
-docker compose -f docker-compose.prod.yml logs -f          # all services
-docker compose -f docker-compose.prod.yml logs -f backend  # backend only
-```
+## Environment Variables
+
+| Variable | Default | Prod required | Notes |
+|----------|---------|:---:|-------|
+| `DB_NAME` | `the_hive_db` | | |
+| `DB_USER` | `postgres` | | |
+| `DB_PASSWORD` | `postgres123` | ✓ | Use a strong password |
+| `DB_HOST` | `localhost` | | `127.0.0.1` for Option 1; `db` inside Docker |
+| `SECRET_KEY` | — | ✓ | Must be long and random |
+| `DEBUG` | `True` | ✓ | Set `False` in prod |
+| `ALLOWED_HOSTS` | `localhost,127.0.0.1` | ✓ | |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | ✓ | |
+| `REDIS_HOST` | `localhost` | | `redis` inside Docker |
+| `DISABLE_THROTTLING` | `False` | | Dev convenience only |
+| `VITE_API_URL` | `/api` | | Frontend build-time var |
 
 ---
 
-## Environment Variables Reference
-
-| Variable | Default | Required in prod | Description |
-|----------|---------|-----------------|-------------|
-| `DB_NAME` | `the_hive_db` | ✓ | PostgreSQL database name |
-| `DB_USER` | `postgres` | ✓ | PostgreSQL user |
-| `DB_PASSWORD` | `postgres123` | ✓ | PostgreSQL password |
-| `DB_HOST` | `localhost` | — | `127.0.0.1` for Option 1, `db` inside Docker |
-| `DB_PORT` | `5432` | — | PostgreSQL port |
-| `SECRET_KEY` | — | ✓ | Django secret key (must be long and random) |
-| `DEBUG` | `True` | ✓ (set `False`) | Django debug mode |
-| `ALLOWED_HOSTS` | `localhost,127.0.0.1` | ✓ | Comma-separated allowed host names |
-| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | ✓ | Comma-separated allowed CORS origins |
-| `REDIS_HOST` | `localhost` | — | Redis host (`redis` inside Docker) |
-| `REDIS_PORT` | `6379` | — | Redis port |
-| `THROTTLE_RELAXED` | `True` | — | Raise API rate limits (useful for dev) |
-| `DISABLE_THROTTLING` | `False` | — | Disable throttling entirely (dev only) |
-| `VITE_API_URL` | `/api` | — | API base URL used by the frontend build |
-
----
-
-## Useful Commands
+## Quick Reference
 
 ```bash
-# ── Makefile shortcuts ────────────────────────────────────────────────────────
-make dev-setup     # First-time local setup (Option 1)
-make dev           # Start backend + frontend + infra (Option 1)
-make dev-stop      # Stop Docker infra containers
-make demo          # Start full Docker stack and seed demo data (Option 2)
-make build         # Build frontend for production
-make clean         # Remove caches, reports, build artefacts
+make dev-setup          # first-time local setup
+make dev                # start everything locally
+make dev-stop           # stop infra
+make demo               # full Docker stack + demo seed
+make build              # production frontend build
+make clean              # remove caches and build artefacts
 
-# ── Django management ─────────────────────────────────────────────────────────
-# (inside .venv for Option 1, or via docker compose exec backend for Options 2/3)
-python manage.py migrate
-python manage.py createsuperuser
-python manage.py shell
-
-# ── Docker helpers ────────────────────────────────────────────────────────────
-docker compose ps                          # service status
-docker compose exec backend bash          # shell into backend container
-docker compose exec db psql -U postgres   # connect to database
-docker volume ls                           # list volumes
+docker compose ps                         # service status
+docker compose exec backend bash          # shell into backend
+docker compose exec db psql -U postgres   # database shell
+docker compose logs -f backend            # tail logs
 ```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,319 @@
+# Deployment Guide
+
+This document covers all supported ways to run **The Hive** — from a quick local development setup to a production server deployment.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Option 1 — Local Dev (infra in Docker, code runs natively)](#option-1--local-dev-infra-in-docker-code-runs-natively)
+- [Option 2 — Full Docker (local)](#option-2--full-docker-local)
+- [Option 3 — Production](#option-3--production)
+- [Environment Variables Reference](#environment-variables-reference)
+- [Useful Commands](#useful-commands)
+
+---
+
+## Prerequisites
+
+| Tool | Minimum Version | Notes |
+|------|----------------|-------|
+| Docker Desktop | 4.x | Required for all options |
+| Docker Compose | v2 (included with Docker Desktop) | |
+| Python | 3.11+ | Option 1 only |
+| Node.js | 20.19+ or 22.12+ | Option 1 only |
+| make | any | Convenience wrapper |
+
+> **macOS (Apple Silicon):** GDAL and GEOS must be installed for the Django backend to run natively.
+> ```bash
+> brew install gdal geos
+> ```
+
+---
+
+## Option 1 — Local Dev (infra in Docker, code runs natively)
+
+This is the recommended setup for day-to-day development. PostgreSQL/PostGIS and Redis run in Docker; the Django backend and Vite frontend run directly on your machine for the best hot-reload experience.
+
+### Architecture
+
+```
+localhost:5173  ←  Vite dev server  (native)
+localhost:8000  ←  Django runserver (native, .venv)
+localhost:5432  ←  PostGIS          (Docker)
+localhost:6379  ←  Redis            (Docker)
+```
+
+### First-time setup
+
+```bash
+# From the project root
+make dev-setup
+```
+
+This single command will:
+1. Create `backend/.venv` (Python virtual environment) if it doesn't exist
+2. Install all Python dependencies from `backend/requirements.txt`
+3. Create `backend/.env` from `.env.example` (sets `DB_HOST=127.0.0.1`, generates a random `SECRET_KEY`)
+4. Start PostGIS and Redis via `docker-compose.infra.yml`
+5. Wait for the database to be ready, then run Django migrations
+6. Install frontend npm dependencies
+7. Seed the database with demo users and services
+
+> **Note:** If `backend/.env` already exists, it will not be overwritten. Edit it manually if needed.
+
+### Start development servers
+
+```bash
+make dev
+```
+
+Both processes start in the same terminal with coloured prefixes (`[backend]` / `[frontend]`). Press **Ctrl+C** to stop both.
+
+| URL | Service |
+|-----|---------|
+| http://localhost:5173 | Frontend (Vite) |
+| http://localhost:8000/api/ | Django REST API |
+| http://localhost:8000/api/docs/ | Swagger UI |
+| http://localhost:8000/django-admin/ | Django admin |
+
+### Demo accounts 
+
+| Email | Role | Balance |
+|-------|------|---------|
+| `moderator@demo.com` | Admin | — |
+| `elif@demo.com` | User | 6.5 h |
+| `cem@demo.com` | User | 4.0 h |
+| `ayse@demo.com` | User | 7.0 h |
+| `mehmet@demo.com` | User | 8.5 h |
+| `zeynep@demo.com` | User | 9.0 h |
+
+### Stop infra
+
+```bash
+make dev-stop          # stop containers, keep volumes
+docker compose -f docker-compose.infra.yml down -v   # also delete data
+```
+
+### Re-seed demo data
+
+```bash
+cd backend && .venv/bin/python setup_demo.py
+```
+
+---
+
+## Option 2 — Full Docker (local)
+
+All services run inside Docker containers behind an Nginx reverse proxy. No local Python or Node.js installation required.
+
+### Architecture
+
+```
+http://localhost:80
+       │
+    Nginx (nginx/nginx.dev.conf)
+    ├── /api/*, /ws/*, /django-admin/, /media/  →  backend:8000
+    └── /*                                       →  frontend:5173 (Vite dev)
+```
+
+### Setup
+
+```bash
+# Copy and edit the root .env (optional — defaults work for local use)
+cp .env.example .env
+
+# Build images and start all services
+docker compose up -d --build
+
+# Run migrations
+docker compose exec backend python manage.py migrate
+
+# Seed demo data
+docker compose exec backend python setup_demo.py
+```
+
+### Access
+
+| URL | Service |
+|-----|---------|
+| http://localhost | Frontend |
+| http://localhost/api/ | REST API |
+| http://localhost/api/docs/ | Swagger UI |
+| http://localhost/django-admin/ | Django admin |
+
+### Common commands
+
+```bash
+docker compose logs -f backend     # tail backend logs
+docker compose logs -f frontend    # tail frontend logs
+docker compose restart backend     # restart a single service
+docker compose down                # stop and remove containers (keeps volumes)
+docker compose down -v             # also remove volumes (⚠ deletes all data)
+```
+
+---
+
+## Option 3 — Production
+
+The production stack uses:
+- **multi-stage Docker build** for the frontend (static assets served directly by Nginx)
+- **Gunicorn/Daphne** ASGI server for the backend
+- **Nginx** as reverse proxy, serving static files and media
+- Health checks on all services
+
+### Architecture
+
+```
+https://yourdomain.com
+       │
+    Nginx (nginx/nginx.prod.conf)
+    ├── /api/*, /ws/*, /django-admin/, /media/  →  backend:8000
+    └── /*                                       →  /usr/share/nginx/html (static build)
+```
+
+### 1. Provision the server
+
+Any Linux server (Ubuntu 22.04 LTS recommended) with:
+- Docker Engine + Docker Compose plugin
+- Port 80 (and 443 if using HTTPS) open in the firewall
+
+```bash
+# Install Docker on Ubuntu
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER   # log out and back in
+```
+
+### 2. Clone the repository
+
+```bash
+git clone <repo-url> /opt/thehive
+cd /opt/thehive
+```
+
+### 3. Create the production `.env`
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set **all** of the following:
+
+```dotenv
+# Database
+DB_NAME=the_hive_db
+DB_USER=hive_user
+DB_PASSWORD=<strong-random-password>
+
+# Django
+SECRET_KEY=<run: python -c "import secrets; print(secrets.token_urlsafe(50))">
+DEBUG=False
+ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
+CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+
+# Throttling (keep enabled in production)
+THROTTLE_RELAXED=False
+DISABLE_THROTTLING=False
+```
+
+> **Never** set `DEBUG=True` in production. Never commit `.env` to version control.
+
+### 4. (Optional) Configure HTTPS
+
+Place your TLS certificates in `nginx/certs/` and update `nginx/nginx.prod.conf` to enable the HTTPS server block. Using [Certbot](https://certbot.eff.org/) with the Nginx plugin is the recommended approach.
+
+### 5. Build and start
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+### 6. Run migrations and collect static files
+
+```bash
+docker compose -f docker-compose.prod.yml exec backend python manage.py migrate
+docker compose -f docker-compose.prod.yml exec backend python manage.py collectstatic --no-input
+```
+
+### 7. (Optional) Seed demo data
+
+```bash
+docker compose -f docker-compose.prod.yml exec backend python setup_demo.py
+```
+
+### 8. Verify health
+
+```bash
+# All services should show "healthy" or "running"
+docker compose -f docker-compose.prod.yml ps
+
+# Check API
+curl http://yourdomain.com/api/health/
+```
+
+### Updating the application
+
+```bash
+git pull
+
+# Rebuild only changed services
+docker compose -f docker-compose.prod.yml up -d --build backend frontend
+
+# Apply any new migrations
+docker compose -f docker-compose.prod.yml exec backend python manage.py migrate
+```
+
+### Logs
+
+```bash
+docker compose -f docker-compose.prod.yml logs -f          # all services
+docker compose -f docker-compose.prod.yml logs -f backend  # backend only
+```
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Required in prod | Description |
+|----------|---------|-----------------|-------------|
+| `DB_NAME` | `the_hive_db` | ✓ | PostgreSQL database name |
+| `DB_USER` | `postgres` | ✓ | PostgreSQL user |
+| `DB_PASSWORD` | `postgres123` | ✓ | PostgreSQL password |
+| `DB_HOST` | `localhost` | — | `127.0.0.1` for Option 1, `db` inside Docker |
+| `DB_PORT` | `5432` | — | PostgreSQL port |
+| `SECRET_KEY` | — | ✓ | Django secret key (must be long and random) |
+| `DEBUG` | `True` | ✓ (set `False`) | Django debug mode |
+| `ALLOWED_HOSTS` | `localhost,127.0.0.1` | ✓ | Comma-separated allowed host names |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | ✓ | Comma-separated allowed CORS origins |
+| `REDIS_HOST` | `localhost` | — | Redis host (`redis` inside Docker) |
+| `REDIS_PORT` | `6379` | — | Redis port |
+| `THROTTLE_RELAXED` | `True` | — | Raise API rate limits (useful for dev) |
+| `DISABLE_THROTTLING` | `False` | — | Disable throttling entirely (dev only) |
+| `VITE_API_URL` | `/api` | — | API base URL used by the frontend build |
+
+---
+
+## Useful Commands
+
+```bash
+# ── Makefile shortcuts ────────────────────────────────────────────────────────
+make dev-setup     # First-time local setup (Option 1)
+make dev           # Start backend + frontend + infra (Option 1)
+make dev-stop      # Stop Docker infra containers
+make demo          # Start full Docker stack and seed demo data (Option 2)
+make build         # Build frontend for production
+make clean         # Remove caches, reports, build artefacts
+
+# ── Django management ─────────────────────────────────────────────────────────
+# (inside .venv for Option 1, or via docker compose exec backend for Options 2/3)
+python manage.py migrate
+python manage.py createsuperuser
+python manage.py shell
+
+# ── Docker helpers ────────────────────────────────────────────────────────────
+docker compose ps                          # service status
+docker compose exec backend bash          # shell into backend container
+docker compose exec db psql -U postgres   # connect to database
+docker volume ls                           # list volumes
+```

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,67 @@
-.PHONY: help install test test-backend test-frontend test-e2e test-all coverage coverage-backend coverage-frontend coverage-report clean demo build
+.PHONY: help install test test-backend test-frontend test-e2e test-all coverage coverage-backend coverage-frontend coverage-report clean demo build \
+        dev dev-setup dev-stop
+
+# ── Local dev config ──────────────────────────────────────────────────────────
+PYTHON  ?= python3
+VENV     = backend/.venv
+PIP      = $(CURDIR)/$(VENV)/bin/pip
+PYEXEC   = $(CURDIR)/$(VENV)/bin/python
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
 	@echo ''
 	@echo 'Available targets:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LOCAL DEVELOPMENT  (docker-compose.infra.yml for DB/Redis, local venv)
+# ─────────────────────────────────────────────────────────────────────────────
+
+dev-setup: ## One-time local setup: venv, deps, infra, migrate, demo data
+	@echo "\033[1;34m[1/7] Python virtual environment...\033[0m"
+	@test -d $(VENV) || $(PYTHON) -m venv $(VENV)
+	@echo "\033[1;34m[2/7] Installing backend dependencies...\033[0m"
+	@$(PIP) install -q -r backend/requirements.txt
+	@echo "\033[1;34m[3/7] Backend .env file...\033[0m"
+	@if [ ! -f backend/.env ]; then \
+		cp .env.example backend/.env; \
+		sed -i '' 's|DB_HOST=localhost|DB_HOST=127.0.0.1|g' backend/.env; \
+		KEY=$$(cd backend && $(PYEXEC) -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"); \
+		sed -i '' "s|SECRET_KEY=.*|SECRET_KEY=$$KEY|" backend/.env; \
+		echo "  Created backend/.env"; \
+	else \
+		echo "  backend/.env already exists, skipping."; \
+	fi
+	@echo "\033[1;34m[4/7] Starting infra (PostGIS + Redis)...\033[0m"
+	@docker compose -f docker-compose.infra.yml up -d
+	@echo "  Waiting for database to accept connections (15s)..."
+	@sleep 15
+	@echo "\033[1;34m[5/7] Running Django migrations...\033[0m"
+	@cd backend && $(PYEXEC) manage.py migrate
+	@echo "\033[1;34m[6/7] Installing frontend dependencies...\033[0m"
+	@cd frontend && npm install --silent
+	@echo "\033[1;34m[7/7] Seeding demo data...\033[0m"
+	@cd backend && DJANGO_SETTINGS_MODULE=hive_project.settings $(PYEXEC) setup_demo.py
+	@echo ""
+	@echo "\033[1;32m✓ Setup complete! Run  make dev  to start.\033[0m"
+	@echo "  Login: elif@demo.com / demo123"
+
+dev: ## Start local dev: infra + backend (8000) + frontend (5173) in parallel
+	@echo "\033[1;34m→ Starting infra...\033[0m"
+	@docker compose -f docker-compose.infra.yml up -d
+	@echo "\033[1;34m→ Starting backend (http://localhost:8000) and frontend (http://localhost:5173)...\033[0m"
+	@echo "  Press Ctrl+C to stop both.\n"
+	@trap 'kill 0; exit 0' INT TERM; \
+	(cd backend && $(PYEXEC) manage.py runserver 0.0.0.0:8000 2>&1 | sed 's/^/\033[0;36m[backend]\033[0m /') & \
+	(cd frontend && npm run dev 2>&1 | sed 's/^/\033[0;35m[frontend]\033[0m /') ; \
+	wait
+
+dev-stop: ## Stop local infra (PostGIS + Redis containers)
+	@echo "\033[1;34m→ Stopping infra...\033[0m"
+	@docker compose -f docker-compose.infra.yml down
+	@echo "\033[1;32m✓ Infra stopped.\033[0m"
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 install: ## Install all dependencies
 	cd backend && pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 # ─────────────────────────────────────────────────────────────────────────────
-# LOCAL DEVELOPMENT  (docker-compose.infra.yml for DB/Redis, local venv)
+# LOCAL DEVELOPMENT  (infra via docker compose, backend/frontend run natively)
 # ─────────────────────────────────────────────────────────────────────────────
 
 dev-setup: ## One-time local setup: venv, deps, infra, migrate, demo data

--- a/backend/hive_project/settings.py
+++ b/backend/hive_project/settings.py
@@ -12,9 +12,12 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 import os
 from pathlib import Path
+from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+load_dotenv(BASE_DIR / '.env')
 
 
 # Quick-start development settings - unsuitable for production
@@ -120,6 +123,19 @@ TEMPLATES = [
 WSGI_APPLICATION = 'hive_project.wsgi.application'
 ASGI_APPLICATION = 'hive_project.asgi.application'
 
+
+# GeoDjango — GDAL/GEOS library paths (macOS Homebrew)
+# Django 5+ doesn't try gdal3.12+ by name; set the path explicitly for local dev.
+import platform as _platform
+if _platform.system() == 'Darwin':
+    import subprocess as _sp
+    try:
+        _brew_prefix = _sp.check_output(['brew', '--prefix', 'gdal'], text=True).strip()
+        GDAL_LIBRARY_PATH = f'{_brew_prefix}/lib/libgdal.dylib'
+        _geos_prefix = _sp.check_output(['brew', '--prefix', 'geos'], text=True).strip()
+        GEOS_LIBRARY_PATH = f'{_geos_prefix}/lib/libgeos_c.dylib'
+    except Exception:
+        pass
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-django
+django>=4.2,<6.0
+python-dotenv
 djangorestframework
 djangorestframework-simplejwt
 psycopg2-binary
@@ -18,9 +19,3 @@ pytest-html>=3.2.0
 pytest-xdist>=3.3.0
 factory-boy>=3.3.0
 faker>=19.0.0
-pytest>=7.4.0
-pytest-django>=4.7.0
-pytest-cov>=4.1.0
-pytest-html>=3.2.0
-pytest-xdist>=3.3.0
-factory-boy>=3.3.0

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,0 +1,49 @@
+# Infrastructure only — PostGIS & Redis
+# Starts the external dependencies so the backend can run locally (outside Docker).
+#
+# Usage:
+#   docker compose -f docker-compose.infra.yml up -d
+#   docker compose -f docker-compose.infra.yml down
+#   docker compose -f docker-compose.infra.yml down -v   # also remove volumes
+
+services:
+  db:
+    image: imresamu/postgis-arm64:alpine-ver20251223-6b15838-2026w09
+    platform: linux/arm64/v8
+    container_name: hive_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB:       ${DB_NAME:-the_hive_db}
+      POSTGRES_USER:     ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres123}
+      PGDATA:            /var/lib/postgresql/data/pgdata
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: hive_redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes --loglevel warning
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,12 +1,31 @@
 services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro
+      - frontend_static:/usr/share/nginx/html:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   backend:
     build:
       context: ./backend
       dockerfile: Dockerfile.prod
     volumes:
       - media_data:/code/media
-    ports:
-      - "${BACKEND_PORT:-8000}:8000"
+    expose:
+      - "8000"
     depends_on:
       db:
         condition: service_healthy
@@ -50,15 +69,14 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.prod
       args:
-        - VITE_API_URL=${VITE_API_URL:-http://localhost:8000/api}
-    ports:
-      - "${FRONTEND_PORT:-5173}:5173"
-    depends_on:
-      backend:
-        condition: service_healthy
+        - VITE_API_URL=/api
+    volumes:
+      - frontend_static:/usr/share/nginx/html
+    expose:
+      - "80"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:5173"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -109,6 +127,8 @@ services:
     command: redis-server --save 60 1000 --loglevel warning
     volumes:
       - redis_data:/data
+    expose:
+      - "6379"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -133,4 +153,4 @@ volumes:
   postgres_data:
   redis_data:
   media_data:
-
+  frontend_static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,40 @@
 services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - backend
+      - frontend
+    restart: unless-stopped
+
   backend:
     build: ./backend
     command: daphne -b 0.0.0.0 -p 8000 hive_project.asgi:application
     volumes:
       - ./backend:/code
       - media_data:/code/media
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     depends_on:
       db:
         condition: service_started
       redis:
         condition: service_started
     environment:
-      - DB_NAME=the_hive_db
-      - DB_USER=your_postgres_user
-      - DB_PASSWORD=your_postgres_password
+      - DB_NAME=${DB_NAME:-the_hive_db}
+      - DB_USER=${DB_USER:-postgres}
+      - DB_PASSWORD=${DB_PASSWORD:-postgres123}
       - DB_HOST=db
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
+      - DEBUG=${DEBUG:-True}
       - DJANGO_E2E=${DJANGO_E2E:-0}
       - E2E=${E2E:-0}
-      - DISABLE_THROTTLING=1
+      - DISABLE_THROTTLING=${DISABLE_THROTTLING:-1}
 
   frontend:
     build: ./frontend
@@ -29,29 +42,39 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    ports:
-      - "5173:5173"  # Vite default port
+    expose:
+      - "5173"
     depends_on:
       - backend
     environment:
-      - VITE_API_URL=http://localhost:8000/api
-      - VITE_E2E=${VITE_E2E:-0}
+      - VITE_API_URL=/api
 
   db:
     image: postgis/postgis:15-3.4
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
-      - POSTGRES_DB=the_hive_db
-      - POSTGRES_USER=your_postgres_user
-      - POSTGRES_PASSWORD=your_postgres_password
+      - POSTGRES_DB=${DB_NAME:-the_hive_db}
+      - POSTGRES_USER=${DB_USER:-postgres}
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-postgres123}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
+    command: redis-server --appendonly yes --loglevel warning
+    expose:
+      - "6379"
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.local
+.env.production
+*.log

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,38 @@
+# ── Dev stage (used by docker-compose.yml) ────────────────────────────────────
+FROM node:20-alpine AS dev
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+
+# ── Build stage ────────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=${VITE_API_URL}
+
+RUN npm run build
+
+# ── Production stage ───────────────────────────────────────────────────────────
+FROM nginx:alpine AS production
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=${VITE_API_URL}
+
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,73 @@
+# React + TypeScript + Vite
+
+This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+
+Currently, two official plugins are available:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## React Compiler
+
+The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+
+## Expanding the ESLint configuration
+
+If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+
+```js
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+
+      // Remove tseslint.configs.recommended and replace with this
+      tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      tseslint.configs.stylisticTypeChecked,
+
+      // Other configs...
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```
+
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+
+```js
+// eslint.config.js
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+      // Enable lint rules for React
+      reactX.configs['recommended-typescript'],
+      // Enable lint rules for React DOM
+      reactDom.configs.recommended,
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Hive</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+      body { margin: 0; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; }
+      .spinner {
+        width: 40px; height: 40px;
+        border: 4px solid #F8C84A;
+        border-top-color: transparent;
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript
+               application/x-javascript application/xml+rss
+               application/javascript application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # No cache for index.html
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,5564 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@chakra-ui/react": "^3.33.0",
+        "axios": "^1.13.6",
+        "date-fns": "^4.1.0",
+        "leaflet": "^1.9.4",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-hook-form": "^7.71.2",
+        "react-icons": "^5.5.0",
+        "react-leaflet": "^5.0.0",
+        "react-router-dom": "^6.30.3",
+        "recharts": "^2.15.4",
+        "sonner": "^2.0.7",
+        "zustand": "^5.0.11"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@types/leaflet": "^1.9.21",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "eslint": "^9.39.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.5.0",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.48.0",
+        "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@ark-ui/react": {
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.34.0.tgz",
+      "integrity": "sha512-9NDgvAyu8sdiJGDjD5MTkgsSwnSU22iYs4emF8Kpn3O8GI4aOb4I65kxqaNjd2ROaFa83jdN9gKozaz3lyml7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.11.0",
+        "@zag-js/accordion": "1.35.2",
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/angle-slider": "1.35.2",
+        "@zag-js/async-list": "1.35.2",
+        "@zag-js/auto-resize": "1.35.2",
+        "@zag-js/avatar": "1.35.2",
+        "@zag-js/carousel": "1.35.2",
+        "@zag-js/cascade-select": "1.35.2",
+        "@zag-js/checkbox": "1.35.2",
+        "@zag-js/clipboard": "1.35.2",
+        "@zag-js/collapsible": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/color-picker": "1.35.2",
+        "@zag-js/color-utils": "1.35.2",
+        "@zag-js/combobox": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/date-picker": "1.35.2",
+        "@zag-js/date-utils": "1.35.2",
+        "@zag-js/dialog": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/drawer": "1.35.2",
+        "@zag-js/editable": "1.35.2",
+        "@zag-js/file-upload": "1.35.2",
+        "@zag-js/file-utils": "1.35.2",
+        "@zag-js/floating-panel": "1.35.2",
+        "@zag-js/focus-trap": "1.35.2",
+        "@zag-js/highlight-word": "1.35.2",
+        "@zag-js/hover-card": "1.35.2",
+        "@zag-js/i18n-utils": "1.35.2",
+        "@zag-js/image-cropper": "1.35.2",
+        "@zag-js/json-tree-utils": "1.35.2",
+        "@zag-js/listbox": "1.35.2",
+        "@zag-js/marquee": "1.35.2",
+        "@zag-js/menu": "1.35.2",
+        "@zag-js/navigation-menu": "1.35.2",
+        "@zag-js/number-input": "1.35.2",
+        "@zag-js/pagination": "1.35.2",
+        "@zag-js/password-input": "1.35.2",
+        "@zag-js/pin-input": "1.35.2",
+        "@zag-js/popover": "1.35.2",
+        "@zag-js/presence": "1.35.2",
+        "@zag-js/progress": "1.35.2",
+        "@zag-js/qr-code": "1.35.2",
+        "@zag-js/radio-group": "1.35.2",
+        "@zag-js/rating-group": "1.35.2",
+        "@zag-js/react": "1.35.2",
+        "@zag-js/scroll-area": "1.35.2",
+        "@zag-js/select": "1.35.2",
+        "@zag-js/signature-pad": "1.35.2",
+        "@zag-js/slider": "1.35.2",
+        "@zag-js/splitter": "1.35.2",
+        "@zag-js/steps": "1.35.2",
+        "@zag-js/switch": "1.35.2",
+        "@zag-js/tabs": "1.35.2",
+        "@zag-js/tags-input": "1.35.2",
+        "@zag-js/timer": "1.35.2",
+        "@zag-js/toast": "1.35.2",
+        "@zag-js/toggle": "1.35.2",
+        "@zag-js/toggle-group": "1.35.2",
+        "@zag-js/tooltip": "1.35.2",
+        "@zag-js/tour": "1.35.2",
+        "@zag-js/tree-view": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.33.0.tgz",
+      "integrity": "sha512-HNbUFsFABjVL5IHBxsqtuT+AH/vQT1+xsEWrxnG0GBM2VjlzlMqlqCxNiDyQOsjLZXQC1ciCMbzPNcSCc63Y9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark-ui/react": "^5.31.0",
+        "@emotion/is-prop-valid": "^1.4.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@pandacss/is-valid-prop": "^1.4.2",
+        "csstype": "^3.2.3"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.3",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.11.0.tgz",
+      "integrity": "sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pandacss/is-valid-prop": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.2.tgz",
+      "integrity": "sha512-wfZ4kzvHXQ9pG3wuIGTUCcbC7Op8pqIQZNIRY/bqWQu67WTHxZUHUPSZgQMhguI8Tz4ot+DNf4Qhha0bhLvNEQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@zag-js/accordion": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.35.2.tgz",
+      "integrity": "sha512-wawSszdN4rzGA0ejZxiOVAXMamXva6398bYuM35A21YcJsntpjSSxfwLsH8KDxwOxprrKTc9UksPzz+3hHTm2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/anatomy": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.35.2.tgz",
+      "integrity": "sha512-aHZBDq3472g8t8uwZBwKAVCxtpP51lqQKuyGnHzh2S5dwqsZMilPhRUEcTybxJEdWRTiRJq+UiYiclaFcr5stQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/angle-slider": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.35.2.tgz",
+      "integrity": "sha512-P3o6i88y91k9uO1oAVheAgAHdQQ0FvRJagm94d541ibwrn0F/QL4ZRZm0D5Y/u08CLhefVFROTxicEa+R01zFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/rect-utils": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/aria-hidden": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.35.2.tgz",
+      "integrity": "sha512-QWEU4fQwgrQRurqX7GUswin2iqE6w0gjpVWAhPukJ9891lZvRKiIp53SSnLQc+NvrxO3u2KA46+Onebt7GfLTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/async-list": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/async-list/-/async-list-1.35.2.tgz",
+      "integrity": "sha512-UZzncsKOKCzzxik6SiBRalRDbKao1RA2E545N8TxwMilDU9hqMSggimekX2r5uFu887puMqhay05LM7Kuhw/tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/auto-resize": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.35.2.tgz",
+      "integrity": "sha512-kg/0DKuvTxjBxfkgdcYU8dG9yfE0f8v6vTpUtYTJkPZUbgHVkQjtUwBwAaHYmROnK49Tl2IjxowNFiwRFpUF0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/avatar": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.35.2.tgz",
+      "integrity": "sha512-j2b63Hffc+p4Er5/MoU+u6J852ysoQzLtck5gWp9TiJgSBXgYyL2VibWkiUc6UPN9acuTrnKspnBdLgSb0n3eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/carousel": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.35.2.tgz",
+      "integrity": "sha512-cBufDBObRpYw5myeZuPCmbIi3KxJxmL3bD/BhIVarHZxuz/3xhzoObZti9xQEsuO8MNB85R2HuaMkvx2swLf9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/scroll-snap": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/cascade-select": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/cascade-select/-/cascade-select-1.35.2.tgz",
+      "integrity": "sha512-/3c1lPIN4bYTzRW5bMZLHeq9Z/BakCNulqrvS9HTgaofiHjSs0RzZSdwvqG3lu+Z+FqIUn8PT7scJbPT23bz4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/rect-utils": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/checkbox": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.35.2.tgz",
+      "integrity": "sha512-pKaBNJSkjEnJj2VVdVnF7t79dMH98L8Qtn45wsjKsONMpQOmZVNnCWcILlAYLDycO+qlI5ZHGVtMr/g5qFPW8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/clipboard": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.35.2.tgz",
+      "integrity": "sha512-XAWaZRRk38ZJ2UnmUW2os8wMzxh7AUPR0EEncmOasBvc3pZAYVLBN33N5uN6mTVtvkxosVlYyxvSI6iD9f5E/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/collapsible": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.35.2.tgz",
+      "integrity": "sha512-o8za0T4zXKuq5O4ghHtJHsr74Yj9CyyAqViva6l8bwa+WTv8bF7mppioBeCgnxJ8e3AQjYIdXzRX8FDsWAPJGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/collection": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.35.2.tgz",
+      "integrity": "sha512-iaZWAjy7V72k+KZEL3UDbJKJgTxQmp8MUEfhe51upo1GVOV0kR+2t4TJGcDO3YZO6/2SlzVkJQZGVWwJud/Bnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/color-picker": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.35.2.tgz",
+      "integrity": "sha512-Fyspx05WR6uoyOPyMEP4LOjVrA0uLwLBPUU6DtUW5wfZuBF1QGRAIH9giOQQMDontDraHdXRJU37hKclwpUuxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/color-utils": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/color-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.35.2.tgz",
+      "integrity": "sha512-4HBVf3qr/01mg9FXs9tgvRdkbqkCjYYrVGmBIetFPmt2mjFEsOTSfvap+e3Q1JCqPPT79dLWbWm1epMJ7zs/aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/combobox": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.35.2.tgz",
+      "integrity": "sha512-wNo2E4o6gdt6/mTKXUobN2dvbJyevSDFaZOuPXezRPFlDlFlZwgklawwGikRegXXdTPsm538qGAvxCLbQuLqeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/aria-hidden": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/core": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.35.2.tgz",
+      "integrity": "sha512-GDA27Val+dV/XEEVh9ghXky96eiC8W4JkSBFt21SecGqJl5LjKJQn9ZMg81TZ+kUwIEd0F3HTfk6FKLSjrC3qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/date-picker": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.35.2.tgz",
+      "integrity": "sha512-C9Or9Qn1TQIt6VoGEfoxpM1pwGZedHX99w+QGZJZErBBBPXejG8rzmCGOwqRI6Ui8Sqlbi9yjWNCY9qRCXKlaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/date-utils": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/live-region": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      },
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/date-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.35.2.tgz",
+      "integrity": "sha512-FGVkU2Dt8FRMTiXcPjarhM+FicSuRgLGvUb7y3/bi6v/lvr5KB/+nwEK+iwwH4IKBYO0Wi00Rn0yGYPX8kZjHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/dialog": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.35.2.tgz",
+      "integrity": "sha512-ruaURHvH2gQH4wgp9I/6fmIiCNbpRczJpsO7MN7PI5f3yvUWWy1yv7+wh/Wl9ni2hmglg316N+dccbalywyXIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/aria-hidden": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-trap": "1.35.2",
+        "@zag-js/remove-scroll": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/dismissable": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.35.2.tgz",
+      "integrity": "sha512-FebClz8ZEV5oWCJ4PKpMZqUjs7YkGgxwwHqCz7zRlD5Ng7+BJxfutuak+geCF7/8hzjo0QRuLhF0Hs5UZe0VfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/interact-outside": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/dom-query": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.35.2.tgz",
+      "integrity": "sha512-iuqtod4+8bMeVC/r5LER/sEqHPRFCXHAyEAdJnAScBnHvnQGbFr0NDxjx3G378gndjYimgHZb98id5rpFwW1Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/types": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/drawer": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/drawer/-/drawer-1.35.2.tgz",
+      "integrity": "sha512-xBmMN0n3iP6f8eVXUy6WFUTZFe6eZmVTm1phAk+psXIlKJwTOH488t07q2XHwlAucxuL9yT+Z7Vpc4cbGbehsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/aria-hidden": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-trap": "1.35.2",
+        "@zag-js/remove-scroll": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/editable": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.35.2.tgz",
+      "integrity": "sha512-FWMX487UlSPvkUKKfwZtQ3p4SB/bKQtseQPvvLel2CW643Fq/+c+fq5yKonluoP2vLWL78F+Jx0g0rGfZT9FvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/interact-outside": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/file-upload": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.35.2.tgz",
+      "integrity": "sha512-YOd8q3JQTzZ0XmeV4MQPl66ODlX7MtullCRlq1yOOdyVVFV1IVGSvuGR/ZNXib7tVFM1Dw5mEFz5NKhGFUSXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/file-utils": "1.35.2",
+        "@zag-js/i18n-utils": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/file-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.35.2.tgz",
+      "integrity": "sha512-J2Y0K3m/EY8usofW4UTa2y6AlCb+cha2EKAyrjCdF62/wGvbbrwxIXokhrz4825m3kx/xzRv962CijxWmnNLxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/i18n-utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/floating-panel": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.35.2.tgz",
+      "integrity": "sha512-rIuwpl/Dz+oAWPNtchuJ6f3zEbQpILqzl4eyqjH0ZbTzWQ7riuq+CvNKaDs6uhU8G8KhFDn54/qwu95OgL1YDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/rect-utils": "1.35.2",
+        "@zag-js/store": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/focus-trap": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.35.2.tgz",
+      "integrity": "sha512-37prN3Ta8+HPyZP+jC5lWS1euQcTM/8aa6VSKfjcpZdjW6Xfl6N3DR65/+cvXFur3pNbEo5J1SCCbVOJU2pvRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.35.2.tgz",
+      "integrity": "sha512-bfB50vZ6Gln2aH7tkaibJfaZZNEy5CJu5vlCSkCd04ccLnxLkO8dzeHOSeCpPw2VS0aer1oIvL4cpnfm6l8shA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/highlight-word": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.35.2.tgz",
+      "integrity": "sha512-ypK5KscytePkthY/AS41ZgWRl4v9+/jN1hTveiXLDJotk8B+pDOl/jGkVxE9Ka03+4amLIDgFcr3poA0UQNvzA==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/hover-card": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.35.2.tgz",
+      "integrity": "sha512-2lqqQD7uNexbEitx0zlJD5JHsciloWeE3rWMpOzzEZDQ7NjenyCU1cugpe93I4OlNPUpxtmUn9jvD/8nOtIUjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/i18n-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.35.2.tgz",
+      "integrity": "sha512-ICpqf18y9uLaBe9fhi7F13ircslUyzbE0orBhZBr16pNjFpIG0mCQ/zT7aL5/ZJcX8ncC1cH7DnwR9QaBk5vZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/image-cropper": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/image-cropper/-/image-cropper-1.35.2.tgz",
+      "integrity": "sha512-tGV06nsM2TrYl0KkAfvKhjKY4HzWQVhlEKw9mSk8PpcAb+ncMrFOtGy89kWR+IDUrUK+QF2LqW8ZC0cWoAxERA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/interact-outside": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.35.2.tgz",
+      "integrity": "sha512-++dzUJ5OSrLn6nJKTsu0oofKjlhhKn7kHAssI0MmNLYhdMnRSMli8INiR3y+OrvCi/pr3BXr2P9knq94LEZbBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/json-tree-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/json-tree-utils/-/json-tree-utils-1.35.2.tgz",
+      "integrity": "sha512-DIE22ZoCnqMb3PgQ6EOsSm7lLLFjz2KQvpF5WV/CeFlmXcVkM7KWfTMMYB8IcXWWSgaXM7jxgpJdjEGsFs+7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/listbox": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.35.2.tgz",
+      "integrity": "sha512-KoF8zplbN1OedRup3xHthLMtv6BbsXXRRlKef7lThUOLrzyTtD+gteBwwBLconeHPiAxsNi3SYDgknRMfkA5RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/live-region": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.35.2.tgz",
+      "integrity": "sha512-BgG14aSW2zo/RAXn8Kk2Ee3ol3HUFShtz25XJB9HH528g8KhSxfIC7NpLihW9MeNOMNLYAgieIHabEI7+mhs5g==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/marquee": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/marquee/-/marquee-1.35.2.tgz",
+      "integrity": "sha512-e0jWaxaYAxrcmUzHC2Jw6xEA5FaKosRcHUKixvpyTqwN5gDAatE1kYi3CVtyRysKlLcfwXaKzXqcozp9X3U7NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/menu": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.35.2.tgz",
+      "integrity": "sha512-W4+ds1S4bBWoaPLqvtDpvCEZv3AsCt3bQYBtD9f/1uB5ciwMjpe1hVb5VKcBQuTt9r3SogZ4Cfg/DeTP5dgx7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/rect-utils": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/navigation-menu": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/navigation-menu/-/navigation-menu-1.35.2.tgz",
+      "integrity": "sha512-553lPpZ9WBNijg//ufD0iqNNRgjQDrU33rZGUKA4wmTIrr/sh8DXcdmf5KmS3/PnJXrjDRs/cJpmDhvrQqefiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/number-input": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.35.2.tgz",
+      "integrity": "sha512-fOI4VG531EjpQwipBhUBhHjvjG7Si5YYZQr5BdjOyw/Fh79lk/itL2wc3lfS8GnDPpgNaAkbcBmT6Y5pDriP1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/number": "3.6.5",
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/pagination": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.35.2.tgz",
+      "integrity": "sha512-UoSVQ8UBlQ1RcT11pkk1gaAUamMmUAboPYqteU203jPo5G3l4CmrvgURQCgVeiHxNjDkV0FfmeiZ/qNy1LyECg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/password-input": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/password-input/-/password-input-1.35.2.tgz",
+      "integrity": "sha512-bVkO0Z8VKl7NwAOE2njA8icdVOXWPd62/5PpkgOQREr8NSTnbJ2+++uY9BwVFtpnp+WfkTdlFGksUhO7qdROxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/pin-input": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.35.2.tgz",
+      "integrity": "sha512-XgNcr+Qs/HvAvCH9LJtDssyc2Q41JupqMyl8O0HLIhxdGFg+ae+HwCBdpmfs+Pn3wLMBIqMSDktUfQ9USgmwuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/popover": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.35.2.tgz",
+      "integrity": "sha512-YS2GpZ8/l+V0I475f+RBYTLEImjyqs2j/chq4RMBtSKn5t4vxeV7PMoTtd8xg3IEtsfq8XKeBYYGWv0jQII8HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/aria-hidden": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-trap": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/remove-scroll": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/popper": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.35.2.tgz",
+      "integrity": "sha512-d867Lb0XYmde8sPPtrkGvW+0Y1owCIIV1aMycMnMmQXxSsc35ZrgF3g8Pwzn2vouIEQP/D7xhbuyGcJzWXyRug==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/presence": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.35.2.tgz",
+      "integrity": "sha512-NGK+dYDNkqu9TQzGzAQyKRfF85AdKLVR11qETxjUzBV/0Deah3XwKBqre6lGC3rjv4e3u4hqezY7JWdnp3diTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/progress": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.35.2.tgz",
+      "integrity": "sha512-53m2pxkqcVBuubMzKx7Gs6q6kgySz7Xj/g3av4ASNM33FJGPgYOi61dGI0QR8L38txuqy4pdwLKxuRBuJOa2kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/qr-code": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.35.2.tgz",
+      "integrity": "sha512-UA522xrboFunJViaVbnQipbdlxinbhF6mJTsPekfyEvYdUw9v69nbRpV/VEsvneCocfYa5lNDL25jNZWIjKc7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2",
+        "proxy-memoize": "3.0.1",
+        "uqr": "0.1.2"
+      }
+    },
+    "node_modules/@zag-js/radio-group": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.35.2.tgz",
+      "integrity": "sha512-FmhB35p1AgOxcGGKOBeQtJva972KqgQ4iiqkbgUIJEmbeHQgyhQCNJVx/IFpm+5IaC3IlZz5Jri0p5frJ+sYyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/rating-group": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.35.2.tgz",
+      "integrity": "sha512-hXCwtunVIiFo+DmvGo+nYl178ww+Av/nLMj/yEzFEKfaSET6VATB3kyRRHSp4E5Vc08b3fI9TIhS89lwRfnbCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/react": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.35.2.tgz",
+      "integrity": "sha512-RrLLRvVH55/xFZe2GTHzQ1JM/2csUM9uUHS1LiXeZxHQQWdlLMa9MH7Vv3K9FA7h30G4JQ6mj7VIdGWtq3eDkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.35.2",
+        "@zag-js/store": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@zag-js/rect-utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.35.2.tgz",
+      "integrity": "sha512-qJUM3611+M6mWAgcUuvyyu3PKSJbOrb045uZTGOOtmZXSHuuRqHQfgo/QN4MlA4veGiYi8unVnQ4Z70uZzKEnA==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/remove-scroll": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.35.2.tgz",
+      "integrity": "sha512-qdKOzbVRZpp4119hJjAyPx4CRaXR12gdLd2uPRV70W8LE7duVyfX2sigEE2OtTxzdffwFOi7z44eL6zbWz5Cfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/scroll-area": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-area/-/scroll-area-1.35.2.tgz",
+      "integrity": "sha512-n923pfUFmy9KNAnJcutmDsPZPAM7zJiwfemig+aPWpSIzLv198Sez0nyHZ9Azu2X2NcnEKhgsGR8FFbeRRF05A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/scroll-snap": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.35.2.tgz",
+      "integrity": "sha512-cDbh1kXxFRDCxjA7nbYOI3oSQbUQbe9BNZML/blDIhQn84tKku+Nsd/+dZZZyB3Ney0mVdtOjEbkBsnFAkulRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/select": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.35.2.tgz",
+      "integrity": "sha512-Y2zqpsJ1XjfuKUhi2GphwTn8aEHR7GPK2ZepJJz9e1BGKCFl5bL1SsDsT59N+GKY+7LiBEESyPi8+PIjnk7Prw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/signature-pad": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.35.2.tgz",
+      "integrity": "sha512-SSFDhPZ49hkZoJTqEgY7AJ7IJNgDQKoT7vByCuzPlIfIpt+KcIykwkOZKExtTlYo3qGfc7N5Eip6dS27i4pAkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2",
+        "perfect-freehand": "^1.2.2"
+      }
+    },
+    "node_modules/@zag-js/slider": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.35.2.tgz",
+      "integrity": "sha512-u9O2w7qph/PmIVaGFd8VMVP9FRhjSlKarnYismzc8Ah+emPso0QzmnVpqoYmZI5Iggv5RtVy6tmUgxnbQqi5ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/splitter": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.35.2.tgz",
+      "integrity": "sha512-tFaWjv6b83MKbgPLkox03FD3OeKR4b2cEz1r9L3nvRGt+/YRVqBqF8ZjlXX0SQMX8JPzkGdJnLostwEfjseTlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/steps": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.35.2.tgz",
+      "integrity": "sha512-ID06v8M2Z1NJmId0ifO2+dSfuNO6+fa2ZD0ux0vws2pMp6L/HA8Z2mDxXXMaoX8Yssris91Q0XcDiw2f5DU1YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/store": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.35.2.tgz",
+      "integrity": "sha512-8ak4muOo739qO+xlXIna9bcqGFbsB3jOcRt9+D04Vgj8IZ2wAZI0yK7/0vUJVJOj33CkgzAQJIVzOWxFty9mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "3.0.1"
+      }
+    },
+    "node_modules/@zag-js/switch": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.35.2.tgz",
+      "integrity": "sha512-2N+t+kAKE/+BkloVZ7v2Io8PnlFYaZJTE4m4/Qd1zLbsKg6lxBkTEk4tVtIqQ7ob/9O+xVO30SzVLj0jsOSihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/tabs": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.35.2.tgz",
+      "integrity": "sha512-YbqxXFbdC7IPdiRpDjwol7TiUnqq6RPV70W87VQAMUPDpoLShfoSULC5IvrOryG7C5dP2Eh1QXfn3WN71czevA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/tags-input": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.35.2.tgz",
+      "integrity": "sha512-C90JfiNz0UQb5egQ+UZD8C2BpE783x9lVGPUVpG3YTFBPieSbINWlcI3qCpuN/6ohtY8LtJQvKwSnqjPJCKaSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/auto-resize": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/interact-outside": "1.35.2",
+        "@zag-js/live-region": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/timer": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.35.2.tgz",
+      "integrity": "sha512-0nfQ3qU7uoBw82v9JmXle1F/voesO9PkQpoQ9F/ygGHvKYlcbePX+0A04BUD/H9BDZjHTIoLhd8tP13dX/mjgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/toast": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.35.2.tgz",
+      "integrity": "sha512-49tIclhb2yyt/jRcjjuQ5REssaVHSRcx/PSeeaUZZQfUtwGAmq1xj1PB2D8NXGayPQ9Ge/ILghbeu/77nsqhng==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/toggle": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.35.2.tgz",
+      "integrity": "sha512-HS1Isst1cngHyV8t8TJUCz6LVucQVOzRbLyT7Dw3hETNQeJWbdeqsy1ERorTMmDaPYiGDDrRcHQp6hTKwuowhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/toggle-group": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.35.2.tgz",
+      "integrity": "sha512-3HEtPTLSTstiSbFCYM3DKHqoXeXeaEBPjYTJQ+a4BhtlMn/qXAbW6HrgCm49EtSkCLJDD50MxJNUtGBZq6boqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/tooltip": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.35.2.tgz",
+      "integrity": "sha512-nQX79TKmWqA1nUsK1s2ZQ9ArYH9VnLHeCVUxHguavqaVS/dF+qVOwm5KSaVpUHw1U8YbpPpyKp6Xv86Vf8j4eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-visible": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/tour": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.35.2.tgz",
+      "integrity": "sha512-FLlfOmJIMnICMYQjS1yraBBw/BF9pQ8S4hMLvjdhZiZnZ+FnQLQq+avFlXul8RbECI/sXLnOC8ouy8koGIV+2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dismissable": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/focus-trap": "1.35.2",
+        "@zag-js/interact-outside": "1.35.2",
+        "@zag-js/popper": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/tree-view": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.35.2.tgz",
+      "integrity": "sha512-7s0ihoTyTCu8cGfxHZQO5mGcX/KK+JCkB3kk6Eo8DFLkFv1tgID9/UEofn51LicgNejrx1rKio3YlB13KMRanQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.35.2",
+        "@zag-js/collection": "1.35.2",
+        "@zag-js/core": "1.35.2",
+        "@zag-js/dom-query": "1.35.2",
+        "@zag-js/types": "1.35.2",
+        "@zag-js/utils": "1.35.2"
+      }
+    },
+    "node_modules/@zag-js/types": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.35.2.tgz",
+      "integrity": "sha512-Y78aZ4yrQJGGiFBh9j/PAPRbFEvHYb0YJ6PlbhqMes3liIH2GOPEdCllFvxMW/Zxck81SvEodrVoVbNLhKL0Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.2.3"
+      }
+    },
+    "node_modules/@zag-js/utils": {
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.35.2.tgz",
+      "integrity": "sha512-E/9S9hzXmeL94wkBY7PFv3ynopqCl0TLL//yhgMzRj0D00F54OWgjgKNY8bUZqSEPztJe/uNJEAwQ6QuyBIfsw==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.3",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/perfect-freehand": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.3.tgz",
+      "integrity": "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
+      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uqr": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^3.33.0",
+    "axios": "^1.13.6",
+    "date-fns": "^4.1.0",
+    "leaflet": "^1.9.4",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-hook-form": "^7.71.2",
+    "react-icons": "^5.5.0",
+    "react-leaflet": "^5.0.0",
+    "react-router-dom": "^6.30.3",
+    "recharts": "^2.15.4",
+    "sonner": "^2.0.7",
+    "zustand": "^5.0.11"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@types/leaflet": "^1.9.21",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "globals": "^16.5.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.1"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,151 @@
+import { lazy, Suspense, useEffect } from 'react'
+import { Routes, Route, useLocation } from 'react-router-dom'
+import { useAuthStore } from '@/store/useAuthStore'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import AdminProtectedRoute from '@/components/AdminProtectedRoute'
+import Navbar from '@/components/Navbar'
+
+// ─── Lazy-loaded Pages ────────────────────────────────────────────────────────
+const HomePage               = lazy(() => import('@/pages/HomePage'))
+const LoginPage              = lazy(() => import('@/pages/LoginPage'))
+const RegistrationPage       = lazy(() => import('@/pages/RegistrationPage'))
+const OnboardingPage         = lazy(() => import('@/pages/OnboardingPage'))
+const DashboardPage          = lazy(() => import('@/pages/DashboardPage'))
+const ServiceDetailPage      = lazy(() => import('@/pages/ServiceDetailPage'))
+const PostOfferForm          = lazy(() => import('@/pages/PostOfferForm'))
+const PostNeedForm           = lazy(() => import('@/pages/PostNeedForm'))
+const ChatPage               = lazy(() => import('@/pages/ChatPage'))
+const UserProfile            = lazy(() => import('@/pages/UserProfile'))
+const PublicProfile          = lazy(() => import('@/pages/PublicProfile'))
+const TransactionHistoryPage = lazy(() => import('@/pages/TransactionHistoryPage'))
+const NotificationsPage      = lazy(() => import('@/pages/NotificationsPage'))
+const AdminDashboard         = lazy(() => import('@/pages/AdminDashboard'))
+const ReportDetail           = lazy(() => import('@/pages/ReportDetail'))
+const ForumCategories        = lazy(() => import('@/pages/ForumCategories'))
+const ForumTopicList         = lazy(() => import('@/pages/ForumTopicList'))
+const ForumTopicDetail       = lazy(() => import('@/pages/ForumTopicDetail'))
+const ForumCreateTopic       = lazy(() => import('@/pages/ForumCreateTopic'))
+const AchievementView        = lazy(() => import('@/pages/AchievementView'))
+const NotFoundPage           = lazy(() => import('@/pages/NotFoundPage'))
+
+// ─── Page-level Loading Fallback ──────────────────────────────────────────────
+const PageFallback = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh' }}>
+    <div>Loading…</div>
+  </div>
+)
+
+// ─── Pages that render their own header (no global Navbar) ────────────────────
+const PAGES_WITHOUT_NAVBAR = ['/', '/login', '/register']
+
+// ─── Public pages where we skip the full-page spinner ─────────────────────────
+const PUBLIC_AUTH_PATHS = ['/login', '/register', '/']
+
+function App() {
+  const { checkAuth, isLoading, user } = useAuthStore()
+  const location = useLocation()
+
+  const isPublicAuthPage = PUBLIC_AUTH_PATHS.includes(location.pathname)
+  const showNavbar = !PAGES_WITHOUT_NAVBAR.includes(location.pathname)
+
+  useEffect(() => {
+    checkAuth()
+  }, [location.pathname, checkAuth])
+
+  if (isLoading && !user && !isPublicAuthPage) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <div>Loading…</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {showNavbar && <Navbar />}
+      <Suspense fallback={<PageFallback />}>
+        <Routes>
+          {/* ── Public ───────────────────────────────────────────────── */}
+          <Route path="/"               element={<HomePage />} />
+          <Route path="/login"          element={<LoginPage />} />
+          <Route path="/register"       element={<RegistrationPage />} />
+          <Route path="/dashboard"      element={<DashboardPage />} />
+          <Route path="/service-detail/:id" element={<ServiceDetailPage />} />
+          <Route path="/public-profile/:userId" element={<PublicProfile />} />
+
+          {/* ── Forum (public) ───────────────────────────────────────── */}
+          <Route path="/forum"                            element={<ForumCategories />} />
+          <Route path="/forum/category/:slug"             element={<ForumTopicList />} />
+          <Route path="/forum/topic/:topicId"             element={<ForumTopicDetail />} />
+
+          {/* ── Onboarding ───────────────────────────────────────────── */}
+          <Route
+            path="/onboarding"
+            element={
+              <ProtectedRoute>
+                <OnboardingPage />
+              </ProtectedRoute>
+            }
+          />
+
+          {/* ── Authenticated ────────────────────────────────────────── */}
+          <Route
+            path="/post-offer"
+            element={<ProtectedRoute><PostOfferForm /></ProtectedRoute>}
+          />
+          <Route
+            path="/post-need"
+            element={<ProtectedRoute><PostNeedForm /></ProtectedRoute>}
+          />
+          <Route
+            path="/messages"
+            element={<ProtectedRoute><ChatPage /></ProtectedRoute>}
+          />
+          <Route
+            path="/profile"
+            element={<ProtectedRoute><UserProfile /></ProtectedRoute>}
+          />
+          <Route
+            path="/transaction-history"
+            element={<ProtectedRoute><TransactionHistoryPage /></ProtectedRoute>}
+          />
+          <Route
+            path="/notifications"
+            element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>}
+          />
+          <Route
+            path="/achievements"
+            element={<ProtectedRoute><AchievementView /></ProtectedRoute>}
+          />
+          <Route
+            path="/forum/new"
+            element={<ProtectedRoute><ForumCreateTopic /></ProtectedRoute>}
+          />
+
+          {/* ── Admin ────────────────────────────────────────────────── */}
+          <Route
+            path="/admin"
+            element={
+              <AdminProtectedRoute>
+                <AdminDashboard />
+              </AdminProtectedRoute>
+            }
+          />
+          <Route
+            path="/report-detail/:id"
+            element={
+              <AdminProtectedRoute>
+                <ReportDetail />
+              </AdminProtectedRoute>
+            }
+          />
+
+          {/* ── 404 ──────────────────────────────────────────────────── */}
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
+    </>
+  )
+}
+
+export default App

--- a/frontend/src/components/AdminProtectedRoute.tsx
+++ b/frontend/src/components/AdminProtectedRoute.tsx
@@ -1,0 +1,40 @@
+import { Navigate } from 'react-router-dom'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useEffect, useState } from 'react'
+
+interface AdminProtectedRouteProps {
+  children: React.ReactNode
+}
+
+const AdminProtectedRoute = ({ children }: AdminProtectedRouteProps) => {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const user = useAuthStore((s) => s.user)
+  const checkAuth = useAuthStore((s) => s.checkAuth)
+  const [isChecking, setIsChecking] = useState(true)
+
+  useEffect(() => {
+    checkAuth().then(() => setIsChecking(false))
+  }, [checkAuth])
+
+  if (isChecking) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+        }}
+      >
+        <div className="spinner" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) return <Navigate to="/login" replace />
+  if (!user?.is_admin) return <Navigate to="/dashboard" replace />
+
+  return <>{children}</>
+}
+
+export default AdminProtectedRoute

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,0 +1,142 @@
+import { useEffect } from 'react'
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+// Fix default Leaflet marker icons in Vite/webpack
+delete (L.Icon.Default.prototype as unknown as Record<string, unknown>)._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+})
+
+const offerIcon = new L.Icon({
+  iconUrl:
+    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+const needIcon = new L.Icon({
+  iconUrl:
+    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+// Istanbul default center
+const ISTANBUL_CENTER: [number, number] = [41.0082, 28.9784]
+
+interface MapServiceItem {
+  id: string
+  title: string
+  type?: string
+  location_type?: string
+  location_lat?: string | number | null
+  location_lng?: string | number | null
+  latitude?: number
+  longitude?: number
+  user?: { first_name?: string; last_name?: string; email?: string }
+  provider?: { first_name?: string; last_name?: string; email?: string }
+}
+
+interface MapViewProps {
+  services: MapServiceItem[]
+  height?: string
+  onServiceClick?: (id: string) => void
+}
+
+function getCoords(
+  s: MapServiceItem,
+): [number, number] | null {
+  const lat = s.location_lat ?? s.latitude
+  const lng = s.location_lng ?? s.longitude
+  if (lat == null || lng == null) return null
+  const latNum = typeof lat === 'string' ? parseFloat(lat) : lat
+  const lngNum = typeof lng === 'string' ? parseFloat(lng) : lng
+  if (isNaN(latNum) || isNaN(lngNum)) return null
+  return [latNum, lngNum]
+}
+
+// Dummy component to invalidate map size after mount (handles hidden container issues)
+function MapResizer() {
+  const map = useMap()
+  useEffect(() => {
+    setTimeout(() => map.invalidateSize(), 100)
+  }, [map])
+  return null
+}
+
+export function MapView({ services, height = '400px', onServiceClick }: MapViewProps) {
+  const locatedServices = services.filter((s) => getCoords(s) !== null)
+
+  return (
+    <MapContainer
+      center={ISTANBUL_CENTER}
+      zoom={11}
+      style={{ height, width: '100%', borderRadius: '12px' }}
+      scrollWheelZoom={false}
+    >
+      <MapResizer />
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {locatedServices.map((service) => {
+        const coords = getCoords(service)!
+        const icon = service.type === 'Offer' ? offerIcon : needIcon
+        const owner = service.user ?? service.provider
+        const ownerName = owner
+          ? `${owner.first_name ?? ''} ${owner.last_name ?? ''}`.trim() || owner.email
+          : ''
+        return (
+          <Marker key={service.id} position={coords} icon={icon}>
+            <Popup>
+              <div style={{ minWidth: '140px' }}>
+                <strong style={{ fontSize: '13px' }}>{service.title}</strong>
+                {ownerName && (
+                  <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>
+                    {ownerName}
+                  </div>
+                )}
+                <div
+                  style={{
+                    display: 'inline-block',
+                    marginTop: '6px',
+                    padding: '2px 8px',
+                    borderRadius: '9999px',
+                    fontSize: '11px',
+                    background: service.type === 'Offer' ? '#dcfce7' : '#dbeafe',
+                    color: service.type === 'Offer' ? '#15803d' : '#1d4ed8',
+                  }}
+                >
+                  {service.type === 'Need' ? 'Want' : service.type}
+                </div>
+                {onServiceClick && (
+                  <div
+                    onClick={() => onServiceClick(service.id)}
+                    style={{
+                      marginTop: '8px',
+                      fontSize: '12px',
+                      color: '#f97316',
+                      cursor: 'pointer',
+                      fontWeight: 500,
+                    }}
+                  >
+                    View details →
+                  </div>
+                )}
+              </div>
+            </Popup>
+          </Marker>
+        )
+      })}
+    </MapContainer>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,354 @@
+import { useState, useRef, useEffect } from 'react'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
+import { Box, Flex, Text, Button, HStack } from '@chakra-ui/react'
+import {
+  FiMessageSquare,
+  FiUser,
+  FiBell,
+  FiLogOut,
+  FiChevronDown,
+  FiPlusCircle,
+  FiGrid,
+  FiMessageCircle,
+} from 'react-icons/fi'
+import { useAuthStore } from '@/store/useAuthStore'
+
+// ─── Brand colours ─────────────────────────────────────────────────────────
+const YELLOW = '#F8C84A'
+const GREEN = '#2D5C4E'
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+function initials(user: { first_name?: string; last_name?: string; email?: string } | null) {
+  if (!user) return '?'
+  const first = user.first_name?.[0] ?? ''
+  const last = user.last_name?.[0] ?? ''
+  if (first || last) return `${first}${last}`.toUpperCase()
+  return (user.email?.[0] ?? '?').toUpperCase()
+}
+
+// ─── Dropdown menu ─────────────────────────────────────────────────────────
+interface DropdownProps {
+  trigger: React.ReactNode
+  children: React.ReactNode
+}
+
+function Dropdown({ trigger, children }: DropdownProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <div onClick={() => setOpen((v) => !v)} style={{ cursor: 'pointer' }}>
+        {trigger}
+      </div>
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 'calc(100% + 8px)',
+            background: '#fff',
+            border: '1px solid #e5e7eb',
+            borderRadius: '12px',
+            boxShadow: '0 10px 25px rgba(0,0,0,0.12)',
+            zIndex: 100,
+            minWidth: '180px',
+            overflow: 'hidden',
+          }}
+          onClick={() => setOpen(false)}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface DropdownItemProps {
+  onClick?: () => void
+  icon?: React.ReactNode
+  children: React.ReactNode
+  danger?: boolean
+}
+
+function DropdownItem({ onClick, icon, children, danger }: DropdownItemProps) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '10px 16px',
+        fontSize: '14px',
+        color: danger ? '#dc2626' : '#374151',
+        cursor: 'pointer',
+        transition: 'background 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        ;(e.currentTarget as HTMLDivElement).style.background = danger ? '#fef2f2' : '#f9fafb'
+      }}
+      onMouseLeave={(e) => {
+        ;(e.currentTarget as HTMLDivElement).style.background = 'transparent'
+      }}
+    >
+      {icon && <span style={{ opacity: 0.7 }}>{icon}</span>}
+      {children}
+    </div>
+  )
+}
+
+// ─── NavLink ───────────────────────────────────────────────────────────────
+interface NavLinkProps {
+  to: string
+  icon?: React.ReactNode
+  children: React.ReactNode
+  active?: boolean
+}
+
+function NavLink({ to, icon, children, active }: NavLinkProps) {
+  return (
+    <Link
+      to={to}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '6px 12px',
+        borderRadius: '8px',
+        fontSize: '14px',
+        fontWeight: active ? 600 : 400,
+        color: active ? GREEN : '#374151',
+        background: active ? `${YELLOW}44` : 'transparent',
+        textDecoration: 'none',
+        transition: 'background 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        if (!active) {
+          ;(e.currentTarget as HTMLAnchorElement).style.background = '#f9fafb'
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!active) {
+          ;(e.currentTarget as HTMLAnchorElement).style.background = 'transparent'
+        }
+      }}
+    >
+      {icon}
+      {children}
+    </Link>
+  )
+}
+
+// ─── Navbar ────────────────────────────────────────────────────────────────
+const Navbar = () => {
+  const { user, isAuthenticated, logout } = useAuthStore()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
+  const balance = user?.timebank_balance ?? 0
+
+  return (
+    <Box
+      as="nav"
+      position="sticky"
+      top={0}
+      zIndex={50}
+      bg="white"
+      borderBottom="1px solid"
+      borderColor="gray.100"
+      boxShadow="0 1px 4px rgba(0,0,0,0.06)"
+    >
+      <Flex
+        maxW="1440px"
+        mx="auto"
+        px={8}
+        h="64px"
+        align="center"
+        justify="space-between"
+      >
+        {/* ── Logo ─── */}
+        <Link to="/" style={{ textDecoration: 'none' }}>
+          <Flex align="center" gap={2}>
+            <Box
+              w="32px"
+              h="32px"
+              bg={YELLOW}
+              borderRadius="8px"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              fontWeight="black"
+              fontSize="16px"
+              color={GREEN}
+            >
+              H
+            </Box>
+            <Text fontWeight="700" fontSize="lg" color="gray.900">
+              The Hive
+            </Text>
+          </Flex>
+        </Link>
+
+        {/* ── Nav links (authenticated) ─── */}
+        {isAuthenticated && (
+          <HStack gap={1}>
+            <NavLink to="/dashboard" icon={<FiGrid size={15} />} active={location.pathname === '/dashboard'}>
+              Browse
+            </NavLink>
+            <NavLink to="/forum" icon={<FiMessageCircle size={15} />} active={location.pathname.startsWith('/forum')}>
+              Forum
+            </NavLink>
+            <NavLink to="/messages" icon={<FiMessageSquare size={15} />} active={location.pathname === '/messages'}>
+              Messages
+            </NavLink>
+          </HStack>
+        )}
+
+        {/* ── Right side ─── */}
+        <HStack gap={3}>
+          {isAuthenticated ? (
+            <>
+              {/* Post service dropdown */}
+              <Dropdown
+                trigger={
+                  <Button
+                    size="sm"
+                    style={{ background: YELLOW, color: GREEN, fontWeight: 600, borderRadius: '9999px', display: 'flex', alignItems: 'center', gap: '6px' }}
+                  >
+                    <FiPlusCircle size={15} />
+                    Post Service
+                    <FiChevronDown size={13} />
+                  </Button>
+                }
+              >
+                <DropdownItem onClick={() => navigate('/post-offer')} icon={<FiPlusCircle size={14} />}>
+                  Offer a Service
+                </DropdownItem>
+                <DropdownItem onClick={() => navigate('/post-need')} icon={<FiPlusCircle size={14} />}>
+                  Request a Service
+                </DropdownItem>
+              </Dropdown>
+
+              {/* Balance badge */}
+              <Box
+                px={3}
+                py={1}
+                bg="#fffbeb"
+                border="1px solid #fde68a"
+                borderRadius="9999px"
+                fontSize="13px"
+                fontWeight={600}
+                color={GREEN}
+                display="flex"
+                alignItems="center"
+                gap={1}
+              >
+                ⏱ {balance.toFixed(1)}h
+              </Box>
+
+              {/* Notifications */}
+              <Box
+                as="button"
+                onClick={() => navigate('/notifications')}
+                p={2}
+                borderRadius="9999px"
+                _hover={{ bg: 'gray.100' }}
+                cursor="pointer"
+                color="gray.600"
+              >
+                <FiBell size={18} />
+              </Box>
+
+              {/* User dropdown */}
+              <Dropdown
+                trigger={
+                  <Flex align="center" gap={2} p={1} borderRadius="9999px" _hover={{ bg: 'gray.100' }}>
+                    <Box
+                      w="34px"
+                      h="34px"
+                      borderRadius="full"
+                      bg={YELLOW}
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="center"
+                      fontWeight="700"
+                      fontSize="13px"
+                      color={GREEN}
+                      overflow="hidden"
+                      flexShrink={0}
+                    >
+                      {user?.avatar_url ? (
+                        <img
+                          src={user.avatar_url}
+                          alt="avatar"
+                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                        />
+                      ) : (
+                        initials(user)
+                      )}
+                    </Box>
+                    <FiChevronDown size={13} style={{ color: '#6b7280' }} />
+                  </Flex>
+                }
+              >
+                <Box px={4} py={3} borderBottom="1px solid #f3f4f6">
+                  <Text fontSize="14px" fontWeight={600} color="gray.900">
+                    {user?.first_name} {user?.last_name}
+                  </Text>
+                  <Text fontSize="12px" color="gray.500">
+                    {user?.email}
+                  </Text>
+                </Box>
+                <DropdownItem onClick={() => navigate('/profile')} icon={<FiUser size={14} />}>
+                  My Profile
+                </DropdownItem>
+                {user?.is_admin && (
+                  <DropdownItem onClick={() => navigate('/admin')} icon={<FiGrid size={14} />}>
+                    Admin Panel
+                  </DropdownItem>
+                )}
+                <DropdownItem onClick={handleLogout} icon={<FiLogOut size={14} />} danger>
+                  Log Out
+                </DropdownItem>
+              </Dropdown>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate('/login')}
+                style={{ color: '#374151' }}
+              >
+                Log In
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => navigate('/register')}
+                style={{ background: GREEN, color: '#fff', borderRadius: '9999px' }}
+              >
+                Sign Up
+              </Button>
+            </>
+          )}
+        </HStack>
+      </Flex>
+    </Box>
+  )
+}
+
+export default Navbar

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,56 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useEffect, useState } from 'react'
+import apiClient from '@/services/api'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const checkAuth = useAuthStore((s) => s.checkAuth)
+  const location = useLocation()
+  const [isChecking, setIsChecking] = useState(true)
+  const [isOnboarded, setIsOnboarded] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    checkAuth().then(() => setIsChecking(false))
+  }, [checkAuth])
+
+  useEffect(() => {
+    if (!isChecking && isAuthenticated) {
+      apiClient
+        .get<{ is_onboarded?: boolean }>('/users/me/profile/')
+        .then((res) => setIsOnboarded(res.data.is_onboarded ?? false))
+        .catch(() => setIsOnboarded(false))
+    }
+  }, [isChecking, isAuthenticated])
+
+  if (isChecking || (isAuthenticated && isOnboarded === null)) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+        }}
+      >
+        <div className="spinner" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  if (!isOnboarded && location.pathname !== '/onboarding') {
+    return <Navigate to="/onboarding" replace />
+  }
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+
+interface WebSocketMessage {
+  type: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message?: any
+  error?: string
+}
+
+interface UseWebSocketOptions {
+  url: string
+  token: string | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onMessage?: (message: any) => void
+  onError?: (error: Event) => void
+  onOpen?: () => void
+  onClose?: () => void
+  enabled?: boolean
+}
+
+export function useWebSocket({
+  url,
+  token,
+  onMessage,
+  onError,
+  onOpen,
+  onClose,
+  enabled = true,
+}: UseWebSocketOptions) {
+  const [isConnected, setIsConnected] = useState(false)
+  const [reconnectAttempts, setReconnectAttempts] = useState(0)
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onMessageRef = useRef(onMessage)
+  const onErrorRef = useRef(onError)
+  const onOpenRef = useRef(onOpen)
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onMessageRef.current = onMessage
+    onErrorRef.current = onError
+    onOpenRef.current = onOpen
+    onCloseRef.current = onClose
+  }, [onMessage, onError, onOpen, onClose])
+
+  const connect = useCallback(() => {
+    if (!enabled || !token || !url) return
+
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+
+    const wsUrl = url.includes('?') ? `${url}&token=${token}` : `${url}?token=${token}`
+
+    try {
+      const ws = new WebSocket(wsUrl)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        setIsConnected(true)
+        setReconnectAttempts(0)
+        onOpenRef.current?.()
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const data: WebSocketMessage = JSON.parse(event.data as string)
+          if (data.type === 'chat_message' && data.message) {
+            onMessageRef.current?.(data.message)
+          } else if (data.type === 'notification' && data.message) {
+            onMessageRef.current?.(data.message)
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+
+      ws.onerror = (error) => {
+        onErrorRef.current?.(error)
+      }
+
+      ws.onclose = (event) => {
+        setIsConnected(false)
+        onCloseRef.current?.()
+
+        if (event.code !== 1000 && enabled) {
+          setReconnectAttempts((prev) => {
+            if (prev < 5) {
+              const delay = Math.min(1000 * Math.pow(2, prev), 30_000)
+              reconnectTimeoutRef.current = setTimeout(() => {
+                connect()
+              }, delay)
+              return prev + 1
+            }
+            return prev
+          })
+        }
+      }
+    } catch (error) {
+      onErrorRef.current?.(error as Event)
+    }
+  }, [url, token, enabled])
+
+  const disconnect = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current)
+      reconnectTimeoutRef.current = null
+    }
+    if (wsRef.current) {
+      wsRef.current.close(1000)
+      wsRef.current = null
+    }
+    setIsConnected(false)
+    setReconnectAttempts(0)
+  }, [])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sendMessage = useCallback((message: any) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'chat_message', body: message }))
+      return true
+    }
+    return false
+  }, [])
+
+  useEffect(() => {
+    if (enabled && token && url) {
+      connect()
+    } else {
+      disconnect()
+    }
+    return () => { disconnect() }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, token, url])
+
+  return { isConnected, sendMessage, disconnect, connect, reconnectAttempts }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ChakraProvider } from '@chakra-ui/react'
+import { BrowserRouter } from 'react-router-dom'
+import { Toaster } from 'sonner'
+import App from './App'
+import system from './theme'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ChakraProvider value={system}>
+      <BrowserRouter>
+        <App />
+        <Toaster position="top-right" richColors />
+      </BrowserRouter>
+    </ChakraProvider>
+  </StrictMode>,
+)

--- a/frontend/src/pages/AchievementView.tsx
+++ b/frontend/src/pages/AchievementView.tsx
@@ -1,0 +1,10 @@
+const AchievementView = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>AchievementView</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default AchievementView

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,0 +1,10 @@
+const AdminDashboard = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>AdminDashboard</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default AdminDashboard

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,10 @@
+const ChatPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ChatPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ChatPage

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,567 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Box,
+  Flex,
+  Text,
+  Button,
+  Input,
+  Grid,
+  VStack,
+  HStack,
+  Badge,
+  Spinner,
+} from '@chakra-ui/react'
+import {
+  FiSearch,
+  FiNavigation,
+  FiMapPin,
+  FiClock,
+  FiUsers,
+  FiMonitor,
+  FiCalendar,
+  FiLoader,
+} from 'react-icons/fi'
+import { MapView } from '@/components/MapView'
+import { serviceAPI } from '@/services/serviceAPI'
+import { useAuthStore } from '@/store/useAuthStore'
+import { getErrorMessage } from '@/services/api'
+import type { Service } from '@/types'
+
+const YELLOW = '#F8C84A'
+const GREEN = '#2D5C4E'
+const ORANGE = '#f97316'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatHours(h: number | string | undefined | null) {
+  const n = typeof h === 'string' ? parseFloat(h) : (h ?? 0)
+  if (isNaN(n)) return '?'
+  return Number.isInteger(n) ? String(n) : n.toFixed(1)
+}
+
+function userInitials(u?: { first_name?: string; last_name?: string; email?: string } | null) {
+  if (!u) return '?'
+  const f = u.first_name?.[0] ?? ''
+  const l = u.last_name?.[0] ?? ''
+  if (f || l) return `${f}${l}`.toUpperCase()
+  return (u.email?.[0] ?? '?').toUpperCase()
+}
+
+function userName(u?: { first_name?: string; last_name?: string; email?: string } | null) {
+  if (!u) return 'User'
+  const name = `${u.first_name ?? ''} ${u.last_name ?? ''}`.trim()
+  return name || u.email || 'User'
+}
+
+// ─── Filter tabs ──────────────────────────────────────────────────────────────
+const FILTERS = [
+  { id: 'all', label: 'All Services' },
+  { id: 'weekend', label: 'This Weekend' },
+  { id: 'online', label: 'Online Only' },
+  { id: 'recurrent', label: 'Recurrent' },
+  { id: 'newest', label: 'Newest' },
+]
+
+const DEBOUNCE_SEARCH = 400
+const DEBOUNCE_DISTANCE = 600
+const POLL_INTERVAL = 30_000
+const GEO_TIMEOUT = 10_000
+
+// ─── Component ────────────────────────────────────────────────────────────────
+const DashboardPage = () => {
+  const navigate = useNavigate()
+  useAuthStore()
+
+  const [activeFilter, setActiveFilter] = useState('all')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [services, setServices] = useState<Service[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+
+  // Location state
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null)
+  const [distanceKm, setDistanceKm] = useState(10)
+  const [debouncedDistance, setDebouncedDistance] = useState(10)
+  const [locationEnabled, setLocationEnabled] = useState(() => localStorage.getItem('locationEnabled') === 'true')
+  const [locationLoading, setLocationLoading] = useState(false)
+  const [locationError, setLocationError] = useState<string | null>(null)
+
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const distanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounce search
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(() => setDebouncedSearch(searchQuery), DEBOUNCE_SEARCH)
+    return () => { if (searchTimer.current) clearTimeout(searchTimer.current) }
+  }, [searchQuery])
+
+  // Debounce distance
+  useEffect(() => {
+    if (distanceTimer.current) clearTimeout(distanceTimer.current)
+    distanceTimer.current = setTimeout(() => setDebouncedDistance(distanceKm), DEBOUNCE_DISTANCE)
+    return () => { if (distanceTimer.current) clearTimeout(distanceTimer.current) }
+  }, [distanceKm])
+
+  // Request geolocation
+  const requestLocation = useCallback(() => {
+    setLocationLoading(true)
+    setLocationError(null)
+    if (!navigator.geolocation) {
+      setLocationError('Geolocation is not supported by your browser')
+      setLocationLoading(false)
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setUserLocation({ lat: pos.coords.latitude, lng: pos.coords.longitude })
+        setLocationEnabled(true)
+        localStorage.setItem('locationEnabled', 'true')
+        setLocationLoading(false)
+      },
+      (err) => {
+        const msgs: Record<number, string> = {
+          [err.PERMISSION_DENIED]: 'Location permission denied',
+          [err.POSITION_UNAVAILABLE]: 'Location information unavailable',
+          [err.TIMEOUT]: 'Location request timed out',
+        }
+        setLocationError(msgs[err.code] ?? 'Unable to get your location')
+        setLocationLoading(false)
+      },
+      { enableHighAccuracy: true, timeout: GEO_TIMEOUT, maximumAge: 300_000 },
+    )
+  }, [])
+
+  const toggleLocation = useCallback(() => {
+    if (locationEnabled) {
+      setLocationEnabled(false)
+      localStorage.setItem('locationEnabled', 'false')
+    } else if (userLocation) {
+      setLocationEnabled(true)
+      localStorage.setItem('locationEnabled', 'true')
+    } else {
+      requestLocation()
+    }
+  }, [locationEnabled, userLocation, requestLocation])
+
+  // Fetch & filter services
+  useEffect(() => {
+    let mounted = true
+    const controller = new AbortController()
+
+    const fetchServices = async () => {
+      try {
+        setIsLoading(true)
+        setFetchError(null)
+
+        const params =
+          locationEnabled && userLocation
+            ? { lat: userLocation.lat, lng: userLocation.lng, distance: debouncedDistance }
+            : undefined
+
+        const data = await serviceAPI.list(params, controller.signal)
+        if (!mounted || controller.signal.aborted) return
+
+        const unique = Array.from(new Map(data.map((s) => [s.id, s])).values())
+
+        let filtered = unique
+
+        if (activeFilter === 'online') {
+          filtered = filtered.filter((s) => s.location_type === 'Online')
+        } else if (activeFilter === 'recurrent') {
+          filtered = filtered.filter((s) => s.schedule_type === 'Recurrent')
+        } else if (activeFilter === 'newest') {
+          filtered = [...filtered].sort(
+            (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+          )
+        } else if (activeFilter === 'weekend') {
+          filtered = filtered.filter((s) => {
+            const details = s.schedule_details?.toLowerCase() ?? ''
+            return details.includes('saturday') || details.includes('sunday') || details.includes('weekend')
+          })
+        }
+
+        if (debouncedSearch.trim()) {
+          const q = debouncedSearch.toLowerCase()
+          filtered = filtered.filter(
+            (s) =>
+              s.title.toLowerCase().includes(q) ||
+              s.description.toLowerCase().includes(q) ||
+              s.tags?.some((t) => t.name.toLowerCase().includes(q)),
+          )
+        }
+
+        if (mounted) {
+          setServices(filtered)
+          setIsLoading(false)
+        }
+      } catch (err: unknown) {
+        if (!mounted) return
+        const e = err as { name?: string; code?: string }
+        if (e?.name === 'AbortError' || e?.name === 'CanceledError' || e?.code === 'ERR_CANCELED') {
+          setIsLoading(false)
+          return
+        }
+        setFetchError(getErrorMessage(err, 'Failed to load services. Please try again.'))
+        setIsLoading(false)
+      }
+    }
+
+    fetchServices()
+    const timer = setInterval(fetchServices, POLL_INTERVAL)
+    const onVisible = () => { if (!document.hidden && mounted) fetchServices() }
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      mounted = false
+      controller.abort()
+      clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [activeFilter, debouncedSearch, locationEnabled, userLocation, debouncedDistance])
+
+  const distanceLabel =
+    distanceKm <= 5 ? 'Nearby' : distanceKm <= 15 ? 'Local Area' : distanceKm <= 30 ? 'Wider Area' : 'City-wide'
+
+  return (
+    <Box minH="100vh" bg="gray.50">
+      {/* ── Page header ── */}
+      <Box maxW="1440px" mx="auto" px={8} pt={8} pb={2}>
+        <Text as="h1" fontSize="2xl" fontWeight="800" color="gray.900" mb={1}>
+          Browse Services
+        </Text>
+        <Text color="gray.500" fontSize="sm">
+          Discover what your community has to offer and share
+        </Text>
+      </Box>
+
+      <Box maxW="1440px" mx="auto" px={8} pb={12}>
+        {/* ── Map ── */}
+        <Box bg="white" borderRadius="xl" border="1px solid" borderColor="gray.200" p={4} mb={8}>
+          <Flex align="center" justify="space-between" mb={3}>
+            <Text fontWeight="600" color="gray.900">
+              Map View
+            </Text>
+            <HStack gap={4} fontSize="sm">
+              <Flex align="center" gap={2}>
+                <Box w={3} h={3} borderRadius="full" bg="green.400" />
+                <Text color="gray.500">Offers</Text>
+              </Flex>
+              <Flex align="center" gap={2}>
+                <Box w={3} h={3} borderRadius="full" bg="blue.400" />
+                <Text color="gray.500">Wants</Text>
+              </Flex>
+            </HStack>
+          </Flex>
+          <MapView
+            services={services}
+            height="380px"
+            onServiceClick={(id) => navigate(`/service-detail/${id}`)}
+          />
+        </Box>
+
+        {/* ── Controls ── */}
+        <VStack gap={4} mb={6} align="stretch">
+          {/* Search input */}
+          <Flex
+            align="center"
+            bg="white"
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="lg"
+            overflow="hidden"
+            _focusWithin={{ borderColor: ORANGE, boxShadow: `0 0 0 2px ${ORANGE}22` }}
+          >
+            <Box px={3} color="gray.400">
+              <FiSearch size={17} />
+            </Box>
+            <Input
+              placeholder="Search services, skills, or tags…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              border="none"
+              outline="none"
+              _focus={{ boxShadow: 'none' }}
+              flex={1}
+            />
+          </Flex>
+
+          {/* Distance filter */}
+          <Box bg="white" borderRadius="lg" border="1px solid" borderColor="gray.200" p={4}>
+            <Flex align="center" justify="space-between" mb={3}>
+              <Flex align="center" gap={2}>
+                <FiNavigation size={17} color={ORANGE} />
+                <Text fontWeight={500} color="gray.900" fontSize="sm">
+                  Search by Distance
+                </Text>
+              </Flex>
+              <Button
+                size="sm"
+                onClick={toggleLocation}
+                disabled={locationLoading}
+                style={{
+                  background: locationEnabled ? ORANGE : 'transparent',
+                  color: locationEnabled ? '#fff' : '#374151',
+                  border: locationEnabled ? 'none' : '1px solid #d1d5db',
+                  borderRadius: '9999px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                }}
+              >
+                {locationLoading ? (
+                  <>
+                    <FiLoader size={13} />
+                    Getting location…
+                  </>
+                ) : locationEnabled ? (
+                  <>
+                    <FiMapPin size={13} />
+                    By Distance
+                  </>
+                ) : (
+                  <>
+                    <FiNavigation size={13} />
+                    Enable Location
+                  </>
+                )}
+              </Button>
+            </Flex>
+
+            {locationError && (
+              <Text fontSize="sm" color="red.500" mb={3}>
+                {locationError}
+              </Text>
+            )}
+
+            {locationEnabled && userLocation ? (
+              <VStack gap={3} align="stretch">
+                <Flex justify="space-between">
+                  <Text fontSize="sm" color="gray.600">
+                    Distance: {distanceKm} km
+                  </Text>
+                  <Text fontSize="xs" color="gray.400">
+                    {distanceLabel}
+                  </Text>
+                </Flex>
+                <input
+                  type="range"
+                  min={1}
+                  max={50}
+                  step={1}
+                  value={distanceKm}
+                  onChange={(e) => setDistanceKm(Number(e.target.value))}
+                  style={{
+                    width: '100%',
+                    accentColor: ORANGE,
+                    height: '6px',
+                    cursor: 'pointer',
+                  }}
+                />
+                <Flex justify="space-between">
+                  <Text fontSize="xs" color="gray.400">1 km</Text>
+                  <Text fontSize="xs" color="gray.400">25 km</Text>
+                  <Text fontSize="xs" color="gray.400">50 km</Text>
+                </Flex>
+              </VStack>
+            ) : (
+              !locationLoading && (
+                <Text fontSize="sm" color="gray.500">
+                  Enable location to find services near you, sorted by distance.
+                </Text>
+              )
+            )}
+          </Box>
+        </VStack>
+
+        {/* ── Filter tabs ── */}
+        <Flex gap={2} mb={6} pb={6} borderBottom="1px solid" borderColor="gray.200" flexWrap="wrap">
+          {FILTERS.map((f) => (
+            <Box
+              key={f.id}
+              as="button"
+              onClick={() => setActiveFilter(f.id)}
+              px={4}
+              py={2}
+              borderRadius="lg"
+              fontSize="sm"
+              fontWeight={activeFilter === f.id ? 600 : 400}
+              bg={activeFilter === f.id ? ORANGE : 'white'}
+              color={activeFilter === f.id ? 'white' : 'gray.700'}
+              border="1px solid"
+              borderColor={activeFilter === f.id ? ORANGE : 'gray.200'}
+              cursor="pointer"
+              transition="all 0.15s"
+              _hover={{
+                bg: activeFilter === f.id ? ORANGE : 'gray.50',
+              }}
+            >
+              {f.label}
+            </Box>
+          ))}
+        </Flex>
+
+        {/* ── Service cards ── */}
+        {isLoading ? (
+          <Flex justify="center" py={16}>
+            <Spinner size="lg" color="orange.400" />
+          </Flex>
+        ) : fetchError ? (
+          <Flex justify="center" py={16}>
+            <Text color="red.500">{fetchError}</Text>
+          </Flex>
+        ) : services.length === 0 ? (
+          <Flex direction="column" align="center" py={16} gap={3}>
+            <Text fontSize="4xl">🔍</Text>
+            <Text color="gray.500">No services found. Be the first to post one!</Text>
+            <Button
+              size="sm"
+              onClick={() => navigate('/post-offer')}
+              style={{ background: ORANGE, color: '#fff', borderRadius: '9999px' }}
+            >
+              Post a Service
+            </Button>
+          </Flex>
+        ) : (
+          <Grid templateColumns="repeat(2, 1fr)" gap={6}>
+            {services.map((service) => {
+              const owner = service.user ?? service.provider
+              const name = userName(owner)
+              const initials = userInitials(owner)
+              const avatarUrl = owner?.avatar_url
+              const isOffer = service.type === 'Offer'
+
+              return (
+                <Box
+                  key={service.id}
+                  as="button"
+                  onClick={() => navigate(`/service-detail/${service.id}`)}
+                  bg="white"
+                  borderRadius="xl"
+                  border="1px solid"
+                  borderColor="gray.200"
+                  p={6}
+                  textAlign="left"
+                  w="full"
+                  transition="all 0.15s"
+                  _hover={{ borderColor: 'orange.300', boxShadow: 'md' }}
+                  cursor="pointer"
+                >
+                  {/* User + title row */}
+                  <Flex gap={3} mb={3} align="flex-start">
+                    <Box
+                      w="40px"
+                      h="40px"
+                      borderRadius="full"
+                      bg={YELLOW}
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="center"
+                      fontWeight="700"
+                      fontSize="13px"
+                      color={GREEN}
+                      flexShrink={0}
+                      overflow="hidden"
+                    >
+                      {avatarUrl ? (
+                        <img
+                          src={avatarUrl}
+                          alt={name}
+                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                        />
+                      ) : (
+                        initials
+                      )}
+                    </Box>
+                    <Box flex={1} minW={0}>
+                      <Flex align="center" gap={2} mb={1} flexWrap="wrap">
+                        <Text fontWeight="700" color="gray.900" fontSize="sm" overflow="hidden" style={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '180px' }}>
+                          {service.title}
+                        </Text>
+                        <Badge
+                          fontSize="xs"
+                          px={2}
+                          py={0.5}
+                          borderRadius="full"
+                          bg={isOffer ? 'green.100' : 'blue.100'}
+                          color={isOffer ? 'green.700' : 'blue.700'}
+                        >
+                          {service.type === 'Need' ? 'Want' : service.type}
+                        </Badge>
+                      </Flex>
+                      <Text fontSize="xs" color="gray.400">
+                        {name}
+                      </Text>
+                    </Box>
+                  </Flex>
+
+                  {/* Description */}
+                  <Text fontSize="sm" color="gray.600" mb={3} style={{ overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                    {service.description}
+                  </Text>
+
+                  {/* Meta row */}
+                  <HStack gap={4} fontSize="sm" color="gray.500" mb={3} flexWrap="wrap">
+                    <Flex align="center" gap={1}>
+                      <FiClock size={13} />
+                      <Text>{formatHours(service.duration)}h</Text>
+                    </Flex>
+                    <Flex align="center" gap={1}>
+                      {service.location_type === 'Online' ? (
+                        <FiMonitor size={13} />
+                      ) : (
+                        <FiUsers size={13} />
+                      )}
+                      <Text>{service.location_type}</Text>
+                    </Flex>
+                    {service.location_area && (
+                      <Flex align="center" gap={1}>
+                        <FiMapPin size={13} />
+                        <Text>{service.location_area}</Text>
+                      </Flex>
+                    )}
+                  </HStack>
+
+                  {/* Schedule */}
+                  {service.schedule_details && (
+                    <Flex align="center" gap={2} mb={3} fontSize="xs" color="gray.400">
+                      <FiCalendar size={12} />
+                      <Text>{service.schedule_details}</Text>
+                    </Flex>
+                  )}
+
+                  {/* Tags + participants */}
+                  <Flex align="center" justify="space-between">
+                    <HStack gap={2} flexWrap="wrap">
+                      {service.tags?.slice(0, 3).map((tag) => (
+                        <Text
+                          key={tag.id}
+                          fontSize="xs"
+                          px={2}
+                          py={0.5}
+                          bg="gray.100"
+                          color="gray.600"
+                          borderRadius="md"
+                        >
+                          #{tag.name}
+                        </Text>
+                      ))}
+                    </HStack>
+                    <Flex align="center" gap={1} fontSize="xs" color="gray.400">
+                      <FiUsers size={11} />
+                      <Text>Max {service.max_participants}</Text>
+                    </Flex>
+                  </Flex>
+                </Box>
+              )
+            })}
+          </Grid>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default DashboardPage

--- a/frontend/src/pages/ForumCategories.tsx
+++ b/frontend/src/pages/ForumCategories.tsx
@@ -1,0 +1,10 @@
+const ForumCategories = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ForumCategories</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ForumCategories

--- a/frontend/src/pages/ForumCreateTopic.tsx
+++ b/frontend/src/pages/ForumCreateTopic.tsx
@@ -1,0 +1,10 @@
+const ForumCreateTopic = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ForumCreateTopic</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ForumCreateTopic

--- a/frontend/src/pages/ForumTopicDetail.tsx
+++ b/frontend/src/pages/ForumTopicDetail.tsx
@@ -1,0 +1,10 @@
+const ForumTopicDetail = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ForumTopicDetail</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ForumTopicDetail

--- a/frontend/src/pages/ForumTopicList.tsx
+++ b/frontend/src/pages/ForumTopicList.tsx
@@ -1,0 +1,10 @@
+const ForumTopicList = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ForumTopicList</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ForumTopicList

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,324 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Box, Flex, Text, Button, VStack, HStack, Grid } from '@chakra-ui/react'
+import { FiClock, FiUsers, FiHeart, FiArrowRight } from 'react-icons/fi'
+import { MapView } from '@/components/MapView'
+import { serviceAPI } from '@/services/serviceAPI'
+import type { Service } from '@/types'
+
+const YELLOW = '#F8C84A'
+const GREEN = '#2D5C4E'
+const ORANGE = '#f97316'
+
+// ─── Honeycomb logo icon (simple SVG) ────────────────────────────────────────
+function HexLogo({ size = 32 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+      <polygon
+        points="16,2 28,9 28,23 16,30 4,23 4,9"
+        fill={YELLOW}
+        stroke={GREEN}
+        strokeWidth="1.5"
+      />
+      <text x="16" y="21" textAnchor="middle" fontSize="13" fontWeight="bold" fill={GREEN}>
+        H
+      </text>
+    </svg>
+  )
+}
+
+// ─── Steps data ───────────────────────────────────────────────────────────────
+const HOW_IT_WORKS = [
+  {
+    icon: <FiUsers size={32} color={ORANGE} />,
+    title: 'Join the Community',
+    body: 'Sign up and receive 3 TimeBank hours to get started. Browse services or post what you can offer to the community.',
+  },
+  {
+    icon: <FiClock size={32} color={ORANGE} />,
+    title: 'Share Your Time',
+    body: 'Connect with others, negotiate schedules, and exchange services. Every hour you give earns you an hour to receive.',
+  },
+  {
+    icon: <FiHeart size={32} color={ORANGE} />,
+    title: 'Build Connections',
+    body: 'Grow your network, learn new skills, and contribute to a thriving community built on mutual support and trust.',
+  },
+]
+
+// ─── Component ────────────────────────────────────────────────────────────────
+const HomePage = () => {
+  const navigate = useNavigate()
+  const [services, setServices] = useState<Service[]>([])
+
+  useEffect(() => {
+    serviceAPI
+      .list()
+      .then((data) => setServices(data.slice(0, 20)))
+      .catch(() => {})
+  }, [])
+
+  return (
+    <Box minH="100vh" bg="linear-gradient(to bottom, #fffbeb, #ffffff)">
+      {/* ── Header ──────────────────────────────────────────────────────────── */}
+      <Box
+        as="header"
+        borderBottom="1px solid"
+        borderColor="orange.100"
+        bg="rgba(255,255,255,0.85)"
+        backdropFilter="blur(10px)"
+        position="sticky"
+        top={0}
+        zIndex={50}
+      >
+        <Flex maxW="1440px" mx="auto" px={8} py={4} align="center" justify="space-between">
+          <Flex align="center" gap={2}>
+            <HexLogo />
+            <Text fontWeight="700" fontSize="lg" color="gray.900">
+              The Hive
+            </Text>
+          </Flex>
+          <HStack gap={3}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/login')}
+              style={{ color: '#374151' }}
+            >
+              Log In
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => navigate('/register')}
+              style={{
+                background: ORANGE,
+                color: '#fff',
+                borderRadius: '9999px',
+                padding: '0 20px',
+              }}
+            >
+              Sign Up
+            </Button>
+          </HStack>
+        </Flex>
+      </Box>
+
+      {/* ── Hero ────────────────────────────────────────────────────────────── */}
+      <Box as="section" maxW="1440px" mx="auto" px={8} py={20}>
+        <Grid templateColumns="1fr 1fr" gap={16} alignItems="center">
+          {/* Left */}
+          <VStack align="flex-start" gap={6}>
+            <Flex
+              align="center"
+              gap={2}
+              px={4}
+              py={2}
+              bg="orange.50"
+              borderRadius="full"
+              border="1px solid"
+              borderColor="orange.200"
+            >
+              <HexLogo size={16} />
+              <Text fontSize="sm" color="orange.800" fontWeight={500}>
+                Community Time-Bank Platform
+              </Text>
+            </Flex>
+
+            <Text
+              as="h1"
+              fontSize={{ base: '3xl', lg: '4xl', xl: '5xl' }}
+              fontWeight="800"
+              color="gray.900"
+              lineHeight="1.15"
+            >
+              Connecting Communities,
+              <br />
+              Sharing Time
+            </Text>
+
+            <Text color="gray.600" maxW="480px" fontSize="lg" lineHeight={1.7}>
+              Join a vibrant community where time is the currency. Share your skills, learn from
+              others, and build meaningful connections through mutual support and collaboration.
+            </Text>
+
+            <HStack gap={4}>
+              <Button
+                size="lg"
+                onClick={() => navigate('/register')}
+                style={{
+                  background: ORANGE,
+                  color: '#fff',
+                  borderRadius: '9999px',
+                  padding: '0 28px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                }}
+              >
+                Get Started <FiArrowRight />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                onClick={() => navigate('/login')}
+                style={{ borderRadius: '9999px', padding: '0 28px' }}
+              >
+                Log In
+              </Button>
+            </HStack>
+          </VStack>
+
+          {/* Right — hero image */}
+          <Box position="relative">
+            <Box borderRadius="2xl" overflow="hidden" boxShadow="2xl">
+              <img
+                src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=800&q=80"
+                alt="Community sharing"
+                style={{ width: '100%', height: '420px', objectFit: 'cover' }}
+              />
+            </Box>
+            {/* Floating stat card */}
+            <Box
+              position="absolute"
+              bottom="-24px"
+              left="-24px"
+              bg="white"
+              borderRadius="xl"
+              boxShadow="lg"
+              p={5}
+              border="1px solid"
+              borderColor="orange.100"
+            >
+              <Flex align="center" gap={3}>
+                <Box
+                  w="44px"
+                  h="44px"
+                  borderRadius="full"
+                  bg="orange.50"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <FiClock size={20} color={ORANGE} />
+                </Box>
+                <Box>
+                  <Text fontWeight="700" color="gray.900">
+                    1,247 Hours
+                  </Text>
+                  <Text fontSize="sm" color="gray.500">
+                    Shared This Month
+                  </Text>
+                </Box>
+              </Flex>
+            </Box>
+          </Box>
+        </Grid>
+      </Box>
+
+      {/* ── How It Works ────────────────────────────────────────────────────── */}
+      <Box as="section" bg="white" py={20} borderY="1px solid" borderColor="gray.100">
+        <Box maxW="1440px" mx="auto" px={8}>
+          <VStack gap={4} mb={16} textAlign="center">
+            <Text as="h2" fontSize="3xl" fontWeight="800" color="gray.900">
+              How It Works
+            </Text>
+            <Text color="gray.600" maxW="2xl" fontSize="lg">
+              The Hive uses a time-based economy where everyone's time is valued equally. No money
+              changes hands—just skills, knowledge, and community spirit.
+            </Text>
+          </VStack>
+
+          <Grid templateColumns="repeat(3, 1fr)" gap={12}>
+            {HOW_IT_WORKS.map((step) => (
+              <VStack key={step.title} gap={4} textAlign="center">
+                <Box
+                  w="72px"
+                  h="72px"
+                  borderRadius="full"
+                  bg="orange.50"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  {step.icon}
+                </Box>
+                <Text as="h3" fontSize="xl" fontWeight="700" color="gray.900">
+                  {step.title}
+                </Text>
+                <Text color="gray.600" lineHeight={1.7}>
+                  {step.body}
+                </Text>
+              </VStack>
+            ))}
+          </Grid>
+        </Box>
+      </Box>
+
+      {/* ── CTA banner ──────────────────────────────────────────────────────── */}
+      <Box as="section" maxW="1440px" mx="auto" px={8} py={20}>
+        <Box
+          bg="linear-gradient(135deg, #f59e0b, #f97316)"
+          borderRadius="3xl"
+          p={16}
+          textAlign="center"
+          color="white"
+        >
+          <Text as="h2" fontSize="3xl" fontWeight="800" mb={4}>
+            Ready to Join The Hive?
+          </Text>
+          <Text fontSize="lg" mb={8} opacity={0.9} maxW="2xl" mx="auto">
+            Start sharing your time and skills with a community that values what you have to offer.
+          </Text>
+          <Button
+            size="lg"
+            onClick={() => navigate('/register')}
+            style={{
+              background: 'white',
+              color: ORANGE,
+              borderRadius: '9999px',
+              padding: '0 32px',
+              fontWeight: 700,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '8px',
+            }}
+          >
+            Create Your Account <FiArrowRight />
+          </Button>
+        </Box>
+      </Box>
+
+      {/* ── Map Section ─────────────────────────────────────────────────────── */}
+      <Box as="section" bg="white" py={20} borderY="1px solid" borderColor="gray.100">
+        <Box maxW="1440px" mx="auto" px={8}>
+          <VStack gap={4} mb={12} textAlign="center">
+            <Text as="h2" fontSize="3xl" fontWeight="800" color="gray.900">
+              Explore Services Across Istanbul
+            </Text>
+            <Text color="gray.600" maxW="2xl" fontSize="lg">
+              Discover in-person services available in different districts. Each location shows
+              approximate areas to protect privacy.
+            </Text>
+          </VStack>
+
+          <MapView
+            services={services}
+            height="440px"
+            onServiceClick={(id) => navigate(`/service-detail/${id}`)}
+          />
+        </Box>
+      </Box>
+
+      {/* ── Footer ──────────────────────────────────────────────────────────── */}
+      <Box as="footer" borderTop="1px solid" borderColor="gray.200" py={8}>
+        <Box maxW="1440px" mx="auto" px={8} textAlign="center">
+          <Text fontSize="sm" color="gray.500">
+            © {new Date().getFullYear()} The Hive. Building communities through shared time.
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default HomePage

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import {
+  Box,
+  Flex,
+  Text,
+  Button,
+  Input,
+  VStack,
+} from '@chakra-ui/react'
+import { FiArrowLeft, FiMail, FiLock } from 'react-icons/fi'
+import { useAuthStore } from '@/store/useAuthStore'
+import { getErrorMessage } from '@/services/api'
+
+const YELLOW = '#F8C84A'
+const GREEN = '#2D5C4E'
+const ORANGE = '#f97316'
+
+function HexLogo({ size = 28 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+      <polygon
+        points="16,2 28,9 28,23 16,30 4,23 4,9"
+        fill={YELLOW}
+        stroke={GREEN}
+        strokeWidth="1.5"
+      />
+      <text x="16" y="21" textAnchor="middle" fontSize="13" fontWeight="bold" fill={GREEN}>
+        H
+      </text>
+    </svg>
+  )
+}
+
+const LoginPage = () => {
+  const navigate = useNavigate()
+  const { login, isLoading } = useAuthStore()
+
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+
+  // Check for session_expired in URL params
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('error') === 'session_expired') {
+      setError('Your session has expired. Please log in again.')
+      window.history.replaceState({}, '', '/login')
+    }
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (!form.email.trim()) { setError('Email is required.'); return }
+    if (!form.password.trim()) { setError('Password is required.'); return }
+
+    try {
+      await login(form.email, form.password)
+      navigate('/dashboard')
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'Login failed. Please check your credentials.'))
+    }
+  }
+
+  return (
+    <Box minH="100vh" bg="linear-gradient(to bottom, #fffbeb, #ffffff)">
+      {/* ── Header ── */}
+      <Box
+        as="header"
+        borderBottom="1px solid"
+        borderColor="orange.100"
+        bg="rgba(255,255,255,0.85)"
+        backdropFilter="blur(10px)"
+      >
+        <Flex maxW="1440px" mx="auto" px={8} py={4} align="center" justify="space-between">
+          <Link to="/" style={{ textDecoration: 'none' }}>
+            <Flex align="center" gap={2}>
+              <HexLogo />
+              <Text fontWeight="700" fontSize="lg" color="gray.900">
+                The Hive
+              </Text>
+            </Flex>
+          </Link>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate('/')}
+            style={{ color: '#374151', display: 'flex', alignItems: 'center', gap: '6px' }}
+          >
+            <FiArrowLeft size={15} />
+            Back to Home
+          </Button>
+        </Flex>
+      </Box>
+
+      {/* ── Form ── */}
+      <Flex maxW="1440px" mx="auto" px={8} py={16} justify="center">
+        <Box
+          w="full"
+          maxW="420px"
+          bg="white"
+          borderRadius="2xl"
+          border="1px solid"
+          borderColor="gray.200"
+          p={8}
+          boxShadow="lg"
+        >
+          <VStack gap={2} mb={8} textAlign="center">
+            <Text as="h1" fontSize="2xl" fontWeight="800" color="gray.900">
+              Welcome Back
+            </Text>
+            <Text color="gray.500" fontSize="sm">
+              Log in to your Hive account
+            </Text>
+          </VStack>
+
+          {/* Error alert */}
+          {error && (
+            <Box
+              mb={6}
+              p={4}
+              bg="red.50"
+              border="1px solid"
+              borderColor="red.200"
+              borderRadius="lg"
+            >
+              <Text fontSize="sm" color="red.700">
+                {error}
+              </Text>
+            </Box>
+          )}
+
+          <form onSubmit={handleSubmit} noValidate>
+            <VStack gap={5}>
+              {/* Email */}
+              <Box w="full">
+                <label htmlFor="email" style={{ fontSize: '14px', fontWeight: 500, color: '#374151', display: 'block', marginBottom: '4px' }}>
+                  Email Address <span style={{ color: '#ef4444' }}>*</span>
+                </label>
+                <Flex
+                  align="center"
+                  border="1px solid"
+                  borderColor="gray.300"
+                  borderRadius="lg"
+                  overflow="hidden"
+                  _focusWithin={{ borderColor: ORANGE, boxShadow: `0 0 0 2px ${ORANGE}33` }}
+                >
+                  <Box px={3} color="gray.400">
+                    <FiMail size={16} />
+                  </Box>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="your.email@example.com"
+                    value={form.email}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    disabled={isLoading}
+                    autoComplete="email"
+                    border="none"
+                    outline="none"
+                    _focus={{ boxShadow: 'none', borderColor: 'transparent' }}
+                    flex={1}
+                  />
+                </Flex>
+              </Box>
+
+              {/* Password */}
+              <Box w="full">
+                <label htmlFor="password" style={{ fontSize: '14px', fontWeight: 500, color: '#374151', display: 'block', marginBottom: '4px' }}>
+                  Password <span style={{ color: '#ef4444' }}>*</span>
+                </label>
+                <Flex
+                  align="center"
+                  border="1px solid"
+                  borderColor="gray.300"
+                  borderRadius="lg"
+                  overflow="hidden"
+                  _focusWithin={{ borderColor: ORANGE, boxShadow: `0 0 0 2px ${ORANGE}33` }}
+                >
+                  <Box px={3} color="gray.400">
+                    <FiLock size={16} />
+                  </Box>
+                  <Input
+                    id="password"
+                    type="password"
+                    placeholder="Enter your password"
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    disabled={isLoading}
+                    autoComplete="current-password"
+                    border="none"
+                    outline="none"
+                    _focus={{ boxShadow: 'none', borderColor: 'transparent' }}
+                    flex={1}
+                  />
+                </Flex>
+              </Box>
+
+              {/* Submit */}
+              <Button
+                type="submit"
+                w="full"
+                size="lg"
+                loading={isLoading}
+                loadingText="Logging in…"
+                disabled={isLoading}
+                style={{
+                  background: ORANGE,
+                  color: '#fff',
+                  borderRadius: '9999px',
+                  fontWeight: 600,
+                }}
+              >
+                Log In
+              </Button>
+            </VStack>
+          </form>
+
+          {/* Register link */}
+          <Text mt={6} textAlign="center" fontSize="sm" color="gray.600">
+            Don't have an account?{' '}
+            <Link
+              to="/register"
+              style={{ color: ORANGE, fontWeight: 600 }}
+            >
+              Sign up
+            </Link>
+          </Text>
+        </Box>
+      </Flex>
+    </Box>
+  )
+}
+
+export default LoginPage

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,10 @@
+const NotFoundPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>NotFoundPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default NotFoundPage

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,10 @@
+const NotificationsPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>NotificationsPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default NotificationsPage

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,0 +1,10 @@
+const OnboardingPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>OnboardingPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default OnboardingPage

--- a/frontend/src/pages/PostNeedForm.tsx
+++ b/frontend/src/pages/PostNeedForm.tsx
@@ -1,0 +1,10 @@
+const PostNeedForm = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>PostNeedForm</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default PostNeedForm

--- a/frontend/src/pages/PostOfferForm.tsx
+++ b/frontend/src/pages/PostOfferForm.tsx
@@ -1,0 +1,10 @@
+const PostOfferForm = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>PostOfferForm</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default PostOfferForm

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,0 +1,10 @@
+const PublicProfile = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>PublicProfile</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default PublicProfile

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -1,0 +1,10 @@
+const RegistrationPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>RegistrationPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default RegistrationPage

--- a/frontend/src/pages/ReportDetail.tsx
+++ b/frontend/src/pages/ReportDetail.tsx
@@ -1,0 +1,10 @@
+const ReportDetail = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ReportDetail</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ReportDetail

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -1,0 +1,10 @@
+const ServiceDetailPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>ServiceDetailPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default ServiceDetailPage

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -1,0 +1,10 @@
+const TransactionHistoryPage = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>TransactionHistoryPage</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default TransactionHistoryPage

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -1,0 +1,10 @@
+const UserProfile = () => {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>UserProfile</h1>
+      <p>This page will be implemented during module migration.</p>
+    </div>
+  )
+}
+
+export default UserProfile

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,178 @@
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
+
+const API_TIMEOUT = 10000
+
+const DEFAULT_API_URL =
+  import.meta.env.MODE === 'test' ? '/api' : 'http://localhost:8000/api'
+const API_BASE_URL =
+  import.meta.env.VITE_API_URL ?? DEFAULT_API_URL
+
+export const apiClient: AxiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: API_TIMEOUT,
+})
+
+// ─── Token Refresh Queue ────────────────────────────────────────────────────
+let isRefreshing = false
+let refreshPromise: Promise<string> | null = null
+let failedQueue: Array<{
+  resolve: (token: string) => void
+  reject: (error: unknown) => void
+}> = []
+
+const processQueue = (error: unknown, token: string | null) => {
+  failedQueue.forEach((prom) => {
+    if (error) prom.reject(error)
+    else if (token) prom.resolve(token)
+  })
+  failedQueue = []
+}
+
+// ─── Request Interceptor: attach JWT ────────────────────────────────────────
+apiClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem('access_token')
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  (error) => Promise.reject(error),
+)
+
+// ─── Response Interceptor: auto-refresh on 401 ──────────────────────────────
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+    const requestUrl: string = originalRequest?.url ?? ''
+
+    const isAuthEndpoint = (url: string) =>
+      url.includes('/auth/login/') ||
+      url.includes('/auth/register/') ||
+      url.includes('/auth/refresh/')
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isAuthEndpoint(requestUrl)) return Promise.reject(error)
+
+      const refreshToken = localStorage.getItem('refresh_token')
+      if (!refreshToken) return Promise.reject(error)
+
+      originalRequest._retry = true
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject })
+        })
+          .then((token) => {
+            if (originalRequest.headers) {
+              originalRequest.headers.Authorization = `Bearer ${token}`
+            }
+            return apiClient(originalRequest)
+          })
+          .catch((err) => Promise.reject(err))
+      }
+
+      isRefreshing = true
+
+      if (!refreshPromise) {
+        refreshPromise = (async () => {
+          try {
+            const res = await axios.post(`${API_BASE_URL}/auth/refresh/`, {
+              refresh: refreshToken,
+            })
+            const { access } = res.data
+            localStorage.setItem('access_token', access)
+            processQueue(null, access)
+            return access
+          } catch (refreshError: unknown) {
+            const e = refreshError as { response?: { status?: number } }
+            if ([400, 401, 500].includes(e.response?.status ?? 0)) {
+              localStorage.removeItem('access_token')
+              localStorage.removeItem('refresh_token')
+              window.location.href = '/login?error=session_expired'
+            }
+            processQueue(refreshError, null)
+            throw refreshError
+          } finally {
+            isRefreshing = false
+            refreshPromise = null
+          }
+        })()
+      }
+
+      try {
+        const newToken = await refreshPromise
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newToken}`
+        }
+        return apiClient(originalRequest)
+      } catch (refreshError) {
+        return Promise.reject(refreshError)
+      }
+    }
+
+    return Promise.reject(error)
+  },
+)
+
+// ─── Error Types ─────────────────────────────────────────────────────────────
+export interface ApiErrorResponse {
+  detail: string
+  code: string
+  field_errors?: Record<string, string[]>
+  error?: string
+  message?: string
+  [key: string]: unknown
+}
+
+export interface ApiError extends Error {
+  response?: {
+    data?: ApiErrorResponse
+    status?: number
+  }
+}
+
+export function getErrorMessage(
+  error: unknown,
+  defaultMessage = 'An unexpected error occurred.',
+): string {
+  if (typeof error === 'string') return error
+
+  if (error && typeof error === 'object') {
+    const e = error as ApiError
+    if (e.response?.data) {
+      const data = e.response.data
+      const detail = typeof data.detail === 'string' ? data.detail : ''
+
+      if (data.detail && data.code) {
+        if (data.field_errors && Object.keys(data.field_errors).length > 0) {
+          const fieldMessages = Object.entries(data.field_errors)
+            .map(([field, errors]) => `${field}: ${errors.join(', ')}`)
+            .join('. ')
+          return `${data.detail} ${fieldMessages}`
+        }
+        return data.detail
+      }
+
+      const fieldErrors: string[] = []
+      if (data.field_errors) {
+        for (const [field, errors] of Object.entries(data.field_errors)) {
+          if (Array.isArray(errors)) fieldErrors.push(`${field}: ${errors.join(', ')}`)
+        }
+      }
+
+      if (detail && fieldErrors.length > 0) return `${detail} ${fieldErrors.join('. ')}`
+      if (detail) return detail
+      if (data.error) return String(data.error)
+      if (data.message) return String(data.message)
+      if (fieldErrors.length > 0) return fieldErrors.join('. ')
+    }
+    if (e.message) return e.message
+  }
+
+  return defaultMessage
+}
+
+export default apiClient

--- a/frontend/src/services/serviceAPI.ts
+++ b/frontend/src/services/serviceAPI.ts
@@ -1,0 +1,51 @@
+import apiClient from './api'
+import type { Service } from '@/types'
+
+export interface ServiceListParams {
+  lat?: number
+  lng?: number
+  distance?: number
+  search?: string
+  type?: 'Offer' | 'Need'
+  status?: string
+}
+
+type ServiceListResponse = Service[] | { results: Service[]; count?: number }
+
+export const serviceAPI = {
+  list: async (params?: ServiceListParams, signal?: AbortSignal): Promise<Service[]> => {
+    const queryParams: Record<string, string> = {}
+    if (params?.lat != null) queryParams.lat = String(params.lat)
+    if (params?.lng != null) queryParams.lng = String(params.lng)
+    if (params?.distance != null) queryParams.distance = String(params.distance)
+    if (params?.search) queryParams.search = params.search
+    if (params?.type) queryParams.type = params.type
+    if (params?.status) queryParams.status = params.status
+
+    const res = await apiClient.get<ServiceListResponse>('/services/', {
+      params: queryParams,
+      signal,
+    })
+    const data = res.data
+    return Array.isArray(data) ? data : (data.results ?? [])
+  },
+
+  get: async (id: string): Promise<Service> => {
+    const res = await apiClient.get<Service>(`/services/${id}/`)
+    return res.data
+  },
+
+  create: async (data: FormData | Record<string, unknown>): Promise<Service> => {
+    const res = await apiClient.post<Service>('/services/', data)
+    return res.data
+  },
+
+  update: async (id: string, data: Partial<Service>): Promise<Service> => {
+    const res = await apiClient.patch<Service>(`/services/${id}/`, data)
+    return res.data
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/services/${id}/`)
+  },
+}

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,163 @@
+import { create } from 'zustand'
+import type { User } from '@/types'
+import apiClient, { getErrorMessage } from '@/services/api'
+
+interface AuthState {
+  user: User | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  error: string | null
+
+  setUser: (user: User | null) => void
+  setError: (error: string | null) => void
+
+  login: (email: string, password: string) => Promise<void>
+  register: (data: {
+    email: string
+    password: string
+    first_name: string
+    last_name: string
+  }) => Promise<void>
+  logout: () => void
+  refreshUser: () => Promise<void>
+  checkAuth: (force?: boolean) => Promise<void>
+  updateUserOptimistically: (updates: Partial<User>) => void
+}
+
+const saveToStorage = (user: User | null) => {
+  if (user) {
+    try {
+      localStorage.setItem('user_data', JSON.stringify(user))
+    } catch {
+      // ignore storage errors
+    }
+  } else {
+    localStorage.removeItem('user_data')
+  }
+}
+
+const loadFromStorage = (): User | null => {
+  try {
+    const stored = localStorage.getItem('user_data')
+    return stored ? (JSON.parse(stored) as User) : null
+  } catch {
+    return null
+  }
+}
+
+export const useAuthStore = create<AuthState>()((set, get) => ({
+  user: loadFromStorage(),
+  isAuthenticated: !!loadFromStorage(),
+  isLoading: false,
+  error: null,
+
+  setUser: (user) => {
+    saveToStorage(user)
+    set({ user, isAuthenticated: !!user })
+  },
+
+  setError: (error) => set({ error }),
+
+  login: async (email, password) => {
+    set({ isLoading: true, error: null })
+    try {
+      const res = await apiClient.post<{
+        access: string
+        refresh: string
+        user?: User
+      }>('/auth/login/', { email, password })
+
+      localStorage.setItem('access_token', res.data.access)
+      localStorage.setItem('refresh_token', res.data.refresh)
+
+      let user = res.data.user ?? null
+      if (!user) {
+        const meRes = await apiClient.get<User>('/users/me/')
+        user = meRes.data
+      }
+
+      saveToStorage(user)
+      set({ user, isAuthenticated: true, isLoading: false })
+    } catch (error) {
+      set({ isLoading: false, error: getErrorMessage(error, 'Login failed') })
+      throw error
+    }
+  },
+
+  register: async (data) => {
+    set({ isLoading: true, error: null })
+    try {
+      const res = await apiClient.post<{
+        access: string
+        refresh: string
+        user?: User
+      }>('/auth/register/', data)
+
+      localStorage.setItem('access_token', res.data.access)
+      localStorage.setItem('refresh_token', res.data.refresh)
+
+      let user = res.data.user ?? null
+      if (!user) {
+        const meRes = await apiClient.get<User>('/users/me/')
+        user = meRes.data
+      }
+
+      saveToStorage(user)
+      set({ user, isAuthenticated: true, isLoading: false })
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: getErrorMessage(error, 'Registration failed'),
+      })
+      throw error
+    }
+  },
+
+  logout: () => {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    saveToStorage(null)
+    set({ user: null, isAuthenticated: false, error: null })
+  },
+
+  refreshUser: async () => {
+    try {
+      const res = await apiClient.get<User>('/users/me/')
+      saveToStorage(res.data)
+      set({ user: res.data, isAuthenticated: true })
+    } catch {
+      // silently fail
+    }
+  },
+
+  checkAuth: async (force = false) => {
+    const state = get()
+    if (!force && state.isAuthenticated && state.user) return
+
+    const token =
+      localStorage.getItem('access_token') ??
+      localStorage.getItem('refresh_token')
+    if (!token) {
+      set({ user: null, isAuthenticated: false, isLoading: false })
+      return
+    }
+
+    set({ isLoading: true })
+    try {
+      const res = await apiClient.get<User>('/users/me/')
+      saveToStorage(res.data)
+      set({ user: res.data, isAuthenticated: true, isLoading: false })
+    } catch {
+      saveToStorage(null)
+      set({ user: null, isAuthenticated: false, isLoading: false })
+    }
+  },
+
+  updateUserOptimistically: (updates) => {
+    const { user } = get()
+    if (!user) return
+    const updated = { ...user, ...updates }
+    saveToStorage(updated)
+    set({ user: updated })
+  },
+}))

--- a/frontend/src/store/useGeoStore.ts
+++ b/frontend/src/store/useGeoStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface GeoState {
+  geoLocation: { latitude: number; longitude: number } | null
+  setGeoLocation: (geoLocation: { latitude: number; longitude: number }) => void
+}
+
+export const useGeoStore = create<GeoState>()((set) => ({
+  geoLocation: { latitude: 0, longitude: 0 },
+  setGeoLocation: (geoLocation) => set({ geoLocation }),
+}))

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,0 +1,84 @@
+import { createSystem, defaultConfig, defineConfig } from '@chakra-ui/react'
+
+const config = defineConfig({
+  theme: {
+    tokens: {
+      colors: {
+        brand: {
+          yellow: {
+            50:  { value: '#FFF9E6' },
+            100: { value: '#FFEFB8' },
+            200: { value: '#FFE58A' },
+            300: { value: '#FFDB5C' },
+            400: { value: '#FFD12E' },
+            500: { value: '#F8C84A' },
+            600: { value: '#E0B23D' },
+            700: { value: '#C89C30' },
+            800: { value: '#B08623' },
+            900: { value: '#987016' },
+          },
+          green: {
+            50:  { value: '#E8F2ED' },
+            100: { value: '#C5DDCE' },
+            200: { value: '#A1C8AF' },
+            300: { value: '#7EB390' },
+            400: { value: '#5A9E71' },
+            500: { value: '#2D5C4E' },
+            600: { value: '#254C40' },
+            700: { value: '#1D3C32' },
+            800: { value: '#152C24' },
+            900: { value: '#0D1C16' },
+          },
+        },
+        background: {
+          light:  { value: '#FFFFFF' },
+          dark:   { value: '#1A202C' },
+          cream:  { value: '#FFF9E6' },
+        },
+      },
+      fonts: {
+        heading: { value: `'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif` },
+        body:    { value: `'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif` },
+      },
+      radii: {
+        none: { value: '0' },
+        sm:   { value: '0.125rem' },
+        base: { value: '0.25rem' },
+        md:   { value: '0.375rem' },
+        lg:   { value: '0.5rem' },
+        xl:   { value: '0.75rem' },
+        '2xl': { value: '1rem' },
+        '3xl': { value: '1.5rem' },
+        full: { value: '9999px' },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        primary: {
+          default: { value: '{colors.brand.yellow.500}' },
+          _dark:   { value: '{colors.brand.yellow.400}' },
+        },
+        secondary: {
+          default: { value: '{colors.brand.green.500}' },
+          _dark:   { value: '{colors.brand.green.400}' },
+        },
+        'text.primary': {
+          default: { value: '#1A202C' },
+          _dark:   { value: '#F7FAFC' },
+        },
+        'text.secondary': {
+          default: { value: '#4A5568' },
+          _dark:   { value: '#A0AEC0' },
+        },
+        'text.light': {
+          default: { value: '#718096' },
+          _dark:   { value: '#718096' },
+        },
+      },
+    },
+  },
+})
+
+const system = createSystem(defaultConfig, config)
+
+export default system

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,366 @@
+// ─── Error Types ─────────────────────────────────────────────────────────────
+
+export interface ApiError {
+  message: string
+  errors?: Record<string, string[]>
+  detail?: string
+}
+
+export const ErrorCodes = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  INSUFFICIENT_BALANCE: 'INSUFFICIENT_BALANCE',
+  INVALID_STATE: 'INVALID_STATE',
+  PERMISSION_DENIED: 'PERMISSION_DENIED',
+  NOT_FOUND: 'NOT_FOUND',
+  AUTHENTICATION_FAILED: 'AUTHENTICATION_FAILED',
+  CONFLICT: 'CONFLICT',
+  ALREADY_EXISTS: 'ALREADY_EXISTS',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  INVALID_INPUT: 'INVALID_INPUT',
+  RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
+  SERVER_ERROR: 'SERVER_ERROR',
+} as const
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes]
+
+// ─── Auth Types ───────────────────────────────────────────────────────────────
+
+export interface LoginCredentials {
+  email: string
+  password: string
+}
+
+export interface RegisterData {
+  email: string
+  password: string
+  first_name: string
+  last_name: string
+  location?: string
+}
+
+export interface AuthResponse {
+  access: string
+  refresh: string
+  user?: User
+}
+
+export interface MeResponse {
+  user: User
+}
+
+// ─── User Types ───────────────────────────────────────────────────────────────
+
+export const UserRole = {
+  ANONYMOUS: 'anonymous',
+  REGISTERED: 'registered',
+  ADMIN: 'admin',
+} as const
+export type UserRole = (typeof UserRole)[keyof typeof UserRole]
+
+export interface User {
+  id: string
+  email: string
+  username?: string
+  first_name: string
+  last_name: string
+  role: string
+  bio?: string
+  avatar_url?: string
+  banner_url?: string
+  date_joined?: string
+  timebank_balance?: number
+  karma_score?: number
+  featured_badge?: string | null
+  featured_achievement_id?: string | null
+  show_history?: boolean
+  video_intro_url?: string | null
+  video_intro_file_url?: string | null
+  is_active?: boolean
+  is_banned?: boolean
+  is_admin?: boolean
+  warning_count?: number
+}
+
+export interface UserProfile {
+  id: string
+  user_id: string
+  bio?: string
+  profile_picture?: string
+  avatar?: string
+  geo_location?: string
+  location?: string
+  skills: string[]
+  time_credits: number
+  rating?: number
+  is_onboarded?: boolean
+}
+
+// ─── Service / Offer Types ────────────────────────────────────────────────────
+
+export interface ServiceFormData {
+  title: string
+  description: string
+  type: 'Offer' | 'Need'
+  duration: number | string
+  location_type: 'In-Person' | 'Online'
+  location_area?: string
+  max_participants: number
+  schedule_type: 'One-Time' | 'Recurrent'
+  schedule_details?: string
+  tags?: string[]
+  tag_names?: string[]
+}
+
+export interface Service {
+  id: string
+  title: string
+  description: string
+  type: 'Offer' | 'Need'
+  duration: number | string
+  status: 'active' | 'inactive' | 'completed'
+  location_type: 'In-Person' | 'Online'
+  location_area?: string
+  // API returns location_lat/location_lng (backend field names)
+  location_lat?: string | number | null
+  location_lng?: string | number | null
+  // Alias fields
+  latitude?: number
+  longitude?: number
+  max_participants: number
+  participant_count: number
+  schedule_type: 'One-Time' | 'Recurrent'
+  schedule_details?: string
+  tags: Tag[]
+  media?: ServiceMedia[]
+  // Backend returns `user`; `provider` kept for compatibility
+  user?: User
+  provider?: User
+  created_at: string
+  updated_at: string
+  interest_count?: number
+  is_visible?: boolean
+  comment_count?: number
+  hot_score?: number
+}
+
+export interface ServiceMedia {
+  id: string
+  file_url: string
+  media_type: 'image' | 'video'
+  order?: number
+}
+
+export interface Tag {
+  id: string
+  name: string
+  wikidata_id?: string
+}
+
+// ─── Handshake Types ──────────────────────────────────────────────────────────
+
+export type HandshakeStatus =
+  | 'pending'
+  | 'accepted'
+  | 'initiated'
+  | 'approved'
+  | 'completed'
+  | 'declined'
+  | 'cancelled'
+  | 'disputed'
+  | 'paused'
+
+export interface Handshake {
+  id: string
+  service: Service
+  requester: User
+  provider: User
+  status: HandshakeStatus
+  proposed_time?: string
+  actual_duration?: number
+  requester_confirmed: boolean
+  provider_confirmed: boolean
+  created_at: string
+  updated_at: string
+  dispute_reason?: string
+  notes?: string
+}
+
+// ─── Chat & Message Types ─────────────────────────────────────────────────────
+
+export interface Conversation {
+  handshake_id: string
+  other_user: User
+  last_message?: ChatMessage
+  unread_count?: number
+}
+
+export interface ChatMessage {
+  id: string
+  handshake: string
+  sender: User
+  body: string
+  created_at: string
+}
+
+// ─── Notification Types ───────────────────────────────────────────────────────
+
+export interface Notification {
+  id: string
+  recipient: string
+  notification_type: string
+  message: string
+  is_read: boolean
+  data?: Record<string, unknown>
+  created_at: string
+}
+
+// ─── Transaction Types ────────────────────────────────────────────────────────
+
+export interface Transaction {
+  id: string
+  user: string
+  counterpart?: User
+  transaction_type: 'credit' | 'debit'
+  amount: number
+  description: string
+  handshake?: string
+  created_at: string
+}
+
+// ─── Reputation Types ─────────────────────────────────────────────────────────
+
+export interface ReputationData {
+  punctual?: boolean
+  helpful?: boolean
+  kind?: boolean
+  handshake_id: string
+  recipient_id: string
+}
+
+// ─── Admin Types ──────────────────────────────────────────────────────────────
+
+export interface AdminReport {
+  id: string
+  reporter: User
+  reported_user?: User
+  service?: Service
+  handshake?: Handshake
+  reason: string
+  description: string
+  status: 'open' | 'resolved' | 'dismissed'
+  resolution_notes?: string
+  created_at: string
+  updated_at: string
+}
+
+// ─── Forum Types ──────────────────────────────────────────────────────────────
+
+export type ForumCategoryColor =
+  | 'blue' | 'green' | 'purple' | 'amber' | 'orange' | 'pink' | 'red' | 'teal'
+
+export interface ForumCategory {
+  id: string
+  name: string
+  description: string
+  slug: string
+  icon: string
+  color: ForumCategoryColor
+  display_order: number
+  is_active: boolean
+  topic_count: number
+  post_count: number
+  last_activity: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ForumTopic {
+  id: string
+  category: string
+  category_name: string
+  category_slug: string
+  author_id: string
+  author_name: string
+  author_avatar_url: string | null
+  title: string
+  body: string
+  is_pinned: boolean
+  is_locked: boolean
+  view_count: number
+  reply_count: number
+  last_activity: string
+  created_at: string
+  updated_at: string
+  posts?: ForumPost[]
+}
+
+export interface ForumPost {
+  id: string
+  topic: string
+  author_id: string
+  author_name: string
+  author_avatar_url: string | null
+  body: string
+  is_deleted: boolean
+  created_at: string
+  updated_at: string
+}
+
+// ─── Achievement / Badge Types ────────────────────────────────────────────────
+
+export interface Achievement {
+  id: string
+  name: string
+  description: string
+  icon: string
+  badge_type: string
+  threshold?: number
+  earned_at?: string
+}
+
+export interface BadgeProgress {
+  badge_type: string
+  name: string
+  description: string
+  current_value: number
+  threshold: number
+  earned: boolean
+  earned_at?: string
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export interface PaginatedResponse<T> {
+  results: T[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const POLLING_INTERVALS = {
+  NOTIFICATIONS: 10_000,
+  MESSAGES: 3_000,
+  CONVERSATIONS: 15_000,
+  SERVICES: 30_000,
+  HANDSHAKE: 3_000,
+} as const
+
+export const DEBOUNCE_DELAYS = {
+  SEARCH: 500,
+  DISTANCE_SLIDER: 300,
+  WIKIDATA_SEARCH: 300,
+} as const
+
+export const MAP_CONFIG = {
+  DEFAULT_ZOOM: 11,
+  FUZZY_RADIUS_METERS: 5000,
+  SERVICE_FUZZY_RADIUS_METERS: 3000,
+} as const
+
+export const DISTANCE_SEARCH = {
+  MIN_KM: 1,
+  MAX_KM: 50,
+  DEFAULT_KM: 10,
+} as const

--- a/frontend/src/utils/cookies.ts
+++ b/frontend/src/utils/cookies.ts
@@ -1,0 +1,24 @@
+/**
+ * Read a cookie value by name
+ */
+export function getCookie(name: string): string | null {
+  const match = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`))
+  return match ? decodeURIComponent(match.slice(name.length + 1)) : null
+}
+
+/**
+ * Check whether any of the provided cookie names exist
+ */
+export function hasCookies(...names: string[]): boolean {
+  return names.some((name) => getCookie(name) !== null)
+}
+
+/**
+ * Delete a cookie by setting its expiry to the past
+ */
+export function deleteCookie(name: string, path = '/'): void {
+  document.cookie = `${name}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+}

--- a/frontend/src/utils/dateTime.ts
+++ b/frontend/src/utils/dateTime.ts
@@ -1,0 +1,66 @@
+import { formatDistanceToNow, format, parseISO } from 'date-fns'
+
+/**
+ * Format an ISO datetime string to a human-readable relative time (e.g. "3 minutes ago")
+ */
+export function timeAgo(isoString: string): string {
+  try {
+    return formatDistanceToNow(parseISO(isoString), { addSuffix: true })
+  } catch {
+    return isoString
+  }
+}
+
+/**
+ * Format an ISO datetime string to a localized date string
+ */
+export function formatDate(isoString: string, pattern = 'MMM d, yyyy'): string {
+  try {
+    return format(parseISO(isoString), pattern)
+  } catch {
+    return isoString
+  }
+}
+
+/**
+ * Format an ISO datetime string to a localized date and time string
+ */
+export function formatDateTime(isoString: string, pattern = 'MMM d, yyyy HH:mm'): string {
+  try {
+    return format(parseISO(isoString), pattern)
+  } catch {
+    return isoString
+  }
+}
+
+/**
+ * Convert hours (decimal) to a human-readable duration string
+ */
+export function formatDuration(hours: number): string {
+  if (hours < 1) {
+    const minutes = Math.round(hours * 60)
+    return `${minutes} min`
+  }
+  if (Number.isInteger(hours)) return `${hours}h`
+  const h = Math.floor(hours)
+  const m = Math.round((hours - h) * 60)
+  return m > 0 ? `${h}h ${m}min` : `${h}h`
+}
+
+/**
+ * Returns a short timestamp label for chat messages
+ */
+export function chatTimestamp(isoString: string): string {
+  try {
+    const date = parseISO(isoString)
+    const now = new Date()
+    const diffMs = now.getTime() - date.getTime()
+    const diffHours = diffMs / (1000 * 60 * 60)
+
+    if (diffHours < 24) return format(date, 'HH:mm')
+    if (diffHours < 48 * 24) return format(date, 'EEE HH:mm')
+    return format(date, 'MMM d')
+  } catch {
+    return isoString
+  }
+}

--- a/frontend/src/utils/location.ts
+++ b/frontend/src/utils/location.ts
@@ -1,0 +1,66 @@
+import { DISTANCE_SEARCH, MAP_CONFIG } from '@/types'
+
+/**
+ * Calculate the distance between two coordinates in kilometres (Haversine formula)
+ */
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+function toRad(deg: number) {
+  return (deg * Math.PI) / 180
+}
+
+/**
+ * Add a random offset to coordinates for privacy (fuzzy location)
+ */
+export function fuzzyCoordinates(
+  lat: number,
+  lon: number,
+  radiusMeters = MAP_CONFIG.FUZZY_RADIUS_METERS,
+): { lat: number; lon: number } {
+  const radiusDeg = radiusMeters / 111_000
+  const u = Math.random()
+  const v = Math.random()
+  const w = radiusDeg * Math.sqrt(u)
+  const t = 2 * Math.PI * v
+  return {
+    lat: lat + w * Math.cos(t),
+    lon: lon + w * Math.sin(t),
+  }
+}
+
+/**
+ * Get current position using the Geolocation API
+ */
+export function getCurrentPosition(): Promise<GeolocationPosition> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('Geolocation is not supported by this browser.'))
+      return
+    }
+    navigator.geolocation.getCurrentPosition(resolve, reject, {
+      enableHighAccuracy: true,
+      timeout: 10_000,
+      maximumAge: 300_000,
+    })
+  })
+}
+
+/**
+ * Clamp distance value within valid search range
+ */
+export function clampDistance(km: number): number {
+  return Math.min(Math.max(km, DISTANCE_SEARCH.MIN_KM), DISTANCE_SEARCH.MAX_KM)
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Path aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/pages/*": ["./src/pages/*"],
+      "@/services/*": ["./src/services/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/store/*": ["./src/store/*"],
+      "@/theme/*": ["./src/theme/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/utils/*": ["./src/utils/*"]
+    },
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiUrl = env.VITE_API_URL || 'http://localhost:8000/api'
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@/components': path.resolve(__dirname, './src/components'),
+        '@/pages': path.resolve(__dirname, './src/pages'),
+        '@/services': path.resolve(__dirname, './src/services'),
+        '@/hooks': path.resolve(__dirname, './src/hooks'),
+        '@/store': path.resolve(__dirname, './src/store'),
+        '@/theme': path.resolve(__dirname, './src/theme'),
+        '@/types': path.resolve(__dirname, './src/types'),
+        '@/utils': path.resolve(__dirname, './src/utils'),
+      },
+    },
+    server: {
+      port: 5173,
+      host: true,
+      strictPort: true,
+      hmr: {
+        overlay: true,
+      },
+      proxy: apiUrl !== '/api' ? {
+        '/api': {
+          target: apiUrl.replace('/api', ''),
+          changeOrigin: true,
+          rewrite: (path) => path,
+        },
+        '/ws': {
+          target: apiUrl.replace('/api', '').replace('http', 'ws'),
+          ws: true,
+          changeOrigin: true,
+        },
+      } : undefined,
+      watch: {
+        usePolling: false,
+      },
+    },
+  }
+})

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,0 +1,97 @@
+upstream backend {
+    server backend:8000;
+}
+
+upstream frontend {
+    server frontend:5173;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    client_max_body_size 50M;
+
+    # ── Django REST API ──────────────────────────────────────────────────────
+    location /api/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # ── Django Admin ─────────────────────────────────────────────────────────
+    location /django-admin/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Media files served by Django ─────────────────────────────────────────
+    location /media/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Django static files (required by Swagger UI / admin) ─────────────────
+    location /static/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Swagger UI & ReDoc shortcuts (convenience redirects) ─────────────────
+    location = /docs {
+        return 301 /api/docs/;
+    }
+    location = /redoc {
+        return 301 /api/redoc/;
+    }
+    location = /schema {
+        return 301 /api/schema/;
+    }
+
+    # ── WebSocket (Django Channels) ──────────────────────────────────────────
+    location /ws/ {
+        proxy_pass         http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+    }
+
+    # ── Vite HMR WebSocket ───────────────────────────────────────────────────
+    location /@vite/ {
+        proxy_pass         http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+    }
+
+    # ── Vite dev server (SPA) ────────────────────────────────────────────────
+    location / {
+        proxy_pass         http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -1,0 +1,107 @@
+upstream backend {
+    server backend:8000;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    client_max_body_size 50M;
+
+    # Gzip
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript
+               application/x-javascript application/xml+rss
+               application/javascript application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # ── Django REST API ──────────────────────────────────────────────────────
+    location /api/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # ── Django Admin ─────────────────────────────────────────────────────────
+    location /django-admin/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Media files served by Django ─────────────────────────────────────────
+    location /media/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Django static files (required by Swagger UI / admin) ─────────────────
+    location /static/ {
+        proxy_pass         http://backend;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── Swagger UI & ReDoc shortcuts (convenience redirects) ─────────────────
+    location = /docs {
+        return 301 /api/docs/;
+    }
+    location = /redoc {
+        return 301 /api/redoc/;
+    }
+    location = /schema {
+        return 301 /api/schema/;
+    }
+
+    # ── WebSocket (Django Channels) ──────────────────────────────────────────
+    location /ws/ {
+        proxy_pass         http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade           $http_upgrade;
+        proxy_set_header   Connection        "upgrade";
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+    }
+
+    # ── Static frontend assets (long-term cache) ─────────────────────────────
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp)$ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # ── index.html — no cache so new deployments are picked up ──────────────
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # ── SPA fallback ─────────────────────────────────────────────────────────
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

This PR initializes the React/TypeScript frontend application for The Hive platform and wires it into the existing backend infrastructure with a full local development and production deployment setup.

### What's included

**Frontend application (`frontend/`)**
- Bootstrapped with **Vite 7 + React 19 + TypeScript**, strict `erasableSyntaxOnly` mode enabled
- **Chakra UI v3** with a custom theme (brand yellow `#F8C84A` / green `#2D5C4E`, semantic tokens, custom radii)
- **React Router v6** with lazy-loaded pages and `ProtectedRoute` / `AdminProtectedRoute` wrappers
- **Zustand v5** stores for auth (`useAuthStore`) and geolocation (`useGeoStore`)
- **Axios** API client with automatic JWT injection and silent token-refresh on 401
- **react-leaflet v5** interactive map with colour-coded markers (green = Offer, blue = Want)
- Custom `useWebSocket` hook with exponential-backoff reconnection
- Utility modules: `dateTime`, `location`, `cookies`
- Comprehensive shared type definitions aligned with the Django REST API

**Implemented pages**

| Page | Path | Notes |
|------|------|-------|
| Landing page | `/` | Hero, How It Works, CTA banner, Istanbul map preview |
| Login | `/login` | JWT login, session-expired handling |
| Dashboard | `/dashboard` | Service grid, Leaflet map, search, distance filter, filter tabs, 30 s auto-refresh |
| 18 placeholder pages | various | Scaffolded and routed, ready for module-by-module migration |

**Infrastructure & DevOps**
- `docker-compose.infra.yml` — lightweight local infra (PostGIS 15 + Redis 7) for native backend development
- `nginx/nginx.dev.conf` / `nginx.prod.conf` — Nginx reverse proxy configs for both environments
- Updated `docker-compose.yml` (dev) and `docker-compose.prod.yml` (prod) with the new `nginx` service; backend and frontend are now internal (`expose`, not `ports`)
- Multi-stage `Dockerfile` / `Dockerfile.prod` for the frontend

**Backend fixes & config**
- Pinned Django to `>=4.2,<6.0` to avoid breaking `CheckConstraint` API change in Django 6
- Added `python-dotenv` so `backend/.env` is loaded automatically during local `runserver`
- macOS GDAL/GEOS library path auto-detection via `brew --prefix` in `settings.py`
- Fixed `UniqueConstraint(check=…)` → `condition=…` (was never valid on `UniqueConstraint`)

**Developer experience**
- `make dev-setup` — one-command first-time setup (venv, install, infra up, migrate, demo seed)
- `make dev` — starts backend + frontend in parallel with coloured log prefixes; `Ctrl+C` stops both
- `make dev-stop` — tears down infra containers
- `DEPLOYMENT.md` — step-by-step guide covering all three environments (local-infra, full-Docker, production)

## Test plan

- [ ] `make dev-setup` completes without errors on a clean checkout
- [ ] `make dev` starts both servers; http://localhost:5173 loads the landing page
- [ ] Login with `elif@demo.com` / `demo123` redirects to `/dashboard`
- [ ] Dashboard shows the service list and Leaflet map with markers
- [ ] Logout clears session and redirects to `/login`
- [ ] `docker compose up -d --build` (Option 2) serves the app on http://localhost:80

## Related issue

Closes #37