### PR TITLE
fix: event chat system overhaul (#76)

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -210,6 +210,12 @@ class PublicChatConsumer(AsyncWebsocketConsumer):
             if not room_exists:
                 await self.close(code=4004)
                 return
+
+            # For event rooms, restrict to organizer + active participants
+            event_access = await self.check_event_access(self.room_id, user)
+            if not event_access:
+                await self.close(code=4003)
+                return
             
             self.user = user
         except Exception:
@@ -286,6 +292,24 @@ class PublicChatConsumer(AsyncWebsocketConsumer):
         try:
             ChatRoom.objects.get(id=room_id)
             return True
+        except ChatRoom.DoesNotExist:
+            return False
+
+    @database_sync_to_async
+    def check_event_access(self, room_id, user):
+        """For event-linked rooms, only allow organizer + active participants."""
+        try:
+            room = ChatRoom.objects.select_related('related_service', 'related_service__user').get(id=room_id)
+            service = room.related_service
+            if not service or service.type != 'Event':
+                return True  # non-event rooms are open
+            if service.user == user:
+                return True  # organizer
+            return Handshake.objects.filter(
+                service=service,
+                requester=user,
+                status__in=['accepted', 'checked_in', 'attended'],
+            ).exists()
         except ChatRoom.DoesNotExist:
             return False
     
@@ -395,6 +419,8 @@ class GroupChatConsumer(AsyncWebsocketConsumer):
         try:
             from .models import Service
             service = Service.objects.select_related('user').get(id=service_id)
+            if service.type == 'Event':
+                return False  # Events use the public chat system, not group chat
             if service.schedule_type != 'One-Time' or service.max_participants <= 1:
                 return False
             if service.user == user:

--- a/backend/api/tests/integration/test_event_chat.py
+++ b/backend/api/tests/integration/test_event_chat.py
@@ -1,0 +1,352 @@
+"""
+Integration tests for event chat changes (GitHub issue #76).
+
+Covers:
+1. ChatViewSet.list() excludes Event-type handshakes from conversations.
+2. PublicChatViewSet restricts event chat to organizer + active participants.
+3. GroupChatViewSet rejects Event-type services entirely.
+"""
+import pytest
+from decimal import Decimal
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework import status
+
+from api.models import ChatMessage, ChatRoom, PublicChatMessage, ServiceGroupChatMessage, Handshake
+from api.tests.helpers.factories import (
+    UserFactory, ServiceFactory, HandshakeFactory, ChatMessageFactory,
+)
+from api.tests.helpers.test_client import AuthenticatedAPIClient
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _event_service(organizer=None, **kwargs):
+    """Create an active Event with a future scheduled_time."""
+    defaults = dict(
+        user=organizer or UserFactory(),
+        type='Event',
+        status='Active',
+        max_participants=10,
+        schedule_type='One-Time',
+        scheduled_time=timezone.now() + timedelta(hours=48),
+        duration=Decimal('1.00'),
+    )
+    defaults.update(kwargs)
+    return ServiceFactory(**defaults)
+
+
+def _offer_service(owner=None, **kwargs):
+    """Create an active Offer service."""
+    defaults = dict(
+        user=owner or UserFactory(),
+        type='Offer',
+        status='Active',
+        schedule_type='One-Time',
+        max_participants=3,
+    )
+    defaults.update(kwargs)
+    return ServiceFactory(**defaults)
+
+
+# ─── ChatViewSet: events excluded from conversation list ─────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestChatViewSetExcludesEvents:
+    """Event-type handshakes must NOT appear in GET /api/chats/."""
+
+    def test_event_handshakes_excluded_from_conversations(self):
+        """When a user has both event and non-event handshakes, only non-event appear."""
+        user = UserFactory()
+
+        # Create an offer handshake (should appear)
+        offer_svc = _offer_service(owner=user)
+        offer_hs = HandshakeFactory(service=offer_svc, requester=UserFactory(), status='accepted')
+        ChatMessageFactory(handshake=offer_hs, sender=offer_hs.requester, body='offer msg')
+
+        # Create an event handshake (should NOT appear)
+        event_svc = _event_service(organizer=user)
+        event_hs = HandshakeFactory(
+            service=event_svc, requester=UserFactory(),
+            status='accepted', provisioned_hours=Decimal('0'),
+        )
+        ChatMessageFactory(handshake=event_hs, sender=event_hs.requester, body='event msg')
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+
+        response = client.get('/api/chats/')
+        assert response.status_code == status.HTTP_200_OK
+
+        results = response.data['results']
+        handshake_ids = {item['handshake_id'] for item in results}
+        assert str(offer_hs.id) in handshake_ids
+        assert str(event_hs.id) not in handshake_ids
+
+    def test_only_event_handshakes_returns_empty(self):
+        """A user with only event handshakes sees an empty conversation list."""
+        user = UserFactory()
+        event_svc = _event_service(organizer=user)
+        event_hs = HandshakeFactory(
+            service=event_svc, requester=UserFactory(),
+            status='accepted', provisioned_hours=Decimal('0'),
+        )
+        ChatMessageFactory(handshake=event_hs, sender=event_hs.requester)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+
+        response = client.get('/api/chats/')
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data['results']) == 0
+
+    def test_requester_side_event_excluded(self):
+        """Event handshake is excluded when the requesting user is the requester, not owner."""
+        requester = UserFactory()
+        event_svc = _event_service()
+        HandshakeFactory(
+            service=event_svc, requester=requester,
+            status='accepted', provisioned_hours=Decimal('0'),
+        )
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(requester)
+
+        response = client.get('/api/chats/')
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data['results']) == 0
+
+
+# ─── PublicChatViewSet: event access control ──────────────────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestPublicChatEventAccess:
+    """
+    For Event-type services, PublicChatViewSet should restrict access to:
+    - The event organizer
+    - Users with an active handshake (accepted, checked_in, attended)
+    
+    Non-event services remain open to all authenticated users.
+    """
+
+    # ── GET (retrieve) ────────────────────────────────────────────────────────
+
+    def test_organizer_can_access_event_chat(self):
+        """Event organizer can retrieve the public chat room."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_200_OK
+        assert 'room' in response.data
+        assert 'messages' in response.data
+
+    def test_accepted_participant_can_access_event_chat(self):
+        """A participant with 'accepted' status can access the event chat."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(participant)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_checked_in_participant_can_access_event_chat(self):
+        """A participant with 'checked_in' status can access the event chat."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='checked_in',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(participant)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_attended_participant_can_access_event_chat(self):
+        """A participant with 'attended' status can access the event chat."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='attended',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(participant)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_non_participant_denied_event_chat(self):
+        """A user with no handshake cannot access the event chat."""
+        event = _event_service()
+        outsider = UserFactory()
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(outsider)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_pending_participant_denied_event_chat(self):
+        """A user with only a pending handshake cannot access the event chat."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='pending',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_cancelled_participant_denied_event_chat(self):
+        """A user with a cancelled handshake cannot access the event chat."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='cancelled',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+
+        response = client.get(f'/api/public-chat/{event.id}/')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # ── POST (create message) ─────────────────────────────────────────────────
+
+    def test_organizer_can_send_event_chat_message(self):
+        """Event organizer can send a message."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+
+        response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Hello from organizer!'})
+        assert response.status_code == status.HTTP_201_CREATED
+        assert PublicChatMessage.objects.filter(
+            room=event.chat_room,
+            body='Hello from organizer!'
+        ).exists()
+
+    def test_active_participant_can_send_event_chat_message(self):
+        """An active participant can send a message."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(participant)
+
+        response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Participant message'})
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_non_participant_cannot_send_event_chat_message(self):
+        """A non-participant cannot send a message to event chat."""
+        event = _event_service()
+        outsider = UserFactory()
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(outsider)
+
+        response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Sneaky msg'})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not PublicChatMessage.objects.filter(
+            room=event.chat_room,
+            body='Sneaky msg'
+        ).exists()
+
+    # ── Non-event services remain open ────────────────────────────────────────
+
+    def test_non_event_public_chat_remains_open_to_all(self):
+        """For non-event services, any authenticated user can access public chat."""
+        service = _offer_service()
+        random_user = UserFactory()
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(random_user)
+
+        response = client.get(f'/api/public-chat/{service.id}/')
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_non_event_public_chat_send_open_to_all(self):
+        """For non-event services, any authenticated user can send messages."""
+        service = _offer_service()
+        random_user = UserFactory()
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(random_user)
+
+        response = client.post(f'/api/public-chat/{service.id}/', {'body': 'Public question'})
+        assert response.status_code == status.HTTP_201_CREATED
+
+
+# ─── GroupChatViewSet: events rejected ────────────────────────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestGroupChatRejectsEvents:
+    """Event-type services cannot use the group chat endpoint."""
+
+    def test_event_service_get_denied(self):
+        """GET /api/group-chat/{event_id}/ returns 403 for Event."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+
+        response = client.get(f'/api/group-chat/{event.id}/')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_event_service_post_denied(self):
+        """POST /api/group-chat/{event_id}/ returns 403 for Event."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+
+        response = client.post(
+            f'/api/group-chat/{event.id}/',
+            {'body': 'Should not work'},
+            format='json',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not ServiceGroupChatMessage.objects.filter(service=event).exists()
+
+    def test_event_participant_also_denied_group_chat(self):
+        """Even an accepted event participant cannot use group chat."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(participant)
+
+        response = client.get(f'/api/group-chat/{event.id}/')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_event_group_chat_still_works(self):
+        """Regular group services still work with group chat."""
+        owner = UserFactory()
+        service = _offer_service(owner=owner, max_participants=3)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(owner)
+
+        response = client.get(f'/api/group-chat/{service.id}/')
+        assert response.status_code == status.HTTP_200_OK

--- a/backend/api/tests/unit/test_event_chat_access.py
+++ b/backend/api/tests/unit/test_event_chat_access.py
@@ -195,7 +195,7 @@ class TestGroupChatBlocksEvents:
 
 # ─── PublicChatConsumer.check_event_access (sync inner) ───────────────────────
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.unit
 class TestPublicChatConsumerEventAccess:
     """Unit tests for PublicChatConsumer.check_event_access database method.

--- a/backend/api/tests/unit/test_event_chat_access.py
+++ b/backend/api/tests/unit/test_event_chat_access.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for event-chat access control (GitHub issue #76).
+
+Tests the _check_event_access helper in PublicChatViewSet,
+the event-blocking guard in GroupChatViewSet._get_service_or_403,
+and the PublicChatConsumer.check_event_access database helper.
+"""
+import pytest
+from decimal import Decimal
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied
+
+from api.models import ChatRoom, Handshake
+from api.tests.helpers.factories import (
+    UserFactory, ServiceFactory, HandshakeFactory,
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _event_service(organizer=None, **kwargs):
+    defaults = dict(
+        user=organizer or UserFactory(),
+        type='Event',
+        status='Active',
+        max_participants=10,
+        schedule_type='One-Time',
+        scheduled_time=timezone.now() + timedelta(hours=48),
+        duration=Decimal('1.00'),
+    )
+    defaults.update(kwargs)
+    return ServiceFactory(**defaults)
+
+
+def _offer_service(owner=None, **kwargs):
+    defaults = dict(
+        user=owner or UserFactory(),
+        type='Offer',
+        status='Active',
+        schedule_type='One-Time',
+        max_participants=3,
+    )
+    defaults.update(kwargs)
+    return ServiceFactory(**defaults)
+
+
+# ─── PublicChatViewSet._check_event_access ────────────────────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestPublicChatEventAccessHelper:
+    """Unit tests for PublicChatViewSet._check_event_access method."""
+
+    def _viewset_with_user(self, user):
+        from api.views import PublicChatViewSet
+        viewset = PublicChatViewSet()
+        request = MagicMock()
+        request.user = user
+        return viewset, request
+
+    def test_non_event_returns_none(self):
+        """Non-event services should have no restriction."""
+        service = _offer_service()
+        vs, request = self._viewset_with_user(UserFactory())
+        result = vs._check_event_access(request, service)
+        assert result is None
+
+    def test_organizer_allowed(self):
+        """Event organizer gets None (= allowed)."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+        vs, request = self._viewset_with_user(organizer)
+        result = vs._check_event_access(request, event)
+        assert result is None
+
+    def test_accepted_participant_allowed(self):
+        """Participant with accepted handshake gets None (= allowed)."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(participant)
+        result = vs._check_event_access(request, event)
+        assert result is None
+
+    def test_checked_in_participant_allowed(self):
+        """Participant with checked_in handshake gets None (= allowed)."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='checked_in',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(participant)
+        result = vs._check_event_access(request, event)
+        assert result is None
+
+    def test_attended_participant_allowed(self):
+        """Participant with attended handshake gets None (= allowed)."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='attended',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(participant)
+        result = vs._check_event_access(request, event)
+        assert result is None
+
+    def test_non_participant_denied(self):
+        """User with no handshake gets a 403 response."""
+        event = _event_service()
+        outsider = UserFactory()
+        vs, request = self._viewset_with_user(outsider)
+        result = vs._check_event_access(request, event)
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_pending_participant_denied(self):
+        """User with pending handshake gets a 403 response."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='pending',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(user)
+        result = vs._check_event_access(request, event)
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_cancelled_participant_denied(self):
+        """User with cancelled handshake gets a 403 response."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='cancelled',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(user)
+        result = vs._check_event_access(request, event)
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_no_show_participant_denied(self):
+        """User with no_show handshake gets a 403 response."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='no_show',
+                         provisioned_hours=Decimal('0'))
+        vs, request = self._viewset_with_user(user)
+        result = vs._check_event_access(request, event)
+        assert result is not None
+        assert result.status_code == 403
+
+
+# ─── GroupChatViewSet._get_service_or_403 blocks events ──────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestGroupChatBlocksEvents:
+    """Unit tests for GroupChatViewSet._get_service_or_403 rejecting events."""
+
+    def _viewset_with_user(self, user):
+        from api.views import GroupChatViewSet
+        viewset = GroupChatViewSet()
+        viewset.request = MagicMock()
+        viewset.request.user = user
+        return viewset
+
+    def test_event_service_raises_permission_denied(self):
+        """Event service raises PermissionDenied regardless of user role."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+        vs = self._viewset_with_user(organizer)
+
+        with pytest.raises(PermissionDenied, match='event chat system'):
+            vs._get_service_or_403(vs.request, str(event.id))
+
+    def test_event_with_participant_raises_permission_denied(self):
+        """Even accepted event participants are blocked from group chat."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+        vs = self._viewset_with_user(participant)
+
+        with pytest.raises(PermissionDenied, match='event chat system'):
+            vs._get_service_or_403(vs.request, str(event.id))
+
+    def test_non_event_service_still_works(self):
+        """Regular group service passes the check normally."""
+        owner = UserFactory()
+        service = _offer_service(owner=owner, max_participants=3)
+        vs = self._viewset_with_user(owner)
+
+        result = vs._get_service_or_403(vs.request, str(service.id))
+        assert result == service
+
+
+# ─── PublicChatConsumer.check_event_access (sync inner) ───────────────────────
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestPublicChatConsumerEventAccess:
+    """Unit tests for PublicChatConsumer.check_event_access database method.
+    
+    We call the inner sync function directly (bypassing async wrapper)
+    since no WebSocket machinery is needed.
+    """
+
+    def _sync_check(self, room_id, user):
+        """Call the sync version of check_event_access."""
+        from api.consumers import PublicChatConsumer
+        consumer = PublicChatConsumer()
+        # The @database_sync_to_async decorated method wraps a sync function.
+        # We can access the underlying sync function or just call it in a sync test.
+        # Since we're in a sync pytest test with django_db, use sync_to_async's inner.
+        from asgiref.sync import async_to_sync
+        return async_to_sync(consumer.check_event_access)(room_id, user)
+
+    def test_non_event_room_returns_true(self):
+        """Rooms linked to non-event services allow all users."""
+        service = _offer_service()
+        room = service.chat_room
+        outsider = UserFactory()
+        assert self._sync_check(room.id, outsider) is True
+
+    def test_event_room_organizer_allowed(self):
+        """Organizer of the event can access the room."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+        room = event.chat_room
+        assert self._sync_check(room.id, organizer) is True
+
+    def test_event_room_accepted_participant_allowed(self):
+        """Accepted participant can access the event room."""
+        event = _event_service()
+        participant = UserFactory()
+        HandshakeFactory(service=event, requester=participant, status='accepted',
+                         provisioned_hours=Decimal('0'))
+        room = event.chat_room
+        assert self._sync_check(room.id, participant) is True
+
+    def test_event_room_non_participant_denied(self):
+        """User with no handshake is denied access to event room."""
+        event = _event_service()
+        outsider = UserFactory()
+        room = event.chat_room
+        assert self._sync_check(room.id, outsider) is False
+
+    def test_event_room_pending_participant_denied(self):
+        """User with only a pending handshake is denied."""
+        event = _event_service()
+        user = UserFactory()
+        HandshakeFactory(service=event, requester=user, status='pending',
+                         provisioned_hours=Decimal('0'))
+        room = event.chat_room
+        assert self._sync_check(room.id, user) is False
+
+    def test_nonexistent_room_returns_false(self):
+        """Non-existent room ID returns False."""
+        import uuid
+        user = UserFactory()
+        assert self._sync_check(uuid.uuid4(), user) is False

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -3052,6 +3052,8 @@ class ChatViewSet(viewsets.ViewSet):
         
         handshakes = Handshake.objects.filter(
             Q(requester=user) | Q(service__user=user)
+        ).exclude(
+            service__type='Event'
         ).select_related(
             'service', 
             'requester', 
@@ -4184,6 +4186,26 @@ class PublicChatViewSet(viewsets.ViewSet):
     throttle_classes = [UserRateThrottle]
     pagination_class = StandardResultsSetPagination
 
+    def _check_event_access(self, request, service):
+        """For Event-type services, restrict access to organizer + active participants."""
+        if service.type != 'Event':
+            return None  # no restriction for non-events
+        user = request.user
+        if service.user == user:
+            return None  # organizer always has access
+        has_active_hs = Handshake.objects.filter(
+            service=service,
+            requester=user,
+            status__in=['accepted', 'checked_in', 'attended'],
+        ).exists()
+        if has_active_hs:
+            return None
+        return create_error_response(
+            'You must be a participant or organizer of this event to access chat',
+            code=ErrorCodes.PERMISSION_DENIED,
+            status_code=status.HTTP_403_FORBIDDEN
+        )
+
     @track_performance
     def retrieve(self, request, pk=None):
         """
@@ -4199,6 +4221,11 @@ class PublicChatViewSet(viewsets.ViewSet):
                 code=ErrorCodes.NOT_FOUND,
                 status_code=status.HTTP_404_NOT_FOUND
             )
+
+        # For events, restrict to organizer + active participants
+        denied = self._check_event_access(request, service)
+        if denied:
+            return denied
 
         # Get or create chat room for the service (atomic to handle concurrent requests)
         room, _ = ChatRoom.objects.get_or_create(
@@ -4251,6 +4278,11 @@ class PublicChatViewSet(viewsets.ViewSet):
                 code=ErrorCodes.NOT_FOUND,
                 status_code=status.HTTP_404_NOT_FOUND
             )
+
+        # For events, restrict to organizer + active participants
+        denied = self._check_event_access(request, service)
+        if denied:
+            return denied
 
         # Get or create chat room (atomic to handle concurrent requests)
         room, _ = ChatRoom.objects.get_or_create(
@@ -4319,6 +4351,10 @@ class GroupChatViewSet(viewsets.ViewSet):
         except Service.DoesNotExist:
             from rest_framework.exceptions import NotFound
             raise NotFound('Service not found')
+
+        if service.type == 'Event':
+            from rest_framework.exceptions import PermissionDenied
+            raise PermissionDenied('Events use the event chat system, not group chat')
 
         if service.schedule_type != 'One-Time' or service.max_participants <= 1:
             from rest_framework.exceptions import PermissionDenied

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -203,6 +203,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -542,6 +543,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -578,6 +580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -585,7 +588,6 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -603,7 +605,6 @@
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -663,8 +664,7 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -683,8 +683,7 @@
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -1355,6 +1354,7 @@
     "node_modules/@internationalized/date": {
       "version": "3.11.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -1945,8 +1945,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2081,14 +2080,14 @@
       "version": "24.11.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
@@ -2100,6 +2099,7 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2108,6 +2108,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2160,6 +2161,7 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3344,6 +3346,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3386,7 +3389,6 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3475,7 +3477,6 @@
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -3537,6 +3538,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3676,13 +3678,11 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -3697,7 +3697,6 @@
     "node_modules/cosmiconfig/node_modules/yaml": {
       "version": "1.10.2",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3930,8 +3929,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3978,7 +3976,6 @@
     "node_modules/error-ex": {
       "version": "1.3.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4087,6 +4084,7 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4330,8 +4328,7 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -4573,7 +4570,6 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -4665,13 +4661,11 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -4793,6 +4787,7 @@
       "version": "28.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -4845,8 +4840,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4903,8 +4897,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4951,7 +4944,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5004,6 +4996,7 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.19.0.tgz",
       "integrity": "sha512-SFObIgdxN0b6hZNsRxSUmQWdVW9q9GM2gw4McgFbycyhekew7BZIh8V57pEERDWlI9x/5SxxraTit5Cf0hm9OA==",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
       "workspaces": [
         "src/style-spec",
         "test/build/vite",
@@ -5216,7 +5209,6 @@
     "node_modules/parse-json": {
       "version": "5.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -5259,13 +5251,11 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5299,6 +5289,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5398,7 +5389,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5412,7 +5402,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5423,8 +5412,7 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5473,6 +5461,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5480,6 +5469,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5490,6 +5480,7 @@
     "node_modules/react-hook-form": {
       "version": "7.71.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5654,7 +5645,6 @@
     "node_modules/resolve": {
       "version": "1.22.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -5849,7 +5839,6 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5939,8 +5928,7 @@
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supercluster": {
       "version": "8.0.1",
@@ -5965,7 +5953,6 @@
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6092,6 +6079,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6230,6 +6218,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6303,6 +6292,7 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -6484,6 +6474,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/EventChatModal.tsx
+++ b/frontend/src/components/EventChatModal.tsx
@@ -1,0 +1,338 @@
+import { useState, useEffect, useRef, useCallback, type KeyboardEvent, type MouseEvent } from 'react'
+import { Box, Flex, Stack, Text, Textarea } from '@chakra-ui/react'
+import { FiX, FiSend, FiMessageSquare, FiUsers, FiWifi, FiWifiOff } from 'react-icons/fi'
+import { toast } from 'sonner'
+import { useAuthStore } from '@/store/useAuthStore'
+import { eventChatAPI, buildEventChatWsUrl } from '@/services/conversationAPI'
+import type { PublicChatMessage } from '@/services/conversationAPI'
+import { useWebSocket } from '@/hooks/useWebSocket'
+import type { Service } from '@/types'
+
+import {
+  AMBER, AMBER_LT,
+  GREEN,
+  GRAY50, GRAY100, GRAY200, GRAY400, GRAY500, GRAY700, GRAY800,
+  WHITE,
+} from '@/theme/tokens'
+
+// ─── Avatar ───────────────────────────────────────────────────────────────────
+
+function Avatar({ name, size = 30, bg = AMBER }: { name: string; size?: number; bg?: string }) {
+  const initials = name.split(' ').map((n) => n[0] ?? '').join('').toUpperCase().slice(0, 2)
+  return (
+    <Box w={`${size}px`} h={`${size}px`} borderRadius="full" bg={bg} color={WHITE}
+      display="flex" alignItems="center" justifyContent="center"
+      fontSize={`${Math.round(size * 0.38)}px`} fontWeight={700} flexShrink={0}
+    >
+      {initials}
+    </Box>
+  )
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  service: Service
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function EventChatModal({ isOpen, onClose, service }: Props) {
+  const { user } = useAuthStore()
+  const [messages, setMessages] = useState<PublicChatMessage[]>([])
+  const [roomId, setRoomId] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  const [isSending, setIsSending] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  const organizerId = service.user?.id ?? (service as unknown as { provider?: { id: string } }).provider?.id
+
+  // ── Fetch messages on open ────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isOpen) return
+    const ac = new AbortController()
+    setIsLoading(true)
+    eventChatAPI.getMessages(service.id, ac.signal)
+      .then(({ room, messages: msgs }) => {
+        setRoomId(room.id)
+        setMessages(msgs.slice().reverse()) // API returns newest-first; we want chronological
+      })
+      .catch((err) => {
+        if (!ac.signal.aborted) {
+          console.error('Failed to load event chat:', err)
+          toast.error('Failed to load event chat')
+        }
+      })
+      .finally(() => setIsLoading(false))
+    return () => ac.abort()
+  }, [isOpen, service.id])
+
+  // ── WebSocket ─────────────────────────────────────────────────────────────
+
+  const handleWsMessage = useCallback((msg: PublicChatMessage) => {
+    setMessages((prev: PublicChatMessage[]) => {
+      // Deduplicate by id
+      if (prev.some((m: PublicChatMessage) => m.id === msg.id)) return prev
+      return [...prev, msg]
+    })
+  }, [])
+
+  const wsUrl = roomId ? buildEventChatWsUrl(roomId) : ''
+  const { isConnected, sendMessage: wsSend } = useWebSocket({
+    url: wsUrl,
+    onMessage: handleWsMessage,
+    enabled: isOpen && !!roomId,
+  })
+
+  // ── Auto-scroll ───────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    const el = bottomRef.current
+    if (!el) return
+    let node: HTMLElement | null = el.parentElement
+    while (node) {
+      if (node.scrollHeight > node.clientHeight) {
+        node.scrollTop = node.scrollHeight
+        return
+      }
+      node = node.parentElement
+    }
+  }, [messages])
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      setTimeout(() => inputRef.current?.focus(), 200)
+    }
+  }, [isOpen, roomId])
+
+  // ── Send message ──────────────────────────────────────────────────────────
+
+  const handleSend = async () => {
+    const body = draft.trim()
+    if (!body || isSending) return
+    setDraft('')
+    setIsSending(true)
+
+    // Try WebSocket first
+    const sent = wsSend(body)
+    if (!sent) {
+      // Fallback to REST
+      try {
+        const msg = await eventChatAPI.sendMessage(service.id, body)
+        setMessages((prev: PublicChatMessage[]) => {
+          if (prev.some((m: PublicChatMessage) => m.id === msg.id)) return prev
+          return [...prev, msg]
+        })
+      } catch {
+        toast.error('Failed to send message')
+        setDraft(body)
+      }
+    }
+    setIsSending(false)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (!isOpen) return null
+
+  return (
+    <Box
+      position="fixed" inset={0} zIndex={1000}
+      bg="rgba(0,0,0,0.55)"
+      display="flex" alignItems="center" justifyContent="center"
+      p={4}
+      onClick={onClose}
+    >
+      <Box
+        bg={WHITE} borderRadius="20px" w="100%" maxW="560px"
+        boxShadow="0 20px 60px rgba(0,0,0,0.2)"
+        onClick={(e: MouseEvent) => e.stopPropagation()}
+        h="min(85vh, 700px)" display="flex" flexDirection="column"
+      >
+        {/* Header */}
+        <Flex align="center" justify="space-between" px={6} py={4}
+          borderBottom={`1px solid ${GRAY100}`}
+          bg={AMBER_LT} borderTopRadius="20px"
+        >
+          <Flex align="center" gap={3}>
+            <Box w="36px" h="36px" borderRadius="10px" bg={AMBER} color={WHITE}
+              display="flex" alignItems="center" justifyContent="center"
+            >
+              <FiMessageSquare size={16} />
+            </Box>
+            <Box>
+              <Text fontSize="15px" fontWeight={800} color={GRAY800}>Event Chat</Text>
+              <Text fontSize="11px" color={GRAY500} mt="1px"
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '300px' }}
+              >
+                {service.title}
+              </Text>
+            </Box>
+          </Flex>
+          <Flex align="center" gap={3}>
+            {/* Connection indicator */}
+            <Box color={isConnected ? GREEN : GRAY400} title={isConnected ? 'Connected' : 'Connecting…'}>
+              {isConnected ? <FiWifi size={14} /> : <FiWifiOff size={14} />}
+            </Box>
+            <Box
+              as="button" onClick={onClose}
+              w="30px" h="30px" borderRadius="8px" bg={WHITE}
+              display="flex" alignItems="center" justifyContent="center"
+              style={{ border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
+            >
+              <FiX size={14} color={GRAY500} />
+            </Box>
+          </Flex>
+        </Flex>
+
+        {/* Participant hint */}
+        <Flex align="center" gap={2} px={6} py="8px" bg={GRAY50}
+          borderBottom={`1px solid ${GRAY100}`}
+        >
+          <FiUsers size={11} color={GRAY400} />
+          <Text fontSize="11px" color={GRAY500}>
+            {service.participant_count ?? 0}/{service.max_participants} participants
+            {' · '}Organizer &amp; participants can chat here
+          </Text>
+        </Flex>
+
+        {/* Messages area */}
+        <Box flex={1} overflowY="auto" px={5} py={4}>
+          {isLoading ? (
+            <Flex align="center" justify="center" h="full">
+              <Text fontSize="13px" color={GRAY400}>Loading messages…</Text>
+            </Flex>
+          ) : messages.length === 0 ? (
+            <Flex direction="column" align="center" justify="center" h="full" gap={3}>
+              <Box w="48px" h="48px" borderRadius="full" bg={AMBER_LT}
+                display="flex" alignItems="center" justifyContent="center"
+                color={AMBER} fontSize="22px"
+              >
+                <FiMessageSquare />
+              </Box>
+              <Text fontSize="13px" color={GRAY400} textAlign="center">
+                No messages yet. Start the conversation!
+              </Text>
+            </Flex>
+          ) : (
+            <Stack gap={1}>
+              {messages.map((msg: PublicChatMessage) => {
+                const isMe = msg.sender_id === user?.id
+                const isOrganizer = msg.sender_id === organizerId
+                return (
+                  <Box
+                    key={msg.id}
+                    display="flex"
+                    flexDirection={isMe ? 'row-reverse' : 'row'}
+                    alignItems="flex-end"
+                    gap={2}
+                    mb={1}
+                  >
+                    {!isMe && (
+                      <Avatar
+                        name={msg.sender_name || '?'}
+                        size={28}
+                        bg={isOrganizer ? AMBER : GRAY400}
+                      />
+                    )}
+                    <Box maxW="75%">
+                      {!isMe && (
+                        <Flex align="center" gap={2} mb="2px" ml="2px">
+                          <Text fontSize="11px" fontWeight={600}
+                            color={isOrganizer ? AMBER : GRAY700}
+                          >
+                            {msg.sender_name}
+                          </Text>
+                          {isOrganizer && (
+                            <Box px="5px" py="1px" borderRadius="full"
+                              fontSize="9px" fontWeight={700}
+                              bg={AMBER_LT} color={AMBER}
+                              border={`1px solid ${AMBER}30`}
+                            >
+                              Organizer
+                            </Box>
+                          )}
+                        </Flex>
+                      )}
+                      <Box
+                        px="12px" py="8px"
+                        borderRadius={isMe ? '14px 14px 4px 14px' : '14px 14px 14px 4px'}
+                        bg={isMe ? AMBER : GRAY100}
+                        color={isMe ? WHITE : GRAY800}
+                        fontSize="13px"
+                        lineHeight={1.5}
+                        style={{ wordBreak: 'break-word' }}
+                      >
+                        {msg.body}
+                      </Box>
+                      <Text
+                        fontSize="10px" color={GRAY400} mt="2px"
+                        textAlign={isMe ? 'right' : 'left'}
+                        px="4px"
+                      >
+                        {new Date(msg.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </Text>
+                    </Box>
+                  </Box>
+                )
+              })}
+              <Box ref={bottomRef} />
+            </Stack>
+          )}
+        </Box>
+
+        {/* Input area */}
+        <Flex gap={2} px={5} py={4} borderTop={`1px solid ${GRAY100}`} bg={GRAY50}
+          borderBottomRadius="20px" align="flex-end"
+        >
+          <Textarea
+            ref={inputRef}
+            value={draft}
+            onChange={(e: { target: { value: string } }) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message…"
+            rows={1}
+            resize="none"
+            fontSize="13px"
+            bg={WHITE}
+            border={`1px solid ${GRAY200}`}
+            borderRadius="12px"
+            px="14px" py="10px"
+            _focus={{ borderColor: AMBER, boxShadow: `0 0 0 2px ${AMBER}18` }}
+            style={{ minHeight: '42px', maxHeight: '100px' }}
+          />
+          <Box
+            as="button"
+            w="42px" h="42px" minW="42px"
+            borderRadius="12px"
+            bg={draft.trim() ? AMBER : GRAY200}
+            color={draft.trim() ? WHITE : GRAY400}
+            display="flex" alignItems="center" justifyContent="center"
+            onClick={handleSend}
+            style={{
+              border: 'none',
+              cursor: draft.trim() && !isSending ? 'pointer' : 'not-allowed',
+              opacity: isSending ? 0.7 : 1,
+              transition: 'background 0.15s, opacity 0.15s',
+            }}
+          >
+            <FiSend size={16} />
+          </Box>
+        </Flex>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/components/EventChatModal.tsx
+++ b/frontend/src/components/EventChatModal.tsx
@@ -45,20 +45,25 @@ export default function EventChatModal({ isOpen, onClose, service }: Props) {
   const [roomId, setRoomId] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
   const [isSending, setIsSending] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const [fetchDone, setFetchDone] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
+  const isLoading = isOpen && !fetchDone
   const organizerId = service.user?.id ?? (service as unknown as { provider?: { id: string } }).provider?.id
 
   // ── Fetch messages on open ────────────────────────────────────────────────
 
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen) {
+      // Cleanup runs async (after render), so this is safe
+      return () => { setFetchDone(false) }
+    }
     const ac = new AbortController()
-    setIsLoading(true)
+    let cancelled = false
     eventChatAPI.getMessages(service.id, ac.signal)
       .then(({ room, messages: msgs }) => {
+        if (cancelled) return
         setRoomId(room.id)
         setMessages(msgs.slice().reverse()) // API returns newest-first; we want chronological
       })
@@ -68,8 +73,8 @@ export default function EventChatModal({ isOpen, onClose, service }: Props) {
           toast.error('Failed to load event chat')
         }
       })
-      .finally(() => setIsLoading(false))
-    return () => ac.abort()
+      .finally(() => { if (!cancelled) setFetchDone(true) })
+    return () => { cancelled = true; ac.abort() }
   }, [isOpen, service.id])
 
   // ── WebSocket ─────────────────────────────────────────────────────────────

--- a/frontend/src/components/MainSidebar.tsx
+++ b/frontend/src/components/MainSidebar.tsx
@@ -198,8 +198,9 @@ export function MainSidebar({
             <Box as="button" flex={1} minW="58px" py="8px" borderRadius="9px"
               fontSize="12px" fontWeight={700}
               display="flex" alignItems="center" justifyContent="center" gap="4px"
-              style={{ background: '#FFFBEB', color: '#D97706', border: '1px solid #FDE68A' }}
-              onClick={() => navigate('/post-event')}>
+              bg="#FFFBEB" color="#D97706" border="1px solid #FDE68A"
+              onClick={() => navigate('/post-event')}
+              _hover={{ bg: '#FEF3C7' }}>
               <FiPlus size={12} /> Event
             </Box>
           </Flex>

--- a/frontend/src/components/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm.tsx
@@ -531,7 +531,7 @@ export default function ServiceForm({ type }: { type: 'Offer' | 'Need' | 'Event'
             <Box>
               <Label required>Title</Label>
               <Input
-                placeholder={type === 'Offer' ? 'e.g. Guitar lessons for beginners' : 'e.g. Need help moving furniture'}
+                placeholder={type === 'Event' ? 'e.g. Weekend hiking meetup' : type === 'Offer' ? 'e.g. Guitar lessons for beginners' : 'e.g. Need help moving furniture'}
                 {...register('title')}
                 style={inputStyle}
                 _focus={{ borderColor: accent, boxShadow: `0 0 0 2px ${accent}18` }}
@@ -542,7 +542,7 @@ export default function ServiceForm({ type }: { type: 'Offer' | 'Need' | 'Event'
             <Box>
               <Label required>Description</Label>
               <Textarea
-                placeholder="Describe what you're offering or what you need in detail…"
+                placeholder={type === 'Event' ? 'Describe your event, what participants can expect…' : "Describe what you're offering or what you need in detail…"}
                 rows={4}
                 {...register('description')}
                 style={{ ...inputStyle, resize: 'vertical' }}
@@ -570,7 +570,7 @@ export default function ServiceForm({ type }: { type: 'Offer' | 'Need' | 'Event'
                 <ErrTxt msg={errors.duration?.message} />
               </Box>
               <Box>
-                <Label required>{type === 'Offer' ? 'Max participants' : 'Helpers needed'}</Label>
+                <Label required>{type === 'Need' ? 'Helpers needed' : 'Max participants'}</Label>
                 <Input
                   type="number" min={1} max={100} placeholder="1"
                   {...register('max_participants')}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1249,10 +1249,12 @@ export default function ChatPage() {
 
   const fetchConversations = useCallback(async (signal: AbortSignal) => {
     const data = await conversationAPI.listConversations(signal)
-    setConversations(data)
+    // Filter out event conversations — events use a dedicated Event Chat modal
+    const filtered = data.filter((c) => c.service_type !== 'Event')
+    setConversations(filtered)
     // Auto-select first active conversation only when nothing is selected yet
-    if (!selectedIdRef.current && !paramIdRef.current && data.length > 0) {
-      const first = data.find((c) => ACTIVE_STATUSES.has(c.status)) ?? data[0]
+    if (!selectedIdRef.current && !paramIdRef.current && filtered.length > 0) {
+      const first = filtered.find((c) => ACTIVE_STATUSES.has(c.status)) ?? filtered[0]
       setSelectedId(first.handshake_id)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -13,6 +13,7 @@ import { commentAPI } from '@/services/commentAPI'
 import { handshakeAPI } from '@/services/handshakeAPI'
 import { MapView } from '@/components/MapView'
 import EventRosterModal from '@/components/EventRosterModal'
+import EventChatModal from '@/components/EventChatModal'
 import {
   isWithinLockdownWindow, isFutureEvent, isEventFull, isNearlyFull,
   spotsLeft, formatEventDateTime, timeUntilEvent, isEventBanned, formatBanExpiry,
@@ -369,6 +370,7 @@ export default function ServiceDetailPage() {
   const [checkinLoading, setCheckinLoading] = useState(false)
   const [cancelLoading, setCancelLoading]   = useState(false)
   const [showRoster, setShowRoster]         = useState(false)
+  const [showEventChat, setShowEventChat]   = useState(false)
   const [completing, setCompleting]         = useState(false)
   const [markingAttendedId, setMarkingAttendedId] = useState<string | null>(null)
 
@@ -960,6 +962,16 @@ export default function ServiceDetailPage() {
                     )}
 
                     <Box as="button" w="full" py="11px" borderRadius="10px"
+                      bg={AMBER} color={WHITE} fontSize="14px" fontWeight={700}
+                      display="flex" alignItems="center" justifyContent="center" gap="7px"
+                      onClick={() => setShowEventChat(true)}
+                      style={{ border: 'none', cursor: 'pointer' }}
+                      _hover={{ opacity: 0.9 }}
+                    >
+                      <FiMessageSquare size={14} /> Event Chat
+                    </Box>
+
+                    <Box as="button" w="full" py="11px" borderRadius="10px"
                       bg={GREEN} color={WHITE} fontSize="14px" fontWeight={700}
                       display="flex" alignItems="center" justifyContent="center" gap="7px"
                       onClick={() => setShowRoster(true)}
@@ -1012,6 +1024,15 @@ export default function ServiceDetailPage() {
                           </Text>
                         </Box>
                       </Box>
+                      <Box as="button" w="full" py="11px" borderRadius="10px"
+                        bg={AMBER} color={WHITE} fontSize="14px" fontWeight={700}
+                        display="flex" alignItems="center" justifyContent="center" gap="7px"
+                        onClick={() => setShowEventChat(true)}
+                        style={{ border: 'none', cursor: 'pointer' }}
+                        _hover={{ opacity: 0.9 }}
+                      >
+                        <FiMessageSquare size={14} /> Event Chat
+                      </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'attended' ? (
                     <Stack gap={3}>
@@ -1025,6 +1046,15 @@ export default function ServiceDetailPage() {
                             The organizer marked you as attended.
                           </Text>
                         </Box>
+                      </Box>
+                      <Box as="button" w="full" py="11px" borderRadius="10px"
+                        bg={AMBER} color={WHITE} fontSize="14px" fontWeight={700}
+                        display="flex" alignItems="center" justifyContent="center" gap="7px"
+                        onClick={() => setShowEventChat(true)}
+                        style={{ border: 'none', cursor: 'pointer' }}
+                        _hover={{ opacity: 0.9 }}
+                      >
+                        <FiMessageSquare size={14} /> Event Chat
                       </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'accepted' && isFutureEvent(service.scheduled_time) ? (
@@ -1058,6 +1088,15 @@ export default function ServiceDetailPage() {
                           {leaveLoading ? 'Leaving…' : 'Leave Event'}
                         </Box>
                       )}
+                      <Box as="button" w="full" py="11px" borderRadius="10px"
+                        bg={AMBER} color={WHITE} fontSize="14px" fontWeight={700}
+                        display="flex" alignItems="center" justifyContent="center" gap="7px"
+                        onClick={() => setShowEventChat(true)}
+                        style={{ border: 'none', cursor: 'pointer' }}
+                        _hover={{ opacity: 0.9 }}
+                      >
+                        <FiMessageSquare size={14} /> Event Chat
+                      </Box>
                     </Stack>
                   ) : !isFutureEvent(service.scheduled_time) ? (
                     /* Past event */
@@ -1331,6 +1370,14 @@ export default function ServiceDetailPage() {
           onMarkAttended={handleMarkAttended}
           markingHandshakeId={markingAttendedId}
           completing={completing}
+        />
+      )}
+
+      {showEventChat && service && (
+        <EventChatModal
+          isOpen={showEventChat}
+          onClose={() => setShowEventChat(false)}
+          service={service}
         />
       )}
     </Box>

--- a/frontend/src/services/conversationAPI.ts
+++ b/frontend/src/services/conversationAPI.ts
@@ -14,6 +14,24 @@ export interface ApiChatMessage {
   created_at: string
 }
 
+export interface PublicChatMessage {
+  id: string
+  room: string
+  sender_id: string
+  sender_name: string
+  sender_avatar_url: string | null
+  body: string
+  created_at: string
+}
+
+interface PublicChatRoom {
+  id: string
+  name: string
+  type: string
+  related_service: string | null
+  created_at: string
+}
+
 export interface ChatConversation {
   handshake_id: string
   service_id: string
@@ -124,10 +142,38 @@ export const groupChatAPI = {
   },
 }
 
+// ─── Event Chat API (public chat rooms) ───────────────────────────────────────
+
+export const eventChatAPI = {
+  /**
+   * GET /api/public-chat/{serviceId}/ — get room info and messages for an event.
+   * Returns { room, messages: { count, next, previous, results } }.
+   */
+  getMessages: async (serviceId: string, signal?: AbortSignal): Promise<{ room: PublicChatRoom; messages: PublicChatMessage[] }> => {
+    const res = await apiClient.get<{ room: PublicChatRoom; messages: { results: PublicChatMessage[] } }>(
+      `/public-chat/${serviceId}/`,
+      { signal },
+    )
+    return {
+      room: res.data.room,
+      messages: res.data.messages?.results ?? [],
+    }
+  },
+
+  /**
+   * POST /api/public-chat/{serviceId}/ — send a message to the event chat.
+   */
+  sendMessage: async (serviceId: string, body: string): Promise<PublicChatMessage> => {
+    const res = await apiClient.post<PublicChatMessage>(`/public-chat/${serviceId}/`, { body })
+    return res.data
+  },
+}
+
 // Both dev and prod connect to the current host; the WS upgrade is forwarded
 // by Vite's /ws proxy rule (dev) or Nginx (prod). This respects VITE_BACKEND_URL
 // without hard-coding a port and works in Docker / LAN setups.
 const wsBase = `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
 
-export const buildChatWsUrl     = (id: string) => `${wsBase}/ws/chat/${id}/`
+export const buildChatWsUrl      = (id: string) => `${wsBase}/ws/chat/${id}/`
 export const buildGroupChatWsUrl = (id: string) => `${wsBase}/ws/group-chat/${id}/`
+export const buildEventChatWsUrl = (roomId: string) => `${wsBase}/ws/public-chat/${roomId}/`

--- a/frontend/src/test/services/eventChatAPI.test.ts
+++ b/frontend/src/test/services/eventChatAPI.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for event chat API helpers and WebSocket URL builder
+ * (GitHub issue #76).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// We need to mock window.location before importing the module
+// since wsBase is computed at module load time.
+// Instead, test the exported functions that use relative paths through apiClient.
+
+describe('eventChatAPI', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('module exports eventChatAPI with getMessages and sendMessage', async () => {
+    const mod = await import('@/services/conversationAPI')
+    expect(mod.eventChatAPI).toBeDefined()
+    expect(typeof mod.eventChatAPI.getMessages).toBe('function')
+    expect(typeof mod.eventChatAPI.sendMessage).toBe('function')
+  })
+
+  it('module exports buildEventChatWsUrl function', async () => {
+    const mod = await import('@/services/conversationAPI')
+    expect(typeof mod.buildEventChatWsUrl).toBe('function')
+  })
+
+  it('buildEventChatWsUrl produces correct path format', async () => {
+    const mod = await import('@/services/conversationAPI')
+    const url = mod.buildEventChatWsUrl('abc-123')
+    // Should end with the correct path regardless of protocol/host
+    expect(url).toContain('/ws/public-chat/abc-123/')
+  })
+
+  it('buildChatWsUrl produces ws/chat path', async () => {
+    const mod = await import('@/services/conversationAPI')
+    const url = mod.buildChatWsUrl('xyz-789')
+    expect(url).toContain('/ws/chat/xyz-789/')
+  })
+
+  it('buildGroupChatWsUrl produces ws/group-chat path', async () => {
+    const mod = await import('@/services/conversationAPI')
+    const url = mod.buildGroupChatWsUrl('svc-456')
+    expect(url).toContain('/ws/group-chat/svc-456/')
+  })
+})
+
+describe('PublicChatMessage type exports', () => {
+  it('conversationAPI module exports all expected API objects', async () => {
+    const mod = await import('@/services/conversationAPI')
+    expect(mod.conversationAPI).toBeDefined()
+    expect(mod.groupChatAPI).toBeDefined()
+    expect(mod.eventChatAPI).toBeDefined()
+
+    // conversationAPI
+    expect(typeof mod.conversationAPI.listConversations).toBe('function')
+    expect(typeof mod.conversationAPI.getMessages).toBe('function')
+    expect(typeof mod.conversationAPI.sendMessage).toBe('function')
+
+    // groupChatAPI
+    expect(typeof mod.groupChatAPI.getMessages).toBe('function')
+    expect(typeof mod.groupChatAPI.sendMessage).toBe('function')
+
+    // eventChatAPI
+    expect(typeof mod.eventChatAPI.getMessages).toBe('function')
+    expect(typeof mod.eventChatAPI.sendMessage).toBe('function')
+  })
+})

--- a/frontend/src/test/utils/eventChatFilter.test.ts
+++ b/frontend/src/test/utils/eventChatFilter.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for ChatPage event-filtering logic (GitHub issue #76).
+ *
+ * The ChatPage filters out conversations where service_type === 'Event'
+ * so that events only appear in the dedicated EventChatModal.
+ */
+import { describe, it, expect } from 'vitest'
+
+// Extract the filter logic used in ChatPage for isolated testing
+const filterEventConversations = <T extends { service_type: string }>(data: T[]): T[] =>
+  data.filter((c) => c.service_type !== 'Event')
+
+describe('filterEventConversations', () => {
+  it('removes Event-type conversations', () => {
+    const conversations = [
+      { service_type: 'Offer', handshake_id: '1' },
+      { service_type: 'Event', handshake_id: '2' },
+      { service_type: 'Need', handshake_id: '3' },
+    ]
+
+    const result = filterEventConversations(conversations)
+    expect(result).toHaveLength(2)
+    expect(result.map((c) => c.service_type)).toEqual(['Offer', 'Need'])
+  })
+
+  it('returns empty array when all are events', () => {
+    const conversations = [
+      { service_type: 'Event', handshake_id: '1' },
+      { service_type: 'Event', handshake_id: '2' },
+    ]
+
+    const result = filterEventConversations(conversations)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns all when none are events', () => {
+    const conversations = [
+      { service_type: 'Offer', handshake_id: '1' },
+      { service_type: 'Need', handshake_id: '2' },
+    ]
+
+    const result = filterEventConversations(conversations)
+    expect(result).toHaveLength(2)
+  })
+
+  it('handles empty array', () => {
+    const result = filterEventConversations([])
+    expect(result).toHaveLength(0)
+  })
+
+  it('is case-sensitive (Event vs event)', () => {
+    const conversations = [
+      { service_type: 'event', handshake_id: '1' },
+      { service_type: 'Event', handshake_id: '2' },
+    ]
+
+    // Only exact 'Event' is filtered
+    const result = filterEventConversations(conversations)
+    expect(result).toHaveLength(1)
+    expect(result[0].service_type).toBe('event')
+  })
+})


### PR DESCRIPTION
- Remove events from 1-to-1 chat (ChatViewSet.list excludes Event type)
- Add EventChatModal: public WebSocket-based chat for event participants
- Restrict event public chat to organizer + active participants (accepted/checked_in/attended)
- Block events from group chat endpoint (GroupChatViewSet)
- Add event access control to PublicChatConsumer WebSocket
- Fix ServiceForm labels: 'Max participants' for Events/Offers, 'Helpers needed' for Needs
- Fix ServiceForm placeholders per service type
- Fix MainSidebar event button hover styling
- Filter event conversations from ChatPage sidebar
- Add eventChatAPI + buildEventChatWsUrl to conversationAPI
- Add backend integration tests for event chat access control
- Add backend unit tests for access control helpers
- Add frontend unit tests for API exports and event filtering

Closes #76