### PR TITLE
Feature/44 transaction history page

### DIFF
--- a/backend/api/cache_utils.py
+++ b/backend/api/cache_utils.py
@@ -200,19 +200,18 @@ def invalidate_conversations(user_id: str) -> None:
     CacheManager.delete(key)
 
 
-def cache_transactions(user_id: str, data: list, ttl: int = CACHE_TTL_SHORT) -> None:
-    key = f"transactions:{user_id}"
+def cache_transactions(user_id: str, data: list, page: str = '1', direction: str = 'all', ttl: int = CACHE_TTL_SHORT) -> None:
+    key = f"transactions:{user_id}:page={page}:direction={direction}"
     CacheManager.set(key, data, ttl)
 
 
-def get_cached_transactions(user_id: str) -> Optional[list]:
-    key = f"transactions:{user_id}"
+def get_cached_transactions(user_id: str, page: str = '1', direction: str = 'all') -> Optional[list]:
+    key = f"transactions:{user_id}:page={page}:direction={direction}"
     return CacheManager.get(key)
 
 
 def invalidate_transactions(user_id: str) -> None:
-    key = f"transactions:{user_id}"
-    CacheManager.delete(key)
+    CacheManager.delete_pattern(f"transactions:{user_id}:")
 
 
 def cache_service_detail(service_id: str, data: dict, ttl: int = CACHE_TTL_MEDIUM) -> None:

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1162,15 +1162,20 @@ class PublicUserProfileSerializer(serializers.ModelSerializer):
 )
 class HandshakeSerializer(serializers.ModelSerializer):
     service_title = serializers.CharField(source='service.title', read_only=True)
+    service_type = serializers.CharField(source='service.type', read_only=True)
     requester_name = serializers.SerializerMethodField()
     provider_name = serializers.SerializerMethodField()
+    counterpart = serializers.SerializerMethodField()
+    is_current_user_provider = serializers.SerializerMethodField()
     user_has_reviewed = serializers.SerializerMethodField()
 
     class Meta:
         model = Handshake
         fields = [
             'id', 'service', 'service_title', 'requester', 'requester_name',
-            'provider_name', 'status', 'provisioned_hours',
+            'provider_name', 'service_type',
+            'counterpart', 'is_current_user_provider',
+            'status', 'provisioned_hours',
             'provider_confirmed_complete', 'receiver_confirmed_complete',
             'exact_location', 'exact_duration', 'scheduled_time',
             'provider_initiated', 'requester_initiated',
@@ -1188,6 +1193,35 @@ class HandshakeSerializer(serializers.ModelSerializer):
         from .utils import get_provider_and_receiver
         provider, _ = get_provider_and_receiver(obj)
         return f"{provider.first_name} {provider.last_name}".strip()
+
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_counterpart(self, obj):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return None
+
+        from .utils import get_provider_and_receiver
+        provider, receiver = get_provider_and_receiver(obj)
+        current_user = request.user
+        counterpart = receiver if str(provider.id) == str(current_user.id) else provider
+
+        return {
+            'id': str(counterpart.id),
+            'first_name': counterpart.first_name,
+            'last_name': counterpart.last_name,
+            'email': counterpart.email,
+            'avatar_url': counterpart.avatar_url,
+        }
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_is_current_user_provider(self, obj):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return False
+
+        from .utils import get_provider_and_receiver
+        provider, _ = get_provider_and_receiver(obj)
+        return str(provider.id) == str(request.user.id)
 
     @extend_schema_field(serializers.BooleanField())
     def get_user_has_reviewed(self, obj):
@@ -1629,12 +1663,16 @@ class ReportSerializer(serializers.ModelSerializer):
 class TransactionHistorySerializer(serializers.ModelSerializer):
     transaction_type_display = serializers.CharField(source='get_transaction_type_display', read_only=True)
     service_title = serializers.SerializerMethodField()
+    service_type = serializers.SerializerMethodField()
+    is_current_user_provider = serializers.SerializerMethodField()
+    counterpart = serializers.SerializerMethodField()
 
     class Meta:
         model = TransactionHistory
         fields = [
             'id', 'transaction_type', 'transaction_type_display', 'amount',
-            'balance_after', 'description', 'service_title', 'created_at'
+            'balance_after', 'description', 'service_title', 'service_type',
+            'is_current_user_provider', 'counterpart', 'created_at'
         ]
         read_only_fields = ['id', 'created_at']
 
@@ -1643,6 +1681,52 @@ class TransactionHistorySerializer(serializers.ModelSerializer):
         if obj.handshake and obj.handshake.service:
             return obj.handshake.service.title
         return None
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_service_type(self, obj):
+        if obj.handshake and obj.handshake.service:
+            return obj.handshake.service.type
+        return None
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_is_current_user_provider(self, obj):
+        handshake = obj.handshake
+        if not handshake or not handshake.service:
+            return False
+
+        service = handshake.service
+        if service.type == 'Offer':
+            provider = service.user
+        else:
+            provider = handshake.requester
+
+        return str(provider.id) == str(obj.user_id)
+
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_counterpart(self, obj):
+        handshake = obj.handshake
+        if not handshake or not handshake.service:
+            return None
+
+        service = handshake.service
+        if service.type == 'Offer':
+            provider = service.user
+            receiver = handshake.requester
+        else:
+            provider = handshake.requester
+            receiver = service.user
+
+        counterpart = receiver if str(provider.id) == str(obj.user_id) else provider
+        if not counterpart:
+            return None
+
+        return {
+            'id': str(counterpart.id),
+            'first_name': counterpart.first_name,
+            'last_name': counterpart.last_name,
+            'email': counterpart.email,
+            'avatar_url': counterpart.avatar_url,
+        }
 
 
 class AdminAuditLogSerializer(serializers.ModelSerializer):

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -12,11 +12,11 @@ from rest_framework.test import APIRequestFactory
 from api.models import Service, Tag, Handshake, Comment, ReputationRep
 from api.serializers import (
     ServiceSerializer, UserProfileSerializer, PublicUserProfileSerializer,
-    CommentSerializer, HandshakeSerializer
+    CommentSerializer, HandshakeSerializer, TransactionHistorySerializer
 )
 from api.tests.helpers.factories import (
     UserFactory, ServiceFactory, TagFactory, HandshakeFactory, CommentFactory,
-    ReputationRepFactory,
+    ReputationRepFactory, TransactionHistoryFactory,
 )
 
 User = get_user_model()
@@ -281,6 +281,90 @@ class TestHandshakeSerializer:
         request.user = requester
         serializer = HandshakeSerializer(handshake, context={'request': request})
         assert serializer.data['user_has_reviewed'] is True
+
+    def test_offer_handshake_exposes_counterpart_and_provider_role(self):
+        """Offer handshakes should expose requester as counterpart for the provider."""
+        provider = UserFactory(first_name='Elif', last_name='Yılmaz')
+        requester = UserFactory(first_name='Cem', last_name='Demir')
+        service = ServiceFactory(user=provider, type='Offer', title='Mantı Workshop')
+        handshake = HandshakeFactory(service=service, requester=requester, status='accepted')
+        request = APIRequestFactory().get('/')
+        request.user = provider
+
+        serializer = HandshakeSerializer(handshake, context={'request': request})
+        data = serializer.data
+
+        assert data['service_type'] == 'Offer'
+        assert data['provider_name'] == 'Elif Yılmaz'
+        assert data['is_current_user_provider'] is True
+        assert data['counterpart']['id'] == str(requester.id)
+        assert data['counterpart']['email'] == requester.email
+
+    def test_need_handshake_exposes_requester_as_provider(self):
+        """Need handshakes should mark requester as provider and owner as counterpart."""
+        service_owner = UserFactory(first_name='Elif', last_name='Yılmaz')
+        requester = UserFactory(first_name='Can', last_name='Şahin')
+        service = ServiceFactory(user=service_owner, type='Need', title='Cooking Help')
+        handshake = HandshakeFactory(service=service, requester=requester, status='accepted')
+        request = APIRequestFactory().get('/')
+        request.user = service_owner
+
+        serializer = HandshakeSerializer(handshake, context={'request': request})
+        data = serializer.data
+
+        assert data['service_type'] == 'Need'
+        assert data['provider_name'] == 'Can Şahin'
+        assert data['is_current_user_provider'] is False
+        assert data['counterpart']['id'] == str(requester.id)
+        assert data['counterpart']['email'] == requester.email
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestTransactionHistorySerializer:
+    """Test TransactionHistorySerializer"""
+
+    def test_offer_transaction_marks_requester_as_receiver(self):
+        """Offer transaction for requester should expose provider counterpart and false role flag."""
+        provider = UserFactory(first_name='Mehmet', last_name='Özkan')
+        requester = UserFactory(first_name='Elif', last_name='Yılmaz')
+        service = ServiceFactory(user=provider, type='Offer', title='Genealogy Help')
+        handshake = HandshakeFactory(service=service, requester=requester, status='completed')
+        transaction = TransactionHistoryFactory(
+            user=requester,
+            handshake=handshake,
+            transaction_type='provision',
+        )
+
+        serializer = TransactionHistorySerializer(transaction)
+        data = serializer.data
+
+        assert data['service_title'] == 'Genealogy Help'
+        assert data['service_type'] == 'Offer'
+        assert data['is_current_user_provider'] is False
+        assert data['counterpart']['id'] == str(provider.id)
+        assert data['counterpart']['email'] == provider.email
+
+    def test_need_transaction_marks_requester_as_provider(self):
+        """Need transaction for requester should expose provider role and owner counterpart."""
+        service_owner = UserFactory(first_name='Zeynep', last_name='Arslan')
+        requester = UserFactory(first_name='Elif', last_name='Yılmaz')
+        service = ServiceFactory(user=service_owner, type='Need', title='Coffee Lesson')
+        handshake = HandshakeFactory(service=service, requester=requester, status='accepted')
+        transaction = TransactionHistoryFactory(
+            user=requester,
+            handshake=handshake,
+            transaction_type='transfer',
+        )
+
+        serializer = TransactionHistorySerializer(transaction)
+        data = serializer.data
+
+        assert data['service_title'] == 'Coffee Lesson'
+        assert data['service_type'] == 'Need'
+        assert data['is_current_user_provider'] is True
+        assert data['counterpart']['id'] == str(service_owner.id)
+        assert data['counterpart']['email'] == service_owner.email
 
 
 @pytest.mark.django_db

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -78,7 +78,7 @@ from .event_permissions import IsNotEventBanned, IsNotOrganizerBanned
 from .achievement_utils import check_and_assign_badges
 from .search_filters import SearchEngine
 from .performance import track_performance
-from django.db.models import Count, Q, Prefetch, Exists, OuterRef, Case, When, UUIDField
+from django.db.models import Count, Q, Prefetch, Exists, OuterRef, Case, When, UUIDField, Sum
 from .cache_utils import (
     get_cached_tag_list, cache_tag_list, invalidate_tag_list,
     get_cached_user_profile, cache_user_profile, invalidate_user_profile,
@@ -4705,26 +4705,65 @@ class TransactionHistoryViewSet(viewsets.ReadOnlyModelViewSet):
     def list(self, request, *args, **kwargs):
         from .cache_utils import get_cached_transactions, cache_transactions
         user = request.user
-        
-        cached_result = get_cached_transactions(str(user.id))
+
+        direction = self._get_direction_filter()
+        page = request.query_params.get('page', '1')
+        cached_result = get_cached_transactions(str(user.id), page=page, direction=direction)
         if cached_result is not None:
             return Response(cached_result)
-        
+
+        summary = self._build_summary(user)
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
             response = self.get_paginated_response(serializer.data)
-            cache_transactions(str(user.id), response.data, ttl=CACHE_TTL_SHORT)
+            response.data['summary'] = summary
+            cache_transactions(str(user.id), response.data, page=request.query_params.get('page', '1'), direction=direction, ttl=CACHE_TTL_SHORT)
             return response
-        
+
         serializer = self.get_serializer(queryset, many=True)
-        response_data = serializer.data
-        cache_transactions(str(user.id), response_data, ttl=CACHE_TTL_SHORT)
+        response_data = {
+            'count': len(serializer.data),
+            'next': None,
+            'previous': None,
+            'results': serializer.data,
+            'summary': summary,
+        }
+        cache_transactions(str(user.id), response_data, page=request.query_params.get('page', '1'), direction=direction, ttl=CACHE_TTL_SHORT)
         return Response(response_data)
 
     def get_queryset(self):
-        return TransactionHistory.objects.filter(user=self.request.user).order_by('-created_at')
+        queryset = TransactionHistory.objects.filter(user=self.request.user).select_related(
+            'handshake__service__user',
+            'handshake__requester',
+        )
+
+        direction = self._get_direction_filter()
+        if direction == 'credit':
+            queryset = queryset.filter(amount__gt=0)
+        elif direction == 'debit':
+            queryset = queryset.filter(amount__lt=0)
+
+        return queryset.order_by('-created_at')
+
+    def _get_direction_filter(self):
+        direction = self.request.query_params.get('direction', 'all').strip().lower()
+        if direction not in {'all', 'credit', 'debit'}:
+            return 'all'
+        return direction
+
+    def _build_summary(self, user):
+        aggregates = TransactionHistory.objects.filter(user=user).aggregate(
+            total_earned=Sum('amount', filter=Q(amount__gt=0)),
+            total_spent=Sum('amount', filter=Q(amount__lt=0)),
+        )
+
+        return {
+            'current_balance': float(user.timebank_balance),
+            'total_earned': float(aggregates['total_earned'] or Decimal('0')),
+            'total_spent': abs(float(aggregates['total_spent'] or Decimal('0'))),
+        }
 
 
 class WikidataSearchView(APIView):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -204,7 +204,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -544,7 +543,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -581,7 +579,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -589,6 +586,7 @@
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -606,6 +604,7 @@
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -665,7 +664,8 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -684,7 +684,8 @@
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -1355,7 +1356,6 @@
     "node_modules/@internationalized/date": {
       "version": "3.11.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -1946,7 +1946,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2081,14 +2082,14 @@
       "version": "24.11.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
@@ -2100,7 +2101,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2109,7 +2109,6 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2162,7 +2161,6 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3347,7 +3345,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3390,6 +3387,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3478,6 +3476,7 @@
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -3539,7 +3538,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3679,11 +3677,13 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -3698,6 +3698,7 @@
     "node_modules/cosmiconfig/node_modules/yaml": {
       "version": "1.10.2",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3930,7 +3931,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3977,6 +3979,7 @@
     "node_modules/error-ex": {
       "version": "1.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4085,7 +4088,6 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4329,7 +4331,8 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -4571,6 +4574,7 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -4662,11 +4666,13 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -4788,7 +4794,6 @@
       "version": "28.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -4841,7 +4846,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4898,7 +4904,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4945,6 +4952,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4997,7 +5005,6 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.19.0.tgz",
       "integrity": "sha512-SFObIgdxN0b6hZNsRxSUmQWdVW9q9GM2gw4McgFbycyhekew7BZIh8V57pEERDWlI9x/5SxxraTit5Cf0hm9OA==",
       "license": "SEE LICENSE IN LICENSE.txt",
-      "peer": true,
       "workspaces": [
         "src/style-spec",
         "test/build/vite",
@@ -5216,6 +5223,7 @@
     "node_modules/parse-json": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -5258,11 +5266,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5296,7 +5306,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5396,6 +5405,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5409,6 +5419,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5419,7 +5430,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5468,7 +5480,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5476,7 +5487,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5501,7 +5511,6 @@
     "node_modules/react-hook-form": {
       "version": "7.71.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5666,6 +5675,7 @@
     "node_modules/resolve": {
       "version": "1.22.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -5860,6 +5870,7 @@
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5949,7 +5960,8 @@
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supercluster": {
       "version": "8.0.1",
@@ -5974,6 +5986,7 @@
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6100,7 +6113,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6239,7 +6251,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6313,7 +6324,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -6495,7 +6505,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/MainSidebar.tsx
+++ b/frontend/src/components/MainSidebar.tsx
@@ -122,8 +122,27 @@ export function MainSidebar({
 
             {/* Time bank widget */}
             <Box
+              as="button"
+              w="full"
+              display="block"
               borderRadius="14px" p="14px" mb={3} position="relative" overflow="hidden"
-              style={{ background: `linear-gradient(135deg, ${GREEN} 0%, #1a3d35 100%)` }}
+              onClick={() => navigate('/transaction-history')}
+              style={{
+                background: `linear-gradient(135deg, ${GREEN} 0%, #1a3d35 100%)`,
+                border: 'none',
+                padding: '14px',
+                textAlign: 'left',
+                cursor: 'pointer',
+                transition: 'transform 0.12s ease, box-shadow 0.12s ease',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLElement).style.transform = 'translateY(-1px)'
+                ;(e.currentTarget as HTMLElement).style.boxShadow = '0 8px 20px rgba(17,24,39,0.18)'
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLElement).style.transform = 'translateY(0)'
+                ;(e.currentTarget as HTMLElement).style.boxShadow = 'none'
+              }}
             >
               <Box style={{ position: 'absolute', top: '-20px', right: '-20px', width: '80px', height: '80px', borderRadius: '50%', background: 'rgba(255,255,255,0.06)' }} />
               <Flex align="center" gap="5px" mb="5px">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -179,7 +179,7 @@ const Navbar = () => {
       <Flex maxW="1440px" mx="auto" px={{ base: 4, md: 8 }} h="64px" align="center" justify="space-between" position="relative">
 
         {/* Logo */}
-        <Link to="/browse" style={{ textDecoration: 'none', flexShrink: 0 }}>
+        <Link to="/dashboard" style={{ textDecoration: 'none', flexShrink: 0 }}>
           <Flex align="center" gap={3}>
             <Logo size={32} />
             <Text fontWeight="800" fontSize="17px" color={GRAY900} letterSpacing="-0.3px">
@@ -231,12 +231,21 @@ const Navbar = () => {
 
               {/* Balance — desktop (invisible on dashboard, keeps layout stable) */}
               <Flex
+                as="button"
                 align="center" gap="5px" px="12px" py="5px" borderRadius="10px"
                 display={{ base: 'none', sm: 'flex' }}
+                onClick={() => navigate('/transaction-history')}
                 style={{
                   background: GREEN_LT, border: `1px solid #BBF7D0`,
                   fontSize: '13px', fontWeight: 700, color: GREEN,
                   visibility: isDashboard ? 'hidden' : 'visible',
+                  cursor: isDashboard ? 'default' : 'pointer',
+                }}
+                onMouseEnter={(e) => {
+                  if (!isDashboard) (e.currentTarget as HTMLDivElement).style.filter = 'brightness(0.98)'
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLDivElement).style.filter = 'none'
                 }}
               >
                 <span style={{ fontSize: '12px' }}>⏱</span>
@@ -365,7 +374,8 @@ const Navbar = () => {
               </Text>
             </Box>
             {/* Time bank inline */}
-            <Flex align="center" gap="4px" px="10px" py="5px" borderRadius="9px"
+            <Flex as="button" align="center" gap="4px" px="10px" py="5px" borderRadius="9px"
+              onClick={() => { navigate('/transaction-history'); setMobileOpen(false) }}
               style={{ background: GREEN_LT, border: `1px solid #BBF7D0`, fontSize: '13px', fontWeight: 700, color: GREEN, flexShrink: 0 }}
             >
               <span style={{ fontSize: '11px' }}>⏱</span>

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -1,11 +1,389 @@
-import { Box, Text } from '@chakra-ui/react'
-import { GRAY50, GRAY200, GRAY400, WHITE } from '@/theme/tokens'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Avatar, Box, Flex, Grid, Spinner, Text } from '@chakra-ui/react'
+import {
+  FiArrowLeft, FiArrowRight, FiClock, FiDownload, FiRefreshCw,
+  FiRepeat, FiTrendingDown, FiTrendingUp, FiUser, FiZap,
+} from 'react-icons/fi'
+import { transactionAPI, type TransactionDirection } from '@/services/transactionAPI'
+import { handshakeAPI, type Handshake } from '@/services/handshakeAPI'
+import { useAuthStore } from '@/store/useAuthStore'
+import type { Transaction, TransactionSummary } from '@/types'
+import {
+  AMBER, AMBER_LT, BLUE, BLUE_LT, GRAY100, GRAY200, GRAY400,
+  GRAY50, GRAY500, GRAY600, GRAY700, GRAY800, GRAY900, GREEN, GREEN_LT,
+  PURPLE, PURPLE_LT, RED, RED_LT, WHITE,
+} from '@/theme/tokens'
+
+const PAGE_SIZE = 20
+
+const EMPTY_SUMMARY: TransactionSummary = {
+  current_balance: 0,
+  total_earned: 0,
+  total_spent: 0,
+}
+
+const FILTERS: { key: TransactionDirection; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'credit', label: 'Credit' },
+  { key: 'debit', label: 'Debit' },
+]
+
+const ACTIVE_HANDSHAKE_STATUSES = new Set(['accepted', 'checked_in', 'attended'])
+
+interface ExpectedAgreement {
+  id: string
+  service_title: string
+  service_type?: Handshake['service_type']
+  is_current_user_provider: boolean
+  counterpart_name: string
+  counterpart_email: string
+  counterpart_avatar_url?: string | null
+  status: Handshake['status']
+  provisioned_hours: number
+  expected_delta: number
+  note: string
+}
+
+function formatHours(value: number): string {
+  const absolute = Math.abs(value)
+  const formatted = Number.isInteger(absolute) ? absolute.toString() : absolute.toFixed(2).replace(/\.?0+$/, '')
+  return `${formatted}h`
+}
+
+function formatAmount(value: number): string {
+  const sign = value > 0 ? '+' : value < 0 ? '−' : ''
+  return `${sign}${formatHours(value)}`
+}
+
+function formatDate(value: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value))
+  } catch {
+    return value
+  }
+}
+
+function counterpartName(transaction: Transaction): string {
+  const counterpart = transaction.counterpart
+  if (!counterpart) return 'System'
+
+  const fullName = `${counterpart.first_name ?? ''} ${counterpart.last_name ?? ''}`.trim()
+  return fullName || counterpart.email || 'Unknown user'
+}
+
+function handshakeCounterpartName(handshake: Handshake, currentUserName?: string): string {
+  const counterpart = handshake.counterpart
+  const fullName = counterpart
+    ? `${counterpart.first_name ?? ''} ${counterpart.last_name ?? ''}`.trim()
+    : ''
+
+  if (fullName && fullName !== currentUserName) return fullName
+  if (counterpart?.email) return counterpart.email
+  if (handshake.provider_name && handshake.provider_name !== currentUserName) return handshake.provider_name
+  if (handshake.receiver_name && handshake.receiver_name !== currentUserName) return handshake.receiver_name
+  if (handshake.requester_name && handshake.requester_name !== currentUserName) return handshake.requester_name
+  return 'Unknown user'
+}
+
+function activeHandshakeLabel(status: Handshake['status']): string {
+  if (status === 'checked_in') return 'Checked In'
+  if (status === 'attended') return 'Attended'
+  return 'Session Confirmed'
+}
+
+function toExpectedAgreement(handshake: Handshake, currentUserName?: string): ExpectedAgreement | null {
+  const hours = Number(handshake.provisioned_hours ?? 0)
+  if (hours <= 0) return null
+
+  const counterpartName = handshakeCounterpartName(handshake, currentUserName)
+  const counterpartEmail = handshake.counterpart?.email ?? ''
+  const isProvider = handshake.is_current_user_provider === true
+
+  return {
+    id: handshake.id,
+    service_title: handshake.service_title,
+    service_type: handshake.service_type,
+    is_current_user_provider: isProvider,
+    counterpart_name: counterpartName,
+    counterpart_email: counterpartEmail,
+    counterpart_avatar_url: handshake.counterpart?.avatar_url ?? null,
+    status: handshake.status,
+    provisioned_hours: hours,
+    expected_delta: isProvider ? hours : 0,
+    note: isProvider
+      ? `Expected credit after completion`
+      : `Hours already reserved from your balance`,
+  }
+}
+
+function amountTone(value: number) {
+  return value >= 0
+    ? { color: GREEN, bg: GREEN_LT }
+    : { color: RED, bg: RED_LT }
+}
+
+function roleAccent(isCurrentUserProvider: boolean) {
+  return isCurrentUserProvider
+    ? { icon: FiTrendingUp, color: GREEN, bg: GREEN_LT, label: 'Provider' }
+    : { icon: FiTrendingDown, color: AMBER, bg: AMBER_LT, label: 'Receiver' }
+}
+
+function isOwnService(serviceType?: Handshake['service_type'] | null, isCurrentUserProvider?: boolean) {
+  if (serviceType === 'Need') return isCurrentUserProvider === false
+  if (serviceType === 'Offer' || serviceType === 'Event') return isCurrentUserProvider === true
+  return false
+}
+
+function serviceMeta(serviceType?: Handshake['service_type'] | null, isCurrentUserProvider?: boolean) {
+  const parts = [
+    isCurrentUserProvider ? 'You are provider' : 'You are receiver',
+    isOwnService(serviceType, isCurrentUserProvider) ? 'Own service' : 'Other user service',
+    serviceType ?? 'Unknown type',
+  ]
+
+  return parts.join(' · ')
+}
+
+function transactionAccent(transaction: Transaction) {
+  const roleBasedAccent = roleAccent(transaction.is_current_user_provider === true)
+
+  switch (transaction.transaction_type) {
+    case 'transfer':
+      return { ...roleBasedAccent, stateLabel: 'Completed' }
+    case 'refund':
+      return { icon: FiRepeat, color: PURPLE, bg: PURPLE_LT, stateLabel: 'Refunded' }
+    case 'provision':
+      return { ...roleBasedAccent, stateLabel: 'Reserved' }
+    case 'adjustment':
+      return { icon: FiZap, color: GRAY600, bg: GRAY100, stateLabel: 'Adjusted' }
+    default:
+      return transaction.amount >= 0
+        ? { ...roleBasedAccent, stateLabel: 'Credit' }
+        : { ...roleBasedAccent, stateLabel: 'Debit' }
+  }
+}
+
+function SummaryCard({
+  label,
+  value,
+  color,
+  bg,
+}: {
+  label: string
+  value: number
+  color: string
+  bg: string
+}) {
+  return (
+    <Box
+      p={{ base: 4, md: 5 }}
+      borderRadius="18px"
+      border={`1px solid ${GRAY200}`}
+      bg={WHITE}
+      boxShadow="0 10px 32px rgba(17,24,39,0.05)"
+    >
+      <Flex align="center" justify="space-between" mb={3}>
+        <Text fontSize="12px" fontWeight={700} letterSpacing="0.08em" textTransform="uppercase" color={GRAY500}>
+          {label}
+        </Text>
+        <Box w="10px" h="10px" borderRadius="full" bg={color} />
+      </Flex>
+      <Box
+        display="inline-flex"
+        alignItems="center"
+        px="12px"
+        py="6px"
+        borderRadius="999px"
+        fontSize="12px"
+        fontWeight={700}
+        color={color}
+        bg={bg}
+      >
+        {formatHours(value)}
+      </Box>
+    </Box>
+  )
+}
+
+function EmptyLedgerIllustration() {
+  return (
+    <Flex direction="column" align="center" justify="center" py={{ base: 16, md: 24 }} px={6} textAlign="center">
+      <Box position="relative" w="120px" h="120px" mb={6}>
+        <Box position="absolute" inset="0" borderRadius="full" bg={PURPLE_LT} />
+        <Box position="absolute" top="14px" left="14px" right="14px" bottom="14px" borderRadius="full" bg={WHITE} border={`1px solid ${GRAY200}`} />
+        <Flex position="absolute" inset="0" align="center" justify="center">
+          <Box p="14px" borderRadius="18px" bg={GREEN_LT} color={GREEN}>
+            <FiClock size={30} />
+          </Box>
+        </Flex>
+        <Box position="absolute" top="8px" right="4px" px="8px" py="4px" borderRadius="999px" bg={AMBER_LT} color={AMBER} fontSize="11px" fontWeight={700}>
+          +0h
+        </Box>
+        <Box position="absolute" bottom="10px" left="0" px="8px" py="4px" borderRadius="999px" bg={BLUE_LT} color={BLUE} fontSize="11px" fontWeight={700}>
+          Ledger
+        </Box>
+      </Box>
+      <Text fontSize="18px" fontWeight={800} color={GRAY800} mb={2}>
+        No transactions yet
+      </Text>
+      <Text maxW="420px" fontSize="14px" color={GRAY500}>
+        Your TimeBank credits and debits will appear here after you start completing exchanges with other members.
+      </Text>
+    </Flex>
+  )
+}
 
 const TransactionHistoryPage = () => {
+  const navigate = useNavigate()
+  const user = useAuthStore((state) => state.user)
+  const requestIdRef = useRef(0)
+  const agreementRequestIdRef = useRef(0)
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [activeAgreements, setActiveAgreements] = useState<ExpectedAgreement[]>([])
+  const [summary, setSummary] = useState<TransactionSummary>(EMPTY_SUMMARY)
+  const [direction, setDirection] = useState<TransactionDirection>('all')
+  const [page, setPage] = useState(1)
+  const [count, setCount] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isExporting, setIsExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(count / PAGE_SIZE)), [count])
+  const exportDisabled = isLoading || isExporting || transactions.length === 0
+  const previousDisabled = page === 1
+  const nextDisabled = page >= totalPages
+  const expectedBalance = useMemo(
+    () => summary.current_balance + activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0),
+    [summary.current_balance, activeAgreements],
+  )
+
+  const fetchTransactions = useCallback(async (signal?: AbortSignal) => {
+    const requestId = ++requestIdRef.current
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const res = await transactionAPI.list({ page, direction }, signal)
+      if (requestId !== requestIdRef.current) return
+      setTransactions(res.results)
+      setSummary(res.summary ?? EMPTY_SUMMARY)
+      setCount(res.count)
+    } catch (error) {
+      const isAbort =
+        signal?.aborted ||
+        (error instanceof Error && (
+          error.name === 'AbortError' ||
+          error.name === 'CanceledError' ||
+          error.message === 'canceled'
+        )) ||
+        (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ERR_CANCELED')
+
+      if (isAbort || requestId !== requestIdRef.current) return
+      setError('Could not load your transaction history. Please try again.')
+    } finally {
+      if (requestId !== requestIdRef.current) return
+      setIsLoading(false)
+    }
+  }, [direction, page])
+
+  const fetchActiveAgreements = useCallback(async (signal?: AbortSignal) => {
+    const requestId = ++agreementRequestIdRef.current
+
+    try {
+      const handshakes = await handshakeAPI.list(signal)
+      if (requestId !== agreementRequestIdRef.current) return
+
+      const nextAgreements = handshakes
+        .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
+        .map((handshake) => toExpectedAgreement(
+          handshake,
+          `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim(),
+        ))
+        .filter((item): item is ExpectedAgreement => item !== null)
+
+      setActiveAgreements(nextAgreements)
+    } catch (error) {
+      const isAbort =
+        signal?.aborted ||
+        (error instanceof Error && (
+          error.name === 'AbortError' ||
+          error.name === 'CanceledError' ||
+          error.message === 'canceled'
+        )) ||
+        (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'ERR_CANCELED')
+
+      if (isAbort || requestId !== agreementRequestIdRef.current) return
+      setActiveAgreements([])
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchTransactions(controller.signal)
+    return () => controller.abort()
+  }, [fetchTransactions])
+
+  useEffect(() => {
+    if (!user) return
+    const controller = new AbortController()
+    fetchActiveAgreements(controller.signal)
+    return () => controller.abort()
+  }, [fetchActiveAgreements, user])
+
+  const handleExportCsv = useCallback(async () => {
+    setIsExporting(true)
+    try {
+      const allRows: Transaction[] = []
+      let exportPage = 1
+
+      while (true) {
+        const res = await transactionAPI.list({ page: exportPage, direction })
+        allRows.push(...res.results)
+        if (!res.next) break
+        exportPage += 1
+      }
+
+      const headers = ['Date', 'Counterpart', 'Service', 'Type', 'Amount', 'Running Balance', 'Description']
+      const rows = allRows.map((transaction) => ([
+        formatDate(transaction.created_at),
+        counterpartName(transaction),
+        transaction.service_title ?? '',
+        transaction.transaction_type_display,
+        formatAmount(transaction.amount),
+        formatHours(transaction.balance_after),
+        transaction.description.replace(/\s+/g, ' ').trim(),
+      ]))
+
+      const csv = [headers, ...rows]
+        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+        .join('\n')
+
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `transaction-history-${direction}-${new Date().toISOString().slice(0, 10)}.csv`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } finally {
+      setIsExporting(false)
+    }
+  }, [direction])
+
   return (
-    <Box bg={GRAY50} h="calc(100vh - 64px)" overflowY="auto"
-      py={{ base: 0, md: '8px' }} px={{ base: 0, md: '12px' }}>
-      <Box maxW="1440px" mx="auto"
+    <Box bg={GRAY50} h="calc(100vh - 64px)" overflowY="auto" py={{ base: 0, md: '8px' }} px={{ base: 0, md: '12px' }}>
+      <Box
+        maxW="1440px"
+        mx="auto"
         bg={WHITE}
         borderRadius={{ base: 0, md: '20px' }}
         border={{ base: 'none', md: `1px solid ${GRAY200}` }}
@@ -14,8 +392,412 @@ const TransactionHistoryPage = () => {
         overflow="hidden"
         p={{ base: 5, md: 8 }}
       >
-        <Text fontSize="22px" fontWeight={800} color="#1F2937" mb={2}>Transaction History</Text>
-        <Text color={GRAY400}>This page will be implemented during module migration.</Text>
+        <Flex direction={{ base: 'column', md: 'row' }} align={{ base: 'flex-start', md: 'center' }} justify="space-between" gap={4} mb={6}>
+          <Box>
+            <Box
+              as="button"
+              onClick={() => navigate('/profile')}
+              mb={3}
+              px="10px"
+              py="6px"
+              borderRadius="999px"
+              fontSize="12px"
+              fontWeight={600}
+              color={GRAY700}
+              bg={GRAY100}
+              style={{ cursor: 'pointer' }}
+            >
+              <Flex align="center" gap={2}>
+                <FiArrowLeft size={14} />
+                Back to Profile
+              </Flex>
+            </Box>
+            <Text fontSize={{ base: '24px', md: '28px' }} fontWeight={800} color={GRAY900} mb={2}>
+              Transaction History
+            </Text>
+            <Text fontSize="14px" color={GRAY500}>
+              Complete ledger of your TimeBank credits and debits.
+            </Text>
+          </Box>
+
+          <Box
+            as="button"
+            onClick={() => {
+              if (exportDisabled) return
+              void handleExportCsv()
+            }}
+            aria-disabled={exportDisabled}
+            px="12px"
+            py="8px"
+            borderRadius="9px"
+            fontSize="12px"
+            fontWeight={600}
+            color={PURPLE}
+            bg={PURPLE_LT}
+            border={`1px solid ${PURPLE}22`}
+            style={{ cursor: exportDisabled ? 'not-allowed' : 'pointer', opacity: exportDisabled ? 0.6 : 1 }}
+          >
+            <Flex align="center" gap={2}>
+              {isExporting ? <Spinner size="sm" color={PURPLE} /> : <FiDownload size={15} />}
+              {isExporting ? 'Exporting…' : 'Export CSV'}
+            </Flex>
+          </Box>
+        </Flex>
+
+        <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)', xl: 'repeat(4, 1fr)' }} gap={4} mb={6}>
+          <SummaryCard label="Current Balance" value={summary.current_balance} color={PURPLE} bg={PURPLE_LT} />
+          <SummaryCard label="Expected Balance" value={expectedBalance} color={BLUE} bg={BLUE_LT} />
+          <SummaryCard label="Total Earned" value={summary.total_earned} color={GREEN} bg={GREEN_LT} />
+          <SummaryCard label="Total Spent" value={summary.total_spent} color={RED} bg={RED_LT} />
+        </Grid>
+
+        {activeAgreements.length > 0 && (
+          <Box borderRadius="20px" border={`1px solid ${BLUE}20`} bg={WHITE} mb={5} overflow="hidden">
+            <Flex
+              px={{ base: 4, md: 5 }}
+              py={{ base: 4, md: 4 }}
+              justify="space-between"
+              align={{ base: 'flex-start', md: 'center' }}
+              direction={{ base: 'column', md: 'row' }}
+              gap={3}
+              bg={BLUE_LT}
+              borderBottom={`1px solid ${GRAY200}`}
+            >
+              <Box>
+                <Text fontSize="15px" fontWeight={800} color={GRAY900} mb={1}>
+                  Active Agreements
+                </Text>
+                <Text fontSize="12px" color={GRAY600}>
+                  Ongoing accepted exchanges. Reserved hours are already reflected in your current balance; only pending incoming credits increase the expected balance.
+                </Text>
+              </Box>
+              <Box px="10px" py="5px" borderRadius="999px" bg={WHITE} color={BLUE} fontSize="12px" fontWeight={700}>
+                {activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0) > 0
+                  ? `Expected +${formatHours(activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0))}`
+                  : 'No pending credit'}
+              </Box>
+            </Flex>
+
+            <Box px={{ base: 4, md: 5 }} py={{ base: 2, md: 3 }}>
+              {activeAgreements.map((agreement, index) => (
+                <Flex
+                  key={agreement.id}
+                  align={{ base: 'flex-start', md: 'center' }}
+                  justify="space-between"
+                  direction={{ base: 'column', md: 'row' }}
+                  gap={3}
+                  py={3}
+                  borderTop={index === 0 ? 'none' : `1px solid ${GRAY100}`}
+                >
+                  {(() => {
+                    const accent = roleAccent(agreement.is_current_user_provider)
+                    const Icon = accent.icon
+
+                    return (
+                      <Flex align="center" gap={3} minW={0}>
+                        <Box p="9px" borderRadius="12px" bg={accent.bg} color={accent.color}>
+                          <Icon size={16} />
+                        </Box>
+                        <Flex align="center" gap={2} minW={0}>
+                          {agreement.counterpart_avatar_url ? (
+                            <Avatar.Root size="xs">
+                              <Avatar.Image src={agreement.counterpart_avatar_url} alt={agreement.counterpart_name} />
+                              <Avatar.Fallback name={agreement.counterpart_name} />
+                            </Avatar.Root>
+                          ) : (
+                            <Box p="5px" borderRadius="full" bg={GRAY100} color={GRAY500}><FiUser size={12} /></Box>
+                          )}
+                          <Box minW={0}>
+                            <Text fontSize="13px" fontWeight={700} color={GRAY800} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                              {agreement.service_title}
+                            </Text>
+                            <Text fontSize="11px" color={GRAY500}>
+                              With {agreement.counterpart_name} · {serviceMeta(agreement.service_type, agreement.is_current_user_provider)} · {activeHandshakeLabel(agreement.status)}
+                            </Text>
+                          </Box>
+                        </Flex>
+                      </Flex>
+                    )
+                  })()}
+
+                  <Flex
+                    align={{ base: 'flex-start', md: 'center' }}
+                    gap={{ base: 2, md: 4 }}
+                    direction={{ base: 'column', md: 'row' }}
+                    flexShrink={0}
+                  >
+                    <Box textAlign={{ base: 'left', md: 'right' }}>
+                      <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Expected</Text>
+                      <Text fontSize="13px" fontWeight={800} color={agreement.expected_delta > 0 ? GREEN : GRAY700}>
+                        {agreement.expected_delta > 0 ? formatAmount(agreement.expected_delta) : 'No additional change'}
+                      </Text>
+                    </Box>
+                  </Flex>
+                </Flex>
+              ))}
+            </Box>
+          </Box>
+        )}
+
+        <Flex
+          direction={{ base: 'column', lg: 'row' }}
+          align={{ base: 'stretch', lg: 'center' }}
+          justify="space-between"
+          gap={4}
+          mb={4}
+        >
+          <Flex gap={2} flexWrap="wrap">
+            {FILTERS.map((filter) => {
+              const active = filter.key === direction
+              return (
+                <Box
+                  key={filter.key}
+                  as="button"
+                  onClick={() => {
+                    setDirection(filter.key)
+                    setPage(1)
+                  }}
+                  px="12px"
+                  py="6px"
+                  borderRadius="999px"
+                  fontSize="12px"
+                  fontWeight={500}
+                  border={`1px solid ${active ? GREEN : GRAY200}`}
+                  bg={active ? GREEN_LT : WHITE}
+                  color={active ? GREEN : GRAY600}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {filter.label}
+                </Box>
+              )
+            })}
+          </Flex>
+
+          <Text fontSize="13px" color={GRAY500}>
+            {count === 0 ? '0 entries' : `${count} ${count === 1 ? 'entry' : 'entries'}`}
+          </Text>
+        </Flex>
+
+        {isLoading ? (
+          <Flex direction="column" align="center" justify="center" py={{ base: 16, md: 24 }} gap={3}>
+            <Spinner color={GREEN} size="lg" />
+            <Text fontSize="14px" color={GRAY500}>Loading transaction history…</Text>
+          </Flex>
+        ) : error ? (
+          <Box borderRadius="20px" border={`1px solid ${RED}22`} bg={RED_LT} p={{ base: 5, md: 6 }}>
+            <Text fontSize="16px" fontWeight={700} color={RED} mb={2}>Could not load transactions</Text>
+            <Text fontSize="14px" color={GRAY700} mb={4}>{error}</Text>
+            <Box
+              as="button"
+              onClick={() => fetchTransactions()}
+              px="12px"
+              py="7px"
+              borderRadius="8px"
+              fontSize="12px"
+              fontWeight={600}
+              color={RED}
+              bg={WHITE}
+              border={`1px solid ${RED}33`}
+              style={{ cursor: 'pointer' }}
+            >
+              <Flex align="center" gap={2}>
+                <FiRefreshCw size={14} />
+                Retry
+              </Flex>
+            </Box>
+          </Box>
+        ) : transactions.length === 0 ? (
+          <Box borderRadius="24px" border={`1px solid ${GRAY200}`} bg={WHITE}>
+            <EmptyLedgerIllustration />
+          </Box>
+        ) : (
+          <Box borderRadius="24px" border={`1px solid ${GRAY200}`} bg={WHITE} overflow="hidden">
+            <Box display={{ base: 'none', md: 'block' }} px={6} py={4} bg={GRAY50} borderBottom={`1px solid ${GRAY200}`}>
+              <Grid templateColumns="180px 220px minmax(220px, 1fr) 140px 140px" gap={4}>
+                {['Date', 'Counterpart', 'Service', 'Amount', 'Running Balance'].map((label) => (
+                  <Text key={label} fontSize="11px" fontWeight={800} color={GRAY500} textTransform="uppercase" letterSpacing="0.08em">
+                    {label}
+                  </Text>
+                ))}
+              </Grid>
+            </Box>
+
+            <Box>
+              {transactions.map((transaction, index) => {
+                const tone = amountTone(transaction.amount)
+                const accent = transactionAccent(transaction)
+                const Icon = accent.icon
+                const name = counterpartName(transaction)
+
+                return (
+                  <Box
+                    key={transaction.id}
+                    px={{ base: 4, md: 6 }}
+                    py={{ base: 4, md: 5 }}
+                    borderTop={index === 0 ? 'none' : `1px solid ${GRAY100}`}
+                  >
+                    <Box display={{ base: 'block', md: 'none' }}>
+                      <Flex justify="space-between" align="flex-start" gap={3} mb={3}>
+                        <Flex align="center" gap={3}>
+                          <Box p="9px" borderRadius="12px" bg={accent.bg} color={accent.color}>
+                            <Icon size={16} />
+                          </Box>
+                          <Box>
+                            <Text fontSize="14px" fontWeight={700} color={GRAY800}>{transaction.service_title ?? transaction.transaction_type_display}</Text>
+                            <Text fontSize="12px" color={GRAY500}>
+                              {formatDate(transaction.created_at)} · {accent.stateLabel}
+                            </Text>
+                          </Box>
+                        </Flex>
+                        <Box px="10px" py="6px" borderRadius="999px" bg={tone.bg} color={tone.color} fontSize="12px" fontWeight={800}>
+                          {formatAmount(transaction.amount)}
+                        </Box>
+                      </Flex>
+
+                      <Grid templateColumns="repeat(2, minmax(0, 1fr))" gap={3}>
+                        <Box>
+                          <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Counterpart</Text>
+                          <Flex align="center" gap={2}>
+                            {transaction.counterpart ? (
+                              <Avatar.Root size="xs">
+                                <Avatar.Image src={transaction.counterpart.avatar_url ?? undefined} alt={name} />
+                                <Avatar.Fallback name={name} />
+                              </Avatar.Root>
+                            ) : (
+                              <Box p="5px" borderRadius="full" bg={GRAY100} color={GRAY500}><FiUser size={12} /></Box>
+                            )}
+                            <Text fontSize="13px" color={GRAY700}>{name}</Text>
+                          </Flex>
+                        </Box>
+                        <Box>
+                          <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Running Balance</Text>
+                          <Text fontSize="13px" fontWeight={700} color={GRAY800}>{formatHours(transaction.balance_after)}</Text>
+                        </Box>
+                      </Grid>
+
+                      <Text fontSize="12px" color={GRAY500} mt={3}>{transaction.description}</Text>
+                      <Text fontSize="11px" color={GRAY500} mt={1}>
+                        {serviceMeta(transaction.service_type, transaction.is_current_user_provider)}
+                      </Text>
+                    </Box>
+
+                    <Grid display={{ base: 'none', md: 'grid' }} templateColumns="180px 220px minmax(220px, 1fr) 140px 140px" gap={4} alignItems="center">
+                      <Box>
+                        <Text fontSize="13px" fontWeight={600} color={GRAY800}>{formatDate(transaction.created_at)}</Text>
+                        <Text fontSize="11px" color={GRAY500} mt={1}>{accent.stateLabel}</Text>
+                      </Box>
+
+                      <Flex align="center" gap={3}>
+                        <Box p="9px" borderRadius="12px" bg={accent.bg} color={accent.color}>
+                          <Icon size={16} />
+                        </Box>
+                        <Flex align="center" gap={2} minW={0}>
+                          {transaction.counterpart ? (
+                            <Avatar.Root size="xs">
+                              <Avatar.Image src={transaction.counterpart.avatar_url ?? undefined} alt={name} />
+                              <Avatar.Fallback name={name} />
+                            </Avatar.Root>
+                          ) : (
+                            <Box p="5px" borderRadius="full" bg={GRAY100} color={GRAY500}><FiUser size={12} /></Box>
+                          )}
+                          <Box minW={0}>
+                            <Text
+                              fontSize="13px"
+                              fontWeight={700}
+                              color={GRAY800}
+                              whiteSpace="nowrap"
+                              overflow="hidden"
+                              textOverflow="ellipsis"
+                            >
+                              {name}
+                            </Text>
+                            <Text fontSize="11px" color={GRAY500}>
+                              {transaction.counterpart?.email ?? 'System entry'}
+                            </Text>
+                          </Box>
+                        </Flex>
+                      </Flex>
+
+                      <Box minW={0}>
+                        <Text fontSize="13px" fontWeight={700} color={GRAY800} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                          {transaction.service_title ?? 'Manual adjustment'}
+                        </Text>
+                        <Text fontSize="11px" color={GRAY500} mt={1} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                          {serviceMeta(transaction.service_type, transaction.is_current_user_provider)}
+                        </Text>
+                        <Text fontSize="11px" color={GRAY500} mt={1} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                          {transaction.description}
+                        </Text>
+                      </Box>
+
+                      <Text fontSize="14px" fontWeight={800} color={tone.color}>
+                        {formatAmount(transaction.amount)}
+                      </Text>
+
+                      <Text fontSize="14px" fontWeight={700} color={GRAY800}>
+                        {formatHours(transaction.balance_after)}
+                      </Text>
+                    </Grid>
+                  </Box>
+                )
+              })}
+            </Box>
+          </Box>
+        )}
+
+        {!isLoading && !error && transactions.length > 0 && (
+          <Flex direction={{ base: 'column', sm: 'row' }} align={{ base: 'stretch', sm: 'center' }} justify="space-between" gap={3} mt={5}>
+            <Text fontSize="13px" color={GRAY500}>
+              Page {page} of {totalPages}
+            </Text>
+            <Flex gap={2}>
+              <Box
+                as="button"
+                onClick={() => {
+                  if (previousDisabled) return
+                  setPage((prev) => Math.max(1, prev - 1))
+                }}
+                aria-disabled={previousDisabled}
+                px="12px"
+                py="7px"
+                borderRadius="8px"
+                border={`1px solid ${GRAY200}`}
+                bg={WHITE}
+                color={GRAY700}
+                fontSize="12px"
+                fontWeight={500}
+                style={{ cursor: previousDisabled ? 'not-allowed' : 'pointer', opacity: previousDisabled ? 0.55 : 1 }}
+              >
+                <Flex align="center" gap={2}>
+                  <FiArrowLeft size={14} />
+                  Previous
+                </Flex>
+              </Box>
+              <Box
+                as="button"
+                onClick={() => {
+                  if (nextDisabled) return
+                  setPage((prev) => Math.min(totalPages, prev + 1))
+                }}
+                aria-disabled={nextDisabled}
+                px="12px"
+                py="7px"
+                borderRadius="8px"
+                border={`1px solid ${GRAY200}`}
+                bg={GREEN_LT}
+                color={GREEN}
+                fontSize="12px"
+                fontWeight={500}
+                style={{ cursor: nextDisabled ? 'not-allowed' : 'pointer', opacity: nextDisabled ? 0.55 : 1 }}
+              >
+                <Flex align="center" gap={2}>
+                  Next
+                  <FiArrowRight size={14} />
+                </Flex>
+              </Box>
+            </Flex>
+          </Flex>
+        )}
       </Box>
     </Box>
   )

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -87,7 +87,6 @@ function handshakeCounterpartName(handshake: Handshake, currentUserName?: string
   if (fullName && fullName !== currentUserName) return fullName
   if (counterpart?.email) return counterpart.email
   if (handshake.provider_name && handshake.provider_name !== currentUserName) return handshake.provider_name
-  if (handshake.receiver_name && handshake.receiver_name !== currentUserName) return handshake.receiver_name
   if (handshake.requester_name && handshake.requester_name !== currentUserName) return handshake.requester_name
   return 'Unknown user'
 }
@@ -259,6 +258,10 @@ const TransactionHistoryPage = () => {
   const exportDisabled = isLoading || isExporting || transactions.length === 0
   const previousDisabled = page === 1
   const nextDisabled = page >= totalPages
+  const currentUserName = useMemo(
+    () => `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim(),
+    [user?.first_name, user?.last_name],
+  )
   const expectedBalance = useMemo(
     () => summary.current_balance + activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0),
     [summary.current_balance, activeAgreements],
@@ -288,8 +291,9 @@ const TransactionHistoryPage = () => {
       if (isAbort || requestId !== requestIdRef.current) return
       setError('Could not load your transaction history. Please try again.')
     } finally {
-      if (requestId !== requestIdRef.current) return
-      setIsLoading(false)
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false)
+      }
     }
   }, [direction, page])
 
@@ -302,10 +306,7 @@ const TransactionHistoryPage = () => {
 
       const nextAgreements = handshakes
         .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
-        .map((handshake) => toExpectedAgreement(
-          handshake,
-          `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim(),
-        ))
+        .map((handshake) => toExpectedAgreement(handshake, currentUserName))
         .filter((item): item is ExpectedAgreement => item !== null)
 
       setActiveAgreements(nextAgreements)
@@ -322,7 +323,7 @@ const TransactionHistoryPage = () => {
       if (isAbort || requestId !== agreementRequestIdRef.current) return
       setActiveAgreements([])
     }
-  }, [user?.id])
+  }, [currentUserName])
 
   useEffect(() => {
     const controller = new AbortController()

--- a/frontend/src/services/handshakeAPI.ts
+++ b/frontend/src/services/handshakeAPI.ts
@@ -4,9 +4,18 @@ export interface Handshake {
   id: string
   service: string | { id: string }
   service_title: string
+  service_type?: 'Offer' | 'Need' | 'Event'
   requester: string
   requester_name: string
   provider_name: string
+  counterpart?: {
+    id: string
+    first_name: string
+    last_name: string
+    email: string
+    avatar_url?: string | null
+  } | null
+  is_current_user_provider?: boolean
   status: 'pending' | 'accepted' | 'denied' | 'cancelled' | 'completed' | 'reported' | 'paused' | 'checked_in' | 'attended' | 'no_show'
   provisioned_hours: number
   provider_confirmed_complete: boolean

--- a/frontend/src/services/transactionAPI.ts
+++ b/frontend/src/services/transactionAPI.ts
@@ -1,0 +1,56 @@
+import apiClient from './api'
+import type { PaginatedTransactionResponse, Transaction, TransactionSummary } from '@/types'
+
+export type TransactionDirection = 'all' | 'credit' | 'debit'
+
+const EMPTY_SUMMARY: TransactionSummary = {
+  current_balance: 0,
+  total_earned: 0,
+  total_spent: 0,
+}
+
+function normalizeTransaction(transaction: Transaction): Transaction {
+  return {
+    ...transaction,
+    amount: Number(transaction.amount ?? 0),
+    balance_after: Number(transaction.balance_after ?? 0),
+  }
+}
+
+export const transactionAPI = {
+  list: async (
+    params: { page?: number; direction?: TransactionDirection } = {},
+    signal?: AbortSignal,
+  ): Promise<PaginatedTransactionResponse> => {
+    const res = await apiClient.get<PaginatedTransactionResponse | Transaction[]>(
+      '/transactions/',
+      {
+        params: {
+          page: params.page ?? 1,
+          direction: params.direction ?? 'all',
+        },
+        signal,
+      },
+    )
+
+    if (Array.isArray(res.data)) {
+      return {
+        count: res.data.length,
+        next: null,
+        previous: null,
+        results: res.data.map(normalizeTransaction),
+        summary: EMPTY_SUMMARY,
+      }
+    }
+
+    return {
+      ...res.data,
+      summary: {
+        current_balance: Number(res.data.summary?.current_balance ?? 0),
+        total_earned: Number(res.data.summary?.total_earned ?? 0),
+        total_spent: Number(res.data.summary?.total_spent ?? 0),
+      },
+      results: res.data.results.map(normalizeTransaction),
+    }
+  },
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -248,12 +248,21 @@ export interface Notification {
 
 export interface Transaction {
   id: string
-  user: string
-  counterpart?: User
-  transaction_type: 'credit' | 'debit'
+  transaction_type: 'provision' | 'transfer' | 'refund' | 'adjustment'
+  transaction_type_display: string
+  service_type?: 'Offer' | 'Need' | 'Event' | null
+  is_current_user_provider?: boolean
+  counterpart: {
+    id: string
+    first_name: string
+    last_name: string
+    email: string
+    avatar_url?: string | null
+  } | null
   amount: number
+  balance_after: number
   description: string
-  handshake?: string
+  service_title?: string | null
   created_at: string
 }
 
@@ -498,6 +507,16 @@ export interface PaginatedResponse<T> {
   count: number
   next: string | null
   previous: string | null
+}
+
+export interface TransactionSummary {
+  current_balance: number
+  total_earned: number
+  total_spent: number
+}
+
+export interface PaginatedTransactionResponse extends PaginatedResponse<Transaction> {
+  summary: TransactionSummary
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a full `/transaction-history` experience with paginated ledger rows, summary cards, active agreement insights, CSV export, and stricter request handling to avoid first-load race issues.
- Extend backend transaction and handshake responses with the metadata the UI needs, including filtered/paginated transaction caching, summary totals, counterpart resolution, and role-aware serializer fields.
- Improve navigation into transaction history from shared UI entry points like the navbar and dashboard sidebar, and add serializer unit tests for the new backend fields.

## Test plan
- [x] Run backend serializer tests with `./.venv/bin/python -m pytest api/tests/unit/test_serializers.py -q --no-cov`
- [x] Verify `GET /api/transactions/` returns paginated results plus `summary`
- [x] Verify `GET /api/transactions/?direction=credit` and `?direction=debit` filter correctly
- [x] Verify `GET /api/handshakes/` returns `counterpart`, `service_type`, and `is_current_user_provider`
- [x] Open `/transaction-history` and confirm:
- [x] Summary cards render current balance, expected balance, total earned, and total spent
- [x] Active agreements render the correct counterpart and expected delta
- [x] Transaction rows show consistent role-based iconography and metadata
- [x] CSV export downloads successfully
- [x] Clicking the navbar balance pill navigates to `/transaction-history`
- [x] Clicking the dashboard/sidebar Time Bank card navigates to `/transaction-history`