### PR TITLE
refactor: update terminology and enhance user experience 

### DIFF
--- a/frontend/src/components/MainSidebar.tsx
+++ b/frontend/src/components/MainSidebar.tsx
@@ -149,7 +149,7 @@ export function MainSidebar({
                 <FiZap size={11} color="rgba(255,255,255,0.65)" />
                 <Text fontSize="10px" fontWeight={600} color="rgba(255,255,255,0.65)"
                   style={{ letterSpacing: '0.07em', textTransform: 'uppercase' }}>
-                  Time Bank
+                  Your Time
                 </Text>
               </Flex>
               <Flex align="baseline" gap="5px">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -349,6 +349,7 @@ const DashboardPage = () => {
   const [searchQuery, setSearchQuery]               = useState('')
   const [debouncedSearch, setDebouncedSearch]       = useState('')
   const [services, setServices]                     = useState<Service[]>([])
+  const [allActiveServices, setAllActiveServices]   = useState<Service[]>([])
   const [mapOpen, setMapOpen]                       = useState(true)
   const [sidebarOpen, setSidebarOpen]               = useState(false)
 
@@ -393,6 +394,7 @@ const DashboardPage = () => {
     }
     const active = raw.filter((s) => s.status === 'Active')
     const unique = Array.from(new Map(active.map((s) => [s.id, s])).values())
+    setAllActiveServices(unique)
     let filtered = unique
     if (activeFilter === 'online')    filtered = filtered.filter((s) => s.location_type === 'Online')
     if (activeFilter === 'recurrent') filtered = filtered.filter((s) => s.schedule_type === 'Recurrent')
@@ -412,7 +414,11 @@ const DashboardPage = () => {
   const { isLoading, error: fetchError } = usePolling(fetchServices, [fetchServices], { interval: POLL_INTERVAL })
 
   const fetchHandshakes = useCallback(async (signal: AbortSignal) => {
-    if (!isAuthenticated) { setHandshakeMap(new Map()); setIncomingMap(new Map()); return }
+    if (!isAuthenticated) {
+      setHandshakeMap(new Map())
+      setIncomingMap(new Map())
+      return
+    }
     const list = await handshakeAPI.list(signal)
     const out  = new Map<string, Handshake>()
     const inc  = new Map<string, Handshake[]>()
@@ -424,7 +430,8 @@ const DashboardPage = () => {
       if (h.requester === user?.id) { out.set(svcId, h) }
       else { const arr = inc.get(svcId) ?? []; arr.push(h); inc.set(svcId, arr) }
     })
-    setHandshakeMap(out); setIncomingMap(inc)
+    setHandshakeMap(out)
+    setIncomingMap(inc)
   }, [isAuthenticated, user?.id])
 
   usePolling(fetchHandshakes, [fetchHandshakes], { interval: POLL_INTERVAL, enabled: isAuthenticated })
@@ -462,11 +469,14 @@ const DashboardPage = () => {
   }, [locationEnabled, userLocation, requestLocation])
 
   // ── Derived ───────────────────────────────────────────────────────────────
-  const allHs              = Array.from(handshakeMap.values())
-  const myServices         = services.filter((s) => { const o = s.user ?? s.provider; return !!user && o?.id === user.id })
-  const pendingHs          = allHs.filter((h) => h.status === 'pending').length
-  const acceptedHs         = allHs.filter((h) => h.status === 'accepted').length
-  const completedHs        = allHs.filter((h) => h.status === 'completed').length
+  const ownServiceHandshakes = Array.from(incomingMap.values()).flat()
+  const myServices         = allActiveServices.filter((s) => { const o = s.user ?? s.provider; return !!user && o?.id === user.id })
+  const pendingHs          = myServices.filter((service) => {
+    const incoming = incomingMap.get(service.id) ?? []
+    return incoming.some((h) => h.status === 'pending')
+  }).length
+  const acceptedHs         = myServices.length
+  const completedHs        = ownServiceHandshakes.filter((h) => h.status === 'completed').length
   const distanceLabel      = distanceKm <= 5 ? 'Nearby' : distanceKm <= 15 ? 'Local' : distanceKm <= 30 ? 'Wider' : 'City-wide'
 
   const sidebarProps = {

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -133,7 +133,7 @@ const OnboardingPage = () => {
                 {[
                   '🎯 Share your skills with neighbours',
                   '🤝 Exchange time — not money',
-                  '⏰ Start with 3 hours in your time bank',
+                  '⏰ Start with 3 hours of shared time',
                 ].map(item => (
                   <Text key={item} fontSize="sm" color={GRAY700}>{item}</Text>
                 ))}
@@ -142,7 +142,7 @@ const OnboardingPage = () => {
             <Box bg={WHITE} borderRadius="10px" px={5} py={3}
               border={`1px solid ${GRAY200}`} boxShadow="0 1px 4px rgba(0,0,0,0.06)">
               <Text fontSize="sm" color={GRAY700} fontWeight="600">
-                🕐 Your balance:{' '}
+                🕐 Your time available:{' '}
                 <span style={{ color: GREEN }}>{user?.timebank_balance ?? 3} hours</span>
               </Text>
             </Box>

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -28,6 +28,11 @@ const joinedYear  = (d?: string) => d ? new Date(d).getFullYear() : null
 const fmtDate     = (d: string) => new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur      = (d: number | string) => `${Number(d)}h`
 
+function isOwnHistoryItem(item: UserHistoryItem) {
+  if (item.service_type === 'Need') return item.was_provider === false
+  return item.was_provider === true
+}
+
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5 }: { children: React.ReactNode; mb?: number }) => (
   <Box bg={WHITE} borderRadius="12px" border={`1px solid ${GRAY200}`} overflow="hidden" mb={mb}
@@ -85,7 +90,7 @@ function ServiceCard({ service, onNav }: { service: Service; onNav: () => void }
 }
 
 // ── History row ───────────────────────────────────────────────────────────────
-function HistoryRow({ item, canClick, onClick }: { item: UserHistoryItem; canClick: boolean; onClick: () => void }) {
+function HistoryRow({ item, canClick, onClick, contextLabel }: { item: UserHistoryItem; canClick: boolean; onClick: () => void; contextLabel: string }) {
   const col = AVATAR_PALETTE[item.partner_name.charCodeAt(0) % AVATAR_PALETTE.length]
   const ini = item.partner_name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
   return (
@@ -100,7 +105,7 @@ function HistoryRow({ item, canClick, onClick }: { item: UserHistoryItem; canCli
       }
       <Box flex={1} minW={0}>
         <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.service_title}</Text>
-        <Text fontSize="11px" color={GRAY500}>{item.was_provider ? 'Provided to' : 'Received from'} {item.partner_name}</Text>
+        <Text fontSize="11px" color={GRAY500}>{contextLabel} {item.partner_name}</Text>
       </Box>
       <Box textAlign="right" flexShrink={0}>
         <Text fontSize="12px" fontWeight={600} color={GREEN}>{fmtDur(item.duration)}</Text>
@@ -211,6 +216,7 @@ const PublicProfile = () => {
   const offersCount = services.filter(s => s.type === 'Offer').length
   const needsCount  = services.filter(s => s.type === 'Need').length
   const earnedBadges = badges.filter(b => b.earned)
+  const ownHistory = history.filter(isOwnHistoryItem)
   const punctual    = profileUser.punctual_count ?? 0
   const helpful     = profileUser.helpful_count  ?? 0
   const kind        = profileUser.kind_count     ?? 0
@@ -299,7 +305,7 @@ const PublicProfile = () => {
             {([
               [offersCount,         'Offers',    GREEN,  GREEN_LT,  <FiZap    size={14} />],
               [needsCount,          'Needs',     BLUE,   BLUE_LT,   <FiLayers size={14} />],
-              [history.length,      'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
+              [ownHistory.length,   'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
               [earnedBadges.length, 'Badges',    PURPLE, PURPLE_LT, <FiAward  size={14} />],
             ] as [number, string, string, string, React.ReactNode][]).map(([val, label, color, bg, icon]) => (
               <Box key={label} bg={WHITE}
@@ -348,16 +354,16 @@ const PublicProfile = () => {
 
               {profileUser.show_history && (
                 <SectionCard mb={0}>
-                  <SectionHead label={`Exchange History (${history.length})`} />
-                  {history.length === 0 ? (
+                  <SectionHead label={`Time Activity (${ownHistory.length})`} />
+                  {ownHistory.length === 0 ? (
                     <Flex py={8} direction="column" align="center" gap={2}>
                       <FiCheckCircle size={18} color={GRAY300} />
-                      <Text fontSize="13px" color={GRAY400}>No completed exchanges yet</Text>
+                      <Text fontSize="13px" color={GRAY400}>No time activity on this user&apos;s own services yet</Text>
                     </Flex>
                   ) : (
                     <Box px={4}>
-                      {history.map((item, i) => (
-                        <HistoryRow key={i} item={item} canClick={!!currentUser}
+                      {ownHistory.map((item, i) => (
+                        <HistoryRow key={i} item={item} canClick={!!currentUser} contextLabel="Own service with"
                           onClick={() => navigate(`/public-profile/${item.partner_id}`)} />
                       ))}
                     </Box>

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -25,8 +25,8 @@ const EMPTY_SUMMARY: TransactionSummary = {
 
 const FILTERS: { key: TransactionDirection; label: string }[] = [
   { key: 'all', label: 'All' },
-  { key: 'credit', label: 'Credit' },
-  { key: 'debit', label: 'Debit' },
+  { key: 'credit', label: 'Received' },
+  { key: 'debit', label: 'Shared' },
 ]
 
 const ACTIVE_HANDSHAKE_STATUSES = new Set(['accepted', 'checked_in', 'attended'])
@@ -117,8 +117,8 @@ function toExpectedAgreement(handshake: Handshake, currentUserName?: string): Ex
     provisioned_hours: hours,
     expected_delta: isProvider ? hours : 0,
     note: isProvider
-      ? `Expected credit after completion`
-      : `Hours already reserved from your balance`,
+      ? `Time expected after completion`
+      : `Hours already reflected in your available time`,
   }
 }
 
@@ -164,8 +164,8 @@ function transactionAccent(transaction: Transaction) {
       return { icon: FiZap, color: GRAY600, bg: GRAY100, stateLabel: 'Adjusted' }
     default:
       return transaction.amount >= 0
-        ? { ...roleBasedAccent, stateLabel: 'Credit' }
-        : { ...roleBasedAccent, stateLabel: 'Debit' }
+        ? { ...roleBasedAccent, stateLabel: 'Received' }
+        : { ...roleBasedAccent, stateLabel: 'Shared' }
   }
 }
 
@@ -226,14 +226,14 @@ function EmptyLedgerIllustration() {
           +0h
         </Box>
         <Box position="absolute" bottom="10px" left="0" px="8px" py="4px" borderRadius="999px" bg={BLUE_LT} color={BLUE} fontSize="11px" fontWeight={700}>
-          Ledger
+          Your Time
         </Box>
       </Box>
       <Text fontSize="18px" fontWeight={800} color={GRAY800} mb={2}>
-        No transactions yet
+        No time activity yet
       </Text>
       <Text maxW="420px" fontSize="14px" color={GRAY500}>
-        Your TimeBank credits and debits will appear here after you start completing exchanges with other members.
+        Your shared time activity will appear here once you start completing exchanges with other members.
       </Text>
     </Flex>
   )
@@ -414,10 +414,10 @@ const TransactionHistoryPage = () => {
               </Flex>
             </Box>
             <Text fontSize={{ base: '24px', md: '28px' }} fontWeight={800} color={GRAY900} mb={2}>
-              Transaction History
+              Time Activity
             </Text>
             <Text fontSize="14px" color={GRAY500}>
-              Complete ledger of your TimeBank credits and debits.
+              A shared record of the time you have received and shared with the community.
             </Text>
           </Box>
 
@@ -446,10 +446,10 @@ const TransactionHistoryPage = () => {
         </Flex>
 
         <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)', xl: 'repeat(4, 1fr)' }} gap={4} mb={6}>
-          <SummaryCard label="Current Balance" value={summary.current_balance} color={PURPLE} bg={PURPLE_LT} />
-          <SummaryCard label="Expected Balance" value={expectedBalance} color={BLUE} bg={BLUE_LT} />
-          <SummaryCard label="Total Earned" value={summary.total_earned} color={GREEN} bg={GREEN_LT} />
-          <SummaryCard label="Total Spent" value={summary.total_spent} color={RED} bg={RED_LT} />
+          <SummaryCard label="Time Available" value={summary.current_balance} color={PURPLE} bg={PURPLE_LT} />
+          <SummaryCard label="Upcoming Time" value={expectedBalance} color={BLUE} bg={BLUE_LT} />
+          <SummaryCard label="Time Received" value={summary.total_earned} color={GREEN} bg={GREEN_LT} />
+          <SummaryCard label="Time Shared" value={summary.total_spent} color={RED} bg={RED_LT} />
         </Grid>
 
         {activeAgreements.length > 0 && (
@@ -469,13 +469,13 @@ const TransactionHistoryPage = () => {
                   Active Agreements
                 </Text>
                 <Text fontSize="12px" color={GRAY600}>
-                  Ongoing accepted exchanges. Reserved hours are already reflected in your current balance; only pending incoming credits increase the expected balance.
+                  Ongoing accepted exchanges. Reserved hours are already reflected in your available time; only pending incoming time increases your upcoming time.
                 </Text>
               </Box>
               <Box px="10px" py="5px" borderRadius="999px" bg={WHITE} color={BLUE} fontSize="12px" fontWeight={700}>
                 {activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0) > 0
-                  ? `Expected +${formatHours(activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0))}`
-                  : 'No pending credit'}
+                  ? `Upcoming +${formatHours(activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0))}`
+                  : 'No upcoming time'}
               </Box>
             </Flex>
 
@@ -528,7 +528,7 @@ const TransactionHistoryPage = () => {
                     flexShrink={0}
                   >
                     <Box textAlign={{ base: 'left', md: 'right' }}>
-                      <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Expected</Text>
+                      <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Upcoming</Text>
                       <Text fontSize="13px" fontWeight={800} color={agreement.expected_delta > 0 ? GREEN : GRAY700}>
                         {agreement.expected_delta > 0 ? formatAmount(agreement.expected_delta) : 'No additional change'}
                       </Text>
@@ -582,11 +582,11 @@ const TransactionHistoryPage = () => {
         {isLoading ? (
           <Flex direction="column" align="center" justify="center" py={{ base: 16, md: 24 }} gap={3}>
             <Spinner color={GREEN} size="lg" />
-            <Text fontSize="14px" color={GRAY500}>Loading transaction history…</Text>
+            <Text fontSize="14px" color={GRAY500}>Loading time activity…</Text>
           </Flex>
         ) : error ? (
           <Box borderRadius="20px" border={`1px solid ${RED}22`} bg={RED_LT} p={{ base: 5, md: 6 }}>
-            <Text fontSize="16px" fontWeight={700} color={RED} mb={2}>Could not load transactions</Text>
+            <Text fontSize="16px" fontWeight={700} color={RED} mb={2}>Could not load time activity</Text>
             <Text fontSize="14px" color={GRAY700} mb={4}>{error}</Text>
             <Box
               as="button"
@@ -615,7 +615,7 @@ const TransactionHistoryPage = () => {
           <Box borderRadius="24px" border={`1px solid ${GRAY200}`} bg={WHITE} overflow="hidden">
             <Box display={{ base: 'none', md: 'block' }} px={6} py={4} bg={GRAY50} borderBottom={`1px solid ${GRAY200}`}>
               <Grid templateColumns="180px 220px minmax(220px, 1fr) 140px 140px" gap={4}>
-                {['Date', 'Counterpart', 'Service', 'Amount', 'Running Balance'].map((label) => (
+                {['Date', 'Counterpart', 'Service', 'Time', 'Time Available'].map((label) => (
                   <Text key={label} fontSize="11px" fontWeight={800} color={GRAY500} textTransform="uppercase" letterSpacing="0.08em">
                     {label}
                   </Text>
@@ -671,7 +671,7 @@ const TransactionHistoryPage = () => {
                           </Flex>
                         </Box>
                         <Box>
-                          <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Running Balance</Text>
+                          <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Time Available</Text>
                           <Text fontSize="13px" fontWeight={700} color={GRAY800}>{formatHours(transaction.balance_after)}</Text>
                         </Box>
                       </Grid>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -36,6 +36,11 @@ const fmtDur      = (d: number | string) => `${Number(d)}h`
 
 type ServiceTab = 'offers' | 'needs' | 'history' | 'settings'
 
+function isOwnHistoryItem(item: UserHistoryItem) {
+  if (item.service_type === 'Need') return item.was_provider === false
+  return item.was_provider === true
+}
+
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5, overflow = 'hidden' }: { children: React.ReactNode; mb?: number; overflow?: string }) => (
   <Box bg={WHITE} borderRadius="12px" border={`1px solid ${GRAY200}`} overflow={overflow} mb={mb}
@@ -106,7 +111,7 @@ function ServiceCard({ service, onNav }: { service: Service; onNav: () => void }
 }
 
 // ── History row ───────────────────────────────────────────────────────────────
-function HistoryRow({ item, onClick }: { item: UserHistoryItem; onClick: () => void }) {
+function HistoryRow({ item, onClick, contextLabel }: { item: UserHistoryItem; onClick: () => void; contextLabel: string }) {
   const col = AVATAR_PALETTE[item.partner_name.charCodeAt(0) % AVATAR_PALETTE.length]
   const ini = item.partner_name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
   return (
@@ -120,7 +125,7 @@ function HistoryRow({ item, onClick }: { item: UserHistoryItem; onClick: () => v
       }
       <Box flex={1} minW={0}>
         <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.service_title}</Text>
-        <Text fontSize="11px" color={GRAY500}>{item.was_provider ? 'Provided to' : 'Received from'} {item.partner_name}</Text>
+        <Text fontSize="11px" color={GRAY500}>{contextLabel} {item.partner_name}</Text>
       </Box>
       <Box textAlign="right" flexShrink={0}>
         <Text fontSize="12px" fontWeight={600} color={GREEN}>{fmtDur(item.duration)}</Text>
@@ -280,6 +285,7 @@ const UserProfile = () => {
 
   const offersTab  = services.filter(s => s.type === 'Offer' && s.status === 'Active')
   const needsTab   = services.filter(s => s.type === 'Need'  && s.status === 'Active')
+  const ownHistory = history.filter(isOwnHistoryItem)
 
   const handleSave = async () => {
     setSaving(true)
@@ -475,7 +481,7 @@ const UserProfile = () => {
             {([
               [offersTab.length,  'Offers',    GREEN,  GREEN_LT,  <FiZap    size={14} />],
               [needsTab.length,   'Needs',     BLUE,   BLUE_LT,   <FiLayers size={14} />],
-              [history.length,    'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
+              [ownHistory.length, 'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
               [badges.filter(b => b.earned).length, 'Badges', PURPLE, PURPLE_LT, <FiAward size={14} />],
             ] as [number, string, string, string, React.ReactNode][]).map(([val, label, color, bg, icon]) => (
               <Box key={label} bg={WHITE}
@@ -502,7 +508,7 @@ const UserProfile = () => {
           {balanceWarn && (
             <Box mb={4} px={4} py={3} borderRadius="10px" fontSize="13px" fontWeight={500}
               style={{ background: RED_LT, border: `1px solid ${RED}40`, color: RED }}>
-              Your TimeBank balance is <strong>{balance}h</strong> — consider spending it on services.
+              Your available time is <strong>{balance}h</strong> — consider sharing it through services in the community.
             </Box>
           )}
 
@@ -612,7 +618,7 @@ const UserProfile = () => {
                 <Flex px={4} pt={3} gap={0} borderBottom={`1px solid ${GRAY100}`} style={{ overflowX: 'auto' }}>
                   <TabBtn active={activeTab === 'offers'}   label={`Offers (${offersTab.length})`}  onClick={() => setActiveTab('offers')} />
                   <TabBtn active={activeTab === 'needs'}    label={`Needs (${needsTab.length})`}    onClick={() => setActiveTab('needs')} />
-                  <TabBtn active={activeTab === 'history'}  label={`History (${history.length})`}   onClick={() => setActiveTab('history')} />
+                  <TabBtn active={activeTab === 'history'}  label={`History (${ownHistory.length})`}   onClick={() => setActiveTab('history')} />
                   <TabBtn active={activeTab === 'settings'} label="Settings"                        onClick={() => setActiveTab('settings')} icon={<FiSettings size={12} />} />
                 </Flex>
 
@@ -653,15 +659,15 @@ const UserProfile = () => {
                 {/* ── History ── */}
                 {activeTab === 'history' && (historyLoading ? (
                   <Flex py={10} justify="center"><Spinner color={GREEN} /></Flex>
-                ) : history.length === 0 ? (
+                ) : ownHistory.length === 0 ? (
                   <Flex py={10} direction="column" align="center" gap={2}>
                     <FiRepeat size={22} color={GRAY300} />
-                    <Text fontSize="13px" color={GRAY400}>No completed exchanges yet</Text>
+                    <Text fontSize="13px" color={GRAY400}>No time activity on your own services yet</Text>
                   </Flex>
                 ) : (
                   <Box px={4}>
-                    {history.map((item, i) => (
-                      <HistoryRow key={i} item={item} onClick={() => navigate(`/public-profile/${item.partner_id}`)} />
+                    {ownHistory.map((item, i) => (
+                      <HistoryRow key={i} item={item} contextLabel="Own service with" onClick={() => navigate(`/public-profile/${item.partner_id}`)} />
                     ))}
                   </Box>
                 ))}
@@ -785,9 +791,9 @@ const UserProfile = () => {
             {/* Right: sidebar cards */}
             <Box w={{ base: '100%', lg: '272px' }} flexShrink={0}>
 
-              {/* TimeBank balance */}
+              {/* Your time */}
               <SectionCard>
-                <SectionHead label="TimeBank Balance" />
+                <SectionHead label="Your Time" />
                 <Box px={4} py={4} textAlign="center">
                   <Flex align="center" justify="center" gap={2} mb={1}>
                     <FiClock size={22} color={balanceWarn ? RED : GREEN} />
@@ -797,10 +803,10 @@ const UserProfile = () => {
                   <Flex justify="center" gap={2}>
                     <Box as="button" px="10px" py="6px" borderRadius="7px" fontSize="11px" fontWeight={600}
                       style={{ background: GRAY100, color: GRAY600, cursor: 'pointer' }}
-                      onClick={() => navigate('/transaction-history')}>View history</Box>
+                      onClick={() => navigate('/transaction-history')}>View activity</Box>
                     <Box as="button" px="10px" py="6px" borderRadius="7px" fontSize="11px" fontWeight={600}
                       style={{ background: GREEN_LT, color: GREEN, border: `1px solid ${GREEN}40`, cursor: 'pointer' }}
-                      onClick={() => navigate('/post-offer')}>Earn more</Box>
+                      onClick={() => navigate('/post-offer')}>Offer a service</Box>
                   </Flex>
                 </Box>
               </SectionCard>
@@ -813,7 +819,7 @@ const UserProfile = () => {
                     ['Post an Offer',       '/post-offer',            GREEN,  GREEN_LT],
                     ['Post a Need',         '/post-need',             BLUE,   BLUE_LT],
                     ['View Achievements',   '/achievements',          AMBER,  AMBER_LT],
-                    ['Transaction History', '/transaction-history',   PURPLE, PURPLE_LT],
+                    ['Time Activity', '/transaction-history',   PURPLE, PURPLE_LT],
                   ] as [string, string, string, string][]).map(([label, path, color]) => (
                     <Flex key={path} as="button" px={4} py="10px" align="center" justify="space-between"
                       borderBottom={`1px solid ${GRAY100}`} fontSize="12px" fontWeight={500} color={GRAY700}


### PR DESCRIPTION
## Summary
- Refresh time-related copy across the app to use warmer, community-focused language such as `Your Time`, `Time Activity`, `Received`, and `Shared`.
- Align profile and public profile history/stat sections so they only show completed activity for the user’s own services.
- Fix dashboard sidebar counters so `Pending`, `Active`, and `Done` reflect own-service state more accurately instead of broader handshake totals.

## What changed
- Updated `TransactionHistoryPage` labels, summaries, empty states, loading/error text, and activity wording.
- Renamed time-balance language in `MainSidebar`, `UserProfile`, and `OnboardingPage`.
- Filtered `UserProfile` and `PublicProfile` history/exchange counts to own completed service activity only.
- Updated `DashboardPage` sidebar stats to:
  - count `Pending` as services with at least one pending incoming request
  - count `Active` as the user’s currently open services
  - count `Done` from completed incoming handshakes on the user’s own services

## Why
- The previous terminology felt too financial and less aligned with the platform’s community-first tone.
- Profile history and exchange counts were mixing in activity that did not belong to the user’s own services.
- Sidebar counters were misleading because they were based on handshake/request totals rather than the user’s own service state.

## Test plan
- [ ] Verify `Transaction History` now appears as `Time Activity` and uses `Received / Shared` terminology.
- [ ] Verify `UserProfile` history and exchange count only include completed activity for the user’s own services.
- [ ] Verify `PublicProfile` history and exchange count also only include the profile owner’s own completed service activity.
- [ ] Verify dashboard sidebar:
  - [ ] `Pending` increases only when an own service has at least one pending incoming request
  - [ ] `Active` matches the number of currently open own services
  - [ ] `Done` matches completed incoming handshakes on own services
- [ ] Sanity check onboarding and sidebar copy for the new `Your Time` wording.