### PR TITLE
feat: add admin pin event to feed (#120)

### DIFF
--- a/backend/api/migrations/0043_service_is_pinned.py
+++ b/backend/api/migrations/0043_service_is_pinned.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0042_notification_type_choices'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='service',
+            name='is_pinned',
+            field=models.BooleanField(default=False, help_text='Admin can pin events to the top of the feed'),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -228,6 +228,7 @@ class Service(models.Model):
     tags = models.ManyToManyField(Tag, blank=True)
     hot_score = models.FloatField(default=0.0, db_index=True, help_text='Ranking score for hot/trending services')
     is_visible = models.BooleanField(default=True, help_text='Admin can hide inappropriate services')
+    is_pinned = models.BooleanField(default=False, help_text='Admin can pin events to the top of the feed')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -359,9 +359,9 @@ class ServiceSerializer(serializers.ModelSerializer):
             'circle_lat', 'circle_lng',
             'status', 'max_participants', 'schedule_type',
             'schedule_details', 'scheduled_time', 'created_at', 'tags', 'tag_ids', 'tag_names', 'wikidata_labels_json', 'comment_count', 'hot_score',
-            'is_visible', 'media', 'participant_count', 'event_evaluation_summary',
+            'is_visible', 'is_pinned', 'media', 'participant_count', 'event_evaluation_summary',
         ]
-        read_only_fields = ['user', 'hot_score', 'is_visible']
+        read_only_fields = ['user', 'hot_score', 'is_visible', 'is_pinned']
 
     @extend_schema_field(TagSerializer(many=True))
     def get_tags(self, obj):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1541,13 +1541,13 @@ class ServiceViewSet(viewsets.ModelViewSet):
         
         # If location-based search, distance ordering takes priority
         if is_valid_coordinate(lat_param) and is_valid_coordinate(lng_param):
-            pass  # Already ordered by distance from search_engine
+            queryset = queryset.order_by('-is_pinned', *queryset.query.order_by)
         elif sort_param == 'hot':
             # Sort by hot score (descending - highest score first)
-            queryset = queryset.order_by('-hot_score', '-created_at')
+            queryset = queryset.order_by('-is_pinned', '-hot_score', '-created_at')
         else:
             # Default: sort by latest (created_at descending)
-            queryset = queryset.order_by('-created_at')
+            queryset = queryset.order_by('-is_pinned', '-created_at')
         
         return queryset
 
@@ -1731,6 +1731,33 @@ class ServiceViewSet(viewsets.ModelViewSet):
             'id': str(service.id),
             'is_visible': service.is_visible,
             'message': f'Service has been {action_text}'
+        })
+
+    @action(detail=True, methods=['post'], url_path='pin-event')
+    def pin_event(self, request, pk=None):
+        """Toggle Pin/Unpin an Event (Admin Only).
+
+        Pinned events appear at the top of the discovery feed.
+
+        **Endpoint:** POST /api/services/{id}/pin-event/
+        """
+        if request.user.role != 'admin':
+            raise PermissionDenied('Admin access required')
+
+        service = self.get_object()
+        if service.type != 'Event':
+            return Response({'error': 'Only events can be pinned'}, status=status.HTTP_400_BAD_REQUEST)
+
+        service.is_pinned = not service.is_pinned
+        service.save(update_fields=['is_pinned'])
+
+        action_text = 'pinned' if service.is_pinned else 'unpinned'
+        invalidate_service_lists()
+
+        return Response({
+            'id': str(service.id),
+            'is_pinned': service.is_pinned,
+            'message': f'Event has been {action_text}'
         })
 
     # ------------------------------------------------------------------

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -262,6 +262,11 @@ function ServiceCard({
           </Flex>
           {/* Badges — never shrink or wrap */}
           <Flex gap="3px" align="center" flexShrink={0} flexWrap="nowrap">
+            {service.is_pinned && (
+              <Flex align="center" gap="3px" bg={GREEN_LT} color={GREEN} borderRadius="6px" px="6px" py="2px" fontSize="10px" fontWeight={700} flexShrink={0}>
+                <FiMapPin size={9} /> Featured
+              </Flex>
+            )}
             <Pill
               label={isOffer ? 'Offer' : service.type === 'Event' ? 'Event' : 'Want'}
               bg={isOffer ? GREEN_LT : service.type === 'Event' ? AMBER_LT : BLUE_LT}
@@ -406,6 +411,8 @@ const DashboardPage = () => {
         s.tags?.some((t) => t.name.toLowerCase().includes(q)),
       )
     }
+    // Float pinned services to the top
+    filtered.sort((a, b) => (b.is_pinned ? 1 : 0) - (a.is_pinned ? 1 : 0))
     setServices(filtered)
   }, [activeFilter, debouncedSearch, locationEnabled, userLocation, debouncedDistance])
 

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -958,6 +958,14 @@ export default function ServiceDetailPage() {
                       </Box>
                     )}
                   </Flex>
+                  {service.is_pinned && isEvent && (
+                    <Flex align="center" gap="4px" px="8px" py="3px" borderRadius="full" fontSize="11px" fontWeight={700}
+                      bg="rgba(16,185,129,0.25)" color={WHITE}
+                      style={{ backdropFilter: 'blur(8px)' }}
+                    >
+                      <FiMapPin size={10} /> Featured Event
+                    </Flex>
+                  )}
                   <Text fontSize="22px" fontWeight={800} color={WHITE} lineHeight={1.2}
                     style={{ textShadow: '0 1px 6px rgba(0,0,0,0.3)' }}
                   >
@@ -1544,6 +1552,29 @@ export default function ServiceDetailPage() {
                     >
                       <FiFlag size={12} />
                       {alreadyReported ? 'Already Reported' : 'Report this listing'}
+                    </Box>
+                  </Box>
+                )}
+
+                {/* Admin: Pin / Unpin Event */}
+                {isAuthenticated && isEvent && user?.role === 'admin' && (
+                  <Box textAlign="center" mt={3} pt={3} borderTop={`1px solid ${GRAY100}`}>
+                    <Box
+                      as="button"
+                      display="inline-flex" alignItems="center" gap={2}
+                      fontSize="12px" fontWeight={600}
+                      color={service.is_pinned ? AMBER : GREEN}
+                      style={{ background: 'none', border: 'none', cursor: 'pointer', transition: 'color 0.15s' }}
+                      onClick={async () => {
+                        try {
+                          const res = await serviceAPI.pinEvent(service.id)
+                          setService((prev) => prev ? { ...prev, is_pinned: res.is_pinned } : prev)
+                          toast.success(res.is_pinned ? 'Event pinned to feed' : 'Event unpinned')
+                        } catch { toast.error('Failed to update pin status') }
+                      }}
+                    >
+                      <FiMapPin size={12} />
+                      {service.is_pinned ? 'Unpin Event' : 'Pin Event'}
                     </Box>
                   </Box>
                 )}

--- a/frontend/src/services/serviceAPI.ts
+++ b/frontend/src/services/serviceAPI.ts
@@ -86,6 +86,11 @@ export const serviceAPI = {
 
   // ─── Event actions ────────────────────────────────────────────────────────
 
+  pinEvent: async (serviceId: string): Promise<Service> => {
+    const res = await apiClient.post<Service>(`/services/${serviceId}/pin-event/`)
+    return res.data
+  },
+
   completeEvent: async (serviceId: string): Promise<void> => {
     await apiClient.post(`/services/${serviceId}/complete-event/`, {})
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -153,6 +153,7 @@ export interface Service {
   updated_at: string
   interest_count?: number
   is_visible?: boolean
+  is_pinned?: boolean
   comment_count?: number
   hot_score?: number
 }


### PR DESCRIPTION
- Add is_pinned field to Service model with migration 0043
- Add pin_event admin-only toggle action (POST /api/services/{id}/pin-event/)
- Prepend -is_pinned to all queryset ordering so pinned events float to top
- Add is_pinned to ServiceSerializer (read-only)
- Add pinEvent API call in frontend serviceAPI
- Add 'Featured' badge (FiMapPin icon + text) on ServiceCard in discovery feed
- Add 'Featured Event' tag on event detail page header for all users
- Add 'Pin Event' / 'Unpin Event' admin toggle button on event detail sidebar
- Client-side sort pinned events to top after filtering


Closes #120.