### PR TITLE
fix(#115): reset participant state on recurring service new cycles

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2216,7 +2216,7 @@ class HandshakeViewSet(viewsets.ModelViewSet):
             Q(requester=user) | Q(service__user=user)
         ).select_related('service', 'requester', 'service__user').prefetch_related(
             Prefetch('reps', queryset=ReputationRep.objects.filter(giver=user), to_attr='user_reps')
-        )
+        ).order_by('-created_at')
 
     @action(detail=False, methods=['post'], url_path=r'services/(?P<service_id>[^/.]+)/interest', permission_classes=[permissions.IsAuthenticated])
     @track_performance

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -532,7 +532,15 @@ export default function ServiceDetailPage() {
     if (typeof val === 'object' && 'id' in (val as Record<string, unknown>)) return (val as { id: string }).id
   }
 
-  const myHandshake = handshakes.find((h) => exId(h.service) === service?.id && exId(h.requester) === user?.id)
+  // For recurrent services, prefer an active handshake over a historical completed one
+  // so the UI reflects the user's *current* participation, not a past cycle.
+  const myHandshake = (() => {
+    const mine = handshakes.filter((h) => exId(h.service) === service?.id && exId(h.requester) === user?.id)
+    if (isRecurr) {
+      return mine.find((h) => ['pending', 'accepted'].includes(h.status)) ?? mine[0]
+    }
+    return mine[0]
+  })()
   const hasInterest = !!myHandshake && ['pending', 'accepted'].includes(myHandshake.status)
   const incoming    = handshakes.filter((h) => exId(h.service) === service?.id && exId(h.requester) !== user?.id)
   const reportedParticipantIds = new Set(
@@ -579,8 +587,12 @@ export default function ServiceDetailPage() {
       && (isOwn ? exId(h.requester) !== currentUserId : exId(h.requester) === currentUserId)
     )
     : []
-  // For "Leave Evaluation" we only care about the first completed handshake where user has NOT yet reviewed
-  const evaluationHandshake = completedHandshakes.find((h) => !h.user_has_reviewed) ?? completedHandshakes[0]
+  // For "Leave Evaluation" we only care about the first completed handshake where user has NOT yet reviewed.
+  // For recurrent services, do NOT fall back to an already-reviewed handshake — that would
+  // permanently show "You already reviewed" and block the user from participating again.
+  const evaluationHandshake = isRecurr
+    ? completedHandshakes.find((h) => !h.user_has_reviewed)
+    : (completedHandshakes.find((h) => !h.user_has_reviewed) ?? completedHandshakes[0])
   const showLeaveEvaluationCTA = !!evaluationHandshake && !evaluationHandshake.user_has_reviewed
   const evaluationCounterpartName = evaluationHandshake
     ? (isOwn ? evaluationHandshake.requester_name : evaluationHandshake.provider_name)


### PR DESCRIPTION
- Backend: order handshakes by -created_at so frontend .find() returns newest first
- Frontend: for recurrent services, prefer active (pending/accepted) handshake over historical completed one when deriving myHandshake
- Frontend: for recurrent services, don't fall back to already-reviewed handshake for evaluationHandshake — clears the permanent 'You already reviewed' badge so users can participate again

Closes #115 .