### PR TITLE
fix: make e2e tests idempotent and resilient to accordion state

### DIFF
--- a/frontend/tests/e2e/group-chat.spec.ts
+++ b/frontend/tests/e2e/group-chat.spec.ts
@@ -22,16 +22,23 @@ import { loginAs, USERS } from './helpers/auth'
 
 const GROUP_SERVICE_TITLE = 'Traditional Manti Cooking Workshop'
 
-/** Expand the Manti service-group accordion and click the group-chat row. */
+/** Ensure the Manti accordion is open and click the group-chat row. */
 async function openGroupChat(page: import('@playwright/test').Page) {
-  // The accordion header is a button containing the service title + "GROUP" badge
+  // Wait for the accordion header to appear
   const header = page.getByRole('button', { name: new RegExp(GROUP_SERVICE_TITLE, 'i') }).first()
   await expect(header).toBeVisible({ timeout: 20_000 })
-  await header.click()
 
-  // Inside the expanded accordion, the group row is a button with "participant" text
+  // The group row is inside the expanded accordion — a button with "participant" text
   const groupRow = page.locator('button').filter({ hasText: /participant/i }).first()
-  await expect(groupRow).toBeVisible({ timeout: 10_000 })
+
+  // If the accordion auto-opened (e.g. a conversation inside was selected), the group
+  // row is already visible. Only click the header if we need to expand it.
+  const isVisible = await groupRow.isVisible().catch(() => false)
+  if (!isVisible) {
+    await header.click()
+    await expect(groupRow).toBeVisible({ timeout: 10_000 })
+  }
+
   return groupRow
 }
 

--- a/frontend/tests/e2e/handshake.spec.ts
+++ b/frontend/tests/e2e/handshake.spec.ts
@@ -34,13 +34,22 @@ test.describe('Handshake — express interest', () => {
     await page.getByText(TARGET_SERVICE).first().click()
     await expect(page).toHaveURL(/\/service-detail\//)
 
-    // Request the service — button is "Request this Service" for Offer-type
+    // The button text depends on whether a handshake already exists (idempotent test):
+    //  - Fresh state: "Request this Service" or "Offer to Help"
+    //  - Already requested: "View Chat (Pending)"
     const requestBtn = page.getByRole('button', { name: /Request this Service|Offer to Help/i })
-    await expect(requestBtn).toBeVisible({ timeout: 10_000 })
-    await requestBtn.click()
+    const alreadyBtn = page.getByRole('button', { name: /View Chat/i })
 
-    // Expect success toast
-    await expectToast(page, /Interest expressed|Messages|already/i)
+    // Wait for either button to appear
+    await expect(requestBtn.or(alreadyBtn)).toBeVisible({ timeout: 10_000 })
+
+    if (await requestBtn.isVisible()) {
+      await requestBtn.click()
+      await expectToast(page, /Interest expressed|Messages|already/i)
+    } else {
+      // Handshake already exists from a prior run — that's fine
+      await expect(alreadyBtn).toBeVisible()
+    }
   })
 
   test('requester sees the new conversation in /messages', async ({ page }) => {


### PR DESCRIPTION
- group-chat: check if accordion is already open before clicking header
- handshake: handle both fresh-request and already-requested states