### PR TITLE
Fix/144 group offer payments and UI

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -10,6 +10,7 @@ from .models import (
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils import timezone
 from decimal import Decimal
 import bleach
 import re
@@ -475,10 +476,37 @@ class ServiceSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, data):
-        """Object-level validation: enforce max_participants=1 for Need services."""
+        """Object-level validation for group offers and Need capacity."""
         data = super().validate(data)
-        if data.get('type') == 'Need':
+        instance = self.instance
+        service_type = data.get('type', getattr(instance, 'type', None))
+        schedule_type = data.get('schedule_type', getattr(instance, 'schedule_type', None))
+        max_participants = data.get('max_participants', getattr(instance, 'max_participants', 1))
+        location_area = data.get('location_area', getattr(instance, 'location_area', ''))
+        scheduled_time = data.get('scheduled_time', getattr(instance, 'scheduled_time', None))
+
+        if service_type == 'Need':
             data['max_participants'] = 1
+            max_participants = 1
+
+        is_fixed_group_offer = (
+            service_type == 'Offer'
+            and schedule_type == 'One-Time'
+            and max_participants > 1
+        )
+        if is_fixed_group_offer:
+            if not (location_area or '').strip():
+                raise serializers.ValidationError({
+                    'location_area': 'One-time group offers require an exact meeting location or link.',
+                })
+            if scheduled_time is None:
+                raise serializers.ValidationError({
+                    'scheduled_time': 'One-time group offers require a scheduled date and time.',
+                })
+            if scheduled_time <= timezone.now():
+                raise serializers.ValidationError({
+                    'scheduled_time': 'One-time group offers must be scheduled in the future.',
+                })
         return data
 
     @extend_schema_field(UserSummarySerializer)
@@ -1250,8 +1278,11 @@ class PublicUserProfileSerializer(serializers.ModelSerializer):
     ]
 )
 class HandshakeSerializer(serializers.ModelSerializer):
+    service_id = serializers.UUIDField(source='service.id', read_only=True)
     service_title = serializers.CharField(source='service.title', read_only=True)
     service_type = serializers.CharField(source='service.type', read_only=True)
+    schedule_type = serializers.CharField(source='service.schedule_type', read_only=True)
+    max_participants = serializers.IntegerField(source='service.max_participants', read_only=True)
     requester_name = serializers.SerializerMethodField()
     provider_name = serializers.SerializerMethodField()
     counterpart = serializers.SerializerMethodField()
@@ -1261,8 +1292,8 @@ class HandshakeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Handshake
         fields = [
-            'id', 'service', 'service_title', 'requester', 'requester_name',
-            'provider_name', 'service_type',
+            'id', 'service', 'service_id', 'service_title', 'requester', 'requester_name',
+            'provider_name', 'service_type', 'schedule_type', 'max_participants',
             'counterpart', 'is_current_user_provider',
             'status', 'provisioned_hours',
             'provider_confirmed_complete', 'receiver_confirmed_complete',
@@ -1750,20 +1781,31 @@ class ReportSerializer(serializers.ModelSerializer):
     ]
 )
 class TransactionHistorySerializer(serializers.ModelSerializer):
+    handshake_id = serializers.UUIDField(source='handshake.id', read_only=True)
+    service_id = serializers.SerializerMethodField()
     transaction_type_display = serializers.CharField(source='get_transaction_type_display', read_only=True)
     service_title = serializers.SerializerMethodField()
     service_type = serializers.SerializerMethodField()
+    schedule_type = serializers.SerializerMethodField()
+    max_participants = serializers.SerializerMethodField()
     is_current_user_provider = serializers.SerializerMethodField()
     counterpart = serializers.SerializerMethodField()
 
     class Meta:
         model = TransactionHistory
         fields = [
-            'id', 'transaction_type', 'transaction_type_display', 'amount',
-            'balance_after', 'description', 'service_title', 'service_type',
-            'is_current_user_provider', 'counterpart', 'created_at'
+            'id', 'handshake_id', 'service_id', 'transaction_type', 'transaction_type_display',
+            'amount', 'balance_after', 'description', 'service_title', 'service_type',
+            'schedule_type', 'max_participants', 'is_current_user_provider',
+            'counterpart', 'created_at'
         ]
         read_only_fields = ['id', 'created_at']
+
+    @extend_schema_field(OpenApiTypes.UUID)
+    def get_service_id(self, obj):
+        if obj.handshake and obj.handshake.service:
+            return str(obj.handshake.service.id)
+        return None
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_service_title(self, obj):
@@ -1775,6 +1817,18 @@ class TransactionHistorySerializer(serializers.ModelSerializer):
     def get_service_type(self, obj):
         if obj.handshake and obj.handshake.service:
             return obj.handshake.service.type
+        return None
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_schedule_type(self, obj):
+        if obj.handshake and obj.handshake.service:
+            return obj.handshake.service.schedule_type
+        return None
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_max_participants(self, obj):
+        if obj.handshake and obj.handshake.service:
+            return obj.handshake.service.max_participants
         return None
 
     @extend_schema_field(serializers.BooleanField())
@@ -1925,6 +1979,21 @@ class ServiceGroupChatMessageSerializer(serializers.ModelSerializer):
 
     def get_sender_avatar_url(self, obj):
         return obj.sender.avatar_url
+
+
+class GroupChatParticipantSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField()
+    avatar_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'name', 'avatar_url']
+
+    def get_name(self, obj):
+        return f"{obj.first_name} {obj.last_name}".strip()
+
+    def get_avatar_url(self, obj):
+        return obj.avatar_url
 
 
 # Comment Serializers
@@ -2230,8 +2299,11 @@ class NegativeRepSerializer(serializers.ModelSerializer):
 )
 class UserHistorySerializer(serializers.Serializer):
     """Serializer for user's completed transaction history"""
+    service_id = serializers.UUIDField()
     service_title = serializers.CharField()
     service_type = serializers.CharField()
+    schedule_type = serializers.CharField()
+    max_participants = serializers.IntegerField()
     duration = serializers.DecimalField(max_digits=5, decimal_places=2)
     partner_name = serializers.CharField()
     partner_id = serializers.UUIDField()

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1781,7 +1781,7 @@ class ReportSerializer(serializers.ModelSerializer):
     ]
 )
 class TransactionHistorySerializer(serializers.ModelSerializer):
-    handshake_id = serializers.UUIDField(source='handshake.id', read_only=True)
+    handshake_id = serializers.SerializerMethodField()
     service_id = serializers.SerializerMethodField()
     transaction_type_display = serializers.CharField(source='get_transaction_type_display', read_only=True)
     service_title = serializers.SerializerMethodField()
@@ -1800,6 +1800,12 @@ class TransactionHistorySerializer(serializers.ModelSerializer):
             'counterpart', 'created_at'
         ]
         read_only_fields = ['id', 'created_at']
+
+    @extend_schema_field(OpenApiTypes.UUID)
+    def get_handshake_id(self, obj):
+        if obj.handshake_id:
+            return str(obj.handshake_id)
+        return None
 
     @extend_schema_field(OpenApiTypes.UUID)
     def get_service_id(self, obj):

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -62,6 +62,15 @@ class HandshakeService:
         # Check if service exists and is active
         if service.status != 'Active':
             return False, 'Service is not active'
+
+        if (
+            service.type == 'Offer'
+            and service.schedule_type == 'One-Time'
+            and service.max_participants > 1
+            and service.scheduled_time is not None
+            and service.scheduled_time <= timezone.now()
+        ):
+            return False, 'This group offer has already started or expired'
         
         # Check if user is trying to express interest in their own service
         if service.user == user:
@@ -142,6 +151,15 @@ class HandshakeService:
             # Validate service exists and is active (inside transaction)
             if service.status != 'Active':
                 raise ValueError('Service is not active')
+
+            if (
+                service.type == 'Offer'
+                and service.schedule_type == 'One-Time'
+                and service.max_participants > 1
+                and service.scheduled_time is not None
+                and service.scheduled_time <= timezone.now()
+            ):
+                raise ValueError('This group offer has already started or expired')
             
             # Check if user is trying to express interest in their own service
             # Use locked service_owner for comparison

--- a/backend/api/tests/integration/test_chat_api.py
+++ b/backend/api/tests/integration/test_chat_api.py
@@ -30,7 +30,24 @@ class TestChatViewSet:
         response = client.get('/api/chats/')
         assert response.status_code == status.HTTP_200_OK
         assert 'results' in response.data
-        assert any(item['handshake_id'] == str(handshake.id) for item in response.data['results'])
+        conversation = next(item for item in response.data['results'] if item['handshake_id'] == str(handshake.id))
+        assert conversation['service_member_count'] == 1
+
+    def test_list_conversations_includes_group_member_count(self):
+        """Group service rows include canonical owner+accepted member count."""
+        owner = UserFactory()
+        service = _group_service(owner)
+        requester = UserFactory()
+        handshake = HandshakeFactory(service=service, requester=requester, status='accepted')
+        _accepted_handshake(service)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(requester)
+
+        response = client.get('/api/chats/')
+        assert response.status_code == status.HTTP_200_OK
+        conversation = next(item for item in response.data['results'] if item['handshake_id'] == str(handshake.id))
+        assert conversation['service_member_count'] == 3
     
     def test_get_conversation_messages(self):
         """Test retrieving messages for a conversation"""
@@ -197,6 +214,12 @@ class TestGroupChatViewSet:
         response = client.get(f'/api/group-chat/{service.id}/')
         assert response.status_code == status.HTTP_200_OK
         assert response.data['service_id'] == str(service.id)
+        assert response.data['service_title'] == service.title
+        assert response.data['participants'] == [{
+            'id': str(owner.id),
+            'name': f'{owner.first_name} {owner.last_name}'.strip(),
+            'avatar_url': owner.avatar_url,
+        }]
         assert 'messages' in response.data
 
     def test_accepted_participant_can_get_messages(self):
@@ -212,6 +235,9 @@ class TestGroupChatViewSet:
         response = client.get(f'/api/group-chat/{service.id}/')
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['messages']) == 1
+        assert len(response.data['participants']) == 2
+        assert response.data['participants'][0]['id'] == str(service.user_id)
+        assert response.data['participants'][1]['id'] == str(participant.id)
 
     def test_get_returns_messages_oldest_first(self):
         """Messages are returned in ascending (oldest-first) order."""
@@ -239,7 +265,7 @@ class TestGroupChatViewSet:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_pending_handshake_user_cannot_get_messages(self):
-        """A user with only a *pending* handshake is denied (must be accepted)."""
+        """A pending requester must wait until the handshake is accepted."""
         service = _group_service()
         requester = UserFactory()
         HandshakeFactory(service=service, requester=requester, status='pending')

--- a/backend/api/tests/integration/test_event_chat.py
+++ b/backend/api/tests/integration/test_event_chat.py
@@ -338,6 +338,30 @@ class TestGroupChatEventAccess:
         response = client.get(f'/api/group-chat/{event.id}/')
         assert response.status_code == status.HTTP_200_OK
 
+    def test_event_participant_list_includes_checked_in_and_attended(self):
+        """Event group chat participants include all active event statuses."""
+        organizer = UserFactory()
+        event = _event_service(organizer=organizer)
+        accepted = UserFactory()
+        checked_in = UserFactory()
+        attended = UserFactory()
+        HandshakeFactory(service=event, requester=accepted, status='accepted')
+        HandshakeFactory(service=event, requester=checked_in, status='checked_in')
+        HandshakeFactory(service=event, requester=attended, status='attended')
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+
+        response = client.get(f'/api/group-chat/{event.id}/')
+        assert response.status_code == status.HTTP_200_OK
+        participant_ids = {participant['id'] for participant in response.data['participants']}
+        assert participant_ids == {
+            str(organizer.id),
+            str(accepted.id),
+            str(checked_in.id),
+            str(attended.id),
+        }
+
     def test_event_cancelled_participant_denied_group_chat(self):
         """A cancelled event participant cannot use group chat."""
         event = _event_service()

--- a/backend/api/tests/integration/test_handshake_api.py
+++ b/backend/api/tests/integration/test_handshake_api.py
@@ -151,6 +151,37 @@ class TestHandshakeViewSet:
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
         assert handshake.exact_location == 'Test Location'
+
+    def test_group_offer_initiate_uses_service_details(self):
+        """One-time group offers must reuse service-level date/location details."""
+        provider = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(
+            user=provider,
+            type='Offer',
+            schedule_type='One-Time',
+            max_participants=3,
+            duration=Decimal('2.00'),
+            location_area='Kadıköy Youth Center',
+            scheduled_time=timezone.now() + timedelta(days=4),
+        )
+        handshake = HandshakeFactory(service=service, requester=requester, status='pending')
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(provider)
+
+        response = client.post(f'/api/handshakes/{handshake.id}/initiate/', {
+            'exact_location': 'Tamper attempt',
+            'exact_duration': 9,
+            'scheduled_time': '2099-01-01T10:00:00Z',
+        })
+        assert response.status_code == status.HTTP_200_OK
+
+        handshake.refresh_from_db()
+        assert handshake.provider_initiated is True
+        assert handshake.exact_location == service.location_area
+        assert handshake.exact_duration == service.duration
+        assert handshake.scheduled_time == service.scheduled_time
     
     def test_approve_handshake(self):
         """Test receiver approving handshake"""

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -68,6 +68,7 @@ class TestServiceViewSet:
             'location_lng': 29.0089,
             'max_participants': 2,
             'schedule_type': 'One-Time',
+            'scheduled_time': (timezone.now() + timedelta(days=3)).isoformat(),
             'status': 'Active',
             'tag_ids': [tag.id]
         })
@@ -531,6 +532,29 @@ class TestServiceRetrieveStatusVisibility:
         assert response.status_code == status.HTTP_200_OK
         assert all(s['status'] == 'Active' for s in response.data['results'])
 
+    def test_list_excludes_expired_group_offers_from_feed(self):
+        """Past one-time group offers should disappear from the public feed."""
+        expired = ServiceFactory(
+            type='Offer',
+            status='Active',
+            schedule_type='One-Time',
+            max_participants=3,
+            scheduled_time=timezone.now() - timedelta(hours=1),
+        )
+        future = ServiceFactory(
+            type='Offer',
+            status='Active',
+            schedule_type='One-Time',
+            max_participants=3,
+            scheduled_time=timezone.now() + timedelta(days=1),
+        )
+
+        response = APIClient().get('/api/services/')
+        assert response.status_code == status.HTTP_200_OK
+        ids = {item['id'] for item in response.data['results']}
+        assert str(expired.id) not in ids
+        assert str(future.id) in ids
+
     def test_need_service_max_participants_forced_to_one(self):
         """Creating a Need service must force max_participants to 1."""
         user = UserFactory()
@@ -562,11 +586,32 @@ class TestServiceRetrieveStatusVisibility:
             'description': 'Group session with multiple participants',
             'type': 'Offer',
             'duration': 2.0,
-            'location_type': 'Online',
+            'location_type': 'In-Person',
+            'location_area': 'Beşiktaş Culture Center',
             'max_participants': 5,
             'schedule_type': 'One-Time',
+            'scheduled_time': (timezone.now() + timedelta(days=3)).isoformat(),
         })
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['max_participants'] == 5
         service = Service.objects.get(id=response.data['id'])
         assert service.max_participants == 5
+
+    def test_group_offer_requires_future_schedule_and_exact_location(self):
+        """One-time group offers must include fixed meeting details."""
+        user = UserFactory()
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+
+        response = client.post('/api/services/', {
+            'title': 'Incomplete Group Offer',
+            'description': 'Missing fixed meeting details',
+            'type': 'Offer',
+            'duration': 2.0,
+            'location_type': 'In-Person',
+            'max_participants': 3,
+            'schedule_type': 'One-Time',
+        })
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        field_errors = response.data.get('field_errors', {})
+        assert 'location_area' in field_errors or 'scheduled_time' in field_errors

--- a/backend/api/tests/unit/test_group_chat.py
+++ b/backend/api/tests/unit/test_group_chat.py
@@ -163,8 +163,8 @@ class TestGroupChatViewSetAccessControl:
         result = vs._get_service_or_403(vs.request, str(service.id))
         assert result == service
 
-    def test_pending_requester_is_denied(self):
-        """User with only a pending handshake is denied."""
+    def test_pending_requester_is_denied_for_group_offer(self):
+        """Pending group-offer requester must wait for acceptance."""
         from rest_framework.exceptions import PermissionDenied
         service = ServiceFactory(schedule_type='One-Time', max_participants=3)
         requester = UserFactory()
@@ -216,12 +216,12 @@ class TestGroupChatViewSetAccessControl:
             vs._get_service_or_403(vs.request, str(uuid.uuid4()))
 
     def test_denied_handshake_status_variations(self):
-        """Statuses other than 'accepted' do not grant access."""
+        """Terminal or rejected statuses do not grant access."""
         from rest_framework.exceptions import PermissionDenied
         service = ServiceFactory(schedule_type='One-Time', max_participants=3)
         requester = UserFactory()
 
-        for hs_status in ('pending', 'denied', 'cancelled', 'completed'):
+        for hs_status in ('denied', 'cancelled'):
             HandshakeFactory(service=service, requester=requester, status=hs_status)
             vs = self._viewset_with_user(requester)
             with pytest.raises(PermissionDenied, match=''):

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -442,6 +442,28 @@ class TestTransactionHistorySerializer:
         assert data['counterpart']['id'] == str(service_owner.id)
         assert data['counterpart']['email'] == service_owner.email
 
+    def test_adjustment_transaction_allows_null_handshake(self):
+        """Adjustment transactions without a handshake should serialize nullable fields as None."""
+        user = UserFactory()
+        transaction = TransactionHistoryFactory(
+            user=user,
+            handshake=None,
+            transaction_type='adjustment',
+            description='Manual admin adjustment',
+        )
+
+        serializer = TransactionHistorySerializer(transaction)
+        data = serializer.data
+
+        assert data['handshake_id'] is None
+        assert data['service_id'] is None
+        assert data['service_title'] is None
+        assert data['service_type'] is None
+        assert data['schedule_type'] is None
+        assert data['max_participants'] is None
+        assert data['counterpart'] is None
+        assert data['is_current_user_provider'] is False
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -2,9 +2,11 @@
 Unit tests for serializers
 """
 import pytest
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.exceptions import ValidationError
@@ -113,6 +115,7 @@ class TestServiceSerializer:
             'location_lng': 29.0089,
             'max_participants': 2,
             'schedule_type': 'One-Time',
+            'scheduled_time': (timezone.now() + timedelta(days=3)).isoformat(),
             'status': 'Active',
             'tag_ids': [tag.id]
         })

--- a/backend/api/tests/unit/test_utils.py
+++ b/backend/api/tests/unit/test_utils.py
@@ -124,6 +124,50 @@ class TestCompleteTimebankTransfer:
             amount=Decimal('2.00')
         ).exists()
 
+    def test_group_one_time_offer_transfers_only_once_and_all_receivers_pay(self):
+        provider = UserFactory(timebank_balance=Decimal('0.00'))
+        receiver1 = UserFactory(timebank_balance=Decimal('5.00'))
+        receiver2 = UserFactory(timebank_balance=Decimal('5.00'))
+        service = ServiceFactory(
+            user=provider,
+            type='Offer',
+            duration=Decimal('3.00'),
+            schedule_type='One-Time',
+            max_participants=2,
+        )
+        handshake1 = HandshakeFactory(service=service, requester=receiver1, status='accepted', provisioned_hours=Decimal('3.00'))
+        handshake2 = HandshakeFactory(service=service, requester=receiver2, status='accepted', provisioned_hours=Decimal('3.00'))
+
+        provision_timebank(handshake1)
+        provision_timebank(handshake2)
+
+        with transaction.atomic():
+            complete_timebank_transfer(handshake1)
+
+        provider.refresh_from_db()
+        receiver1.refresh_from_db()
+        receiver2.refresh_from_db()
+
+        assert provider.timebank_balance == Decimal('0.00')
+        assert receiver1.timebank_balance == Decimal('2.00')
+        assert receiver2.timebank_balance == Decimal('2.00')
+
+        with transaction.atomic():
+            complete_timebank_transfer(handshake2)
+
+        provider.refresh_from_db()
+        receiver1.refresh_from_db()
+        receiver2.refresh_from_db()
+
+        assert provider.timebank_balance == Decimal('3.00')
+        assert receiver1.timebank_balance == Decimal('2.00')
+        assert receiver2.timebank_balance == Decimal('2.00')
+        assert TransactionHistory.objects.filter(
+            user=provider,
+            transaction_type='transfer',
+            handshake__service=service,
+        ).count() == 1
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -81,6 +81,14 @@ def provision_timebank(handshake: Handshake) -> bool:
         
         return True
 
+def _is_group_one_time_service(service: Service) -> bool:
+    return (
+        service.type in ('Offer', 'Need')
+        and service.schedule_type == 'One-Time'
+        and service.max_participants > 1
+    )
+
+
 def complete_timebank_transfer(handshake: Handshake) -> bool:
     """Credit the provider once both parties confirm completion.
     
@@ -94,45 +102,42 @@ def complete_timebank_transfer(handshake: Handshake) -> bool:
         if handshake.status == 'completed':
             return True
 
+        service = Service.objects.select_for_update().get(id=handshake.service.id)
         provider, receiver = get_provider_and_receiver(handshake)
-        provider = User.objects.select_for_update().get(id=provider.id)
-        hours = handshake.provisioned_hours
+        impacted_user_ids: set[str] = {str(provider.id), str(receiver.id)}
 
-        # Use F() expression for atomic balance update
-        provider.timebank_balance = F("timebank_balance") + hours
-        provider.save(update_fields=["timebank_balance"])
+        handshake.status = "completed"
+        handshake.save(update_fields=["status"])
 
-        # Refresh to get the actual balance value after atomic update
-        provider.refresh_from_db(fields=["timebank_balance"])
+        if not _is_group_one_time_service(service):
+            provider = User.objects.select_for_update().get(id=provider.id)
+            hours = handshake.provisioned_hours
 
-        # Record transaction history
-        TransactionHistory.objects.create(
-            user=provider,
-            transaction_type='transfer',
-            amount=hours,  # Positive for credit
-            balance_after=provider.timebank_balance,
-            handshake=handshake,
-            description=f"Service completed: '{handshake.service.title}' ({hours} hours transferred)"
-        )
+            provider.timebank_balance = F("timebank_balance") + hours
+            provider.save(update_fields=["timebank_balance"])
+            provider.refresh_from_db(fields=["timebank_balance"])
 
-        # Award karma for completing handshake as provider (+5)
-        provider.karma_score = F("karma_score") + 5
-        provider.save(update_fields=["karma_score"])
-        provider.refresh_from_db(fields=["karma_score"])
+            TransactionHistory.objects.create(
+                user=provider,
+                transaction_type='transfer',
+                amount=hours,
+                balance_after=provider.timebank_balance,
+                handshake=handshake,
+                description=f"Service completed: '{handshake.service.title}' ({hours} hours transferred)"
+            )
 
-        receiver_id = str(receiver.id)
-        provider_id = str(provider.id)
+            provider.karma_score = F("karma_score") + 5
+            provider.save(update_fields=["karma_score"])
+            provider.refresh_from_db(fields=["karma_score"])
 
         def invalidate_after_commit() -> None:
-            invalidate_conversations(provider_id)
-            invalidate_conversations(receiver_id)
-            invalidate_transactions(provider_id)
-            invalidate_transactions(receiver_id)
+            for user_id in impacted_user_ids:
+                invalidate_conversations(user_id)
+                invalidate_transactions(user_id)
 
         transaction.on_commit(invalidate_after_commit)
 
         # Option B: One-Time services become Completed only when all participant handshakes are completed.
-        service = Service.objects.select_for_update().get(id=handshake.service.id)
         if service.schedule_type == 'One-Time':
             # Compute post-completion counts without depending on an in-transaction status flip.
             completed_excluding_current = Handshake.objects.filter(
@@ -152,8 +157,34 @@ def complete_timebank_transfer(handshake: Handshake) -> bool:
                 service.status = 'Completed'
                 service.save(update_fields=['status'])
 
-        handshake.status = "completed"
-        handshake.save(update_fields=["status"])
+            if _is_group_one_time_service(service) and active_count_after == 0:
+                provider = User.objects.select_for_update().get(id=provider.id)
+                already_paid = TransactionHistory.objects.filter(
+                    user=provider,
+                    transaction_type='transfer',
+                    handshake__service=service,
+                ).exists()
+                if not already_paid:
+                    hours = Decimal(service.duration)
+                    provider.timebank_balance = F("timebank_balance") + hours
+                    provider.save(update_fields=["timebank_balance"])
+                    provider.refresh_from_db(fields=["timebank_balance"])
+
+                    TransactionHistory.objects.create(
+                        user=provider,
+                        transaction_type='transfer',
+                        amount=hours,
+                        balance_after=provider.timebank_balance,
+                        handshake=handshake,
+                        description=(
+                            f"Group service completed: '{service.title}' "
+                            f"({hours} hours transferred after all participants completed)"
+                        )
+                    )
+
+                    provider.karma_score = F("karma_score") + 5
+                    provider.save(update_fields=["karma_score"])
+                    provider.refresh_from_db(fields=["karma_score"])
 
         return True
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -5197,6 +5197,14 @@ class GroupChatViewSet(viewsets.ViewSet):
     """
     permission_classes = [permissions.IsAuthenticated]
 
+    def _active_statuses_for_group_chat(self, service):
+        is_event = service.type == 'Event'
+        return (
+            ['accepted', 'checked_in', 'attended']
+            if is_event
+            else ['accepted']
+        )
+
     def _get_service_or_403(self, request, pk):
         """Return the service if eligible and the user has access; raise otherwise."""
         try:
@@ -5216,11 +5224,7 @@ class GroupChatViewSet(viewsets.ViewSet):
 
         user = request.user
         is_owner = service.user == user
-        active_statuses = (
-            ['accepted', 'checked_in', 'attended']
-            if is_event
-            else ['accepted']
-        )
+        active_statuses = self._active_statuses_for_group_chat(service)
         has_access = Handshake.objects.filter(
             service=service, requester=user, status__in=active_statuses
         ).exists()
@@ -5235,10 +5239,11 @@ class GroupChatViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         """Get the last 50 messages for the group chat."""
         service = self._get_service_or_403(request, pk)
+        active_statuses = self._active_statuses_for_group_chat(service)
         participant_users = [service.user]
         accepted_participants = list(
             User.objects.filter(
-                id__in=Handshake.objects.filter(service=service, status='accepted')
+                id__in=Handshake.objects.filter(service=service, status__in=active_statuses)
                 .values_list('requester_id', flat=True)
             ).distinct()
         )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -62,6 +62,7 @@ from .serializers import (
     ChatRoomSerializer,
     PublicChatMessageSerializer,
     ServiceGroupChatMessageSerializer,
+    GroupChatParticipantSerializer,
     CommentSerializer,
     NegativeRepSerializer,
     ForumCategorySerializer,
@@ -1220,8 +1221,11 @@ class UserHistoryView(APIView):
                 partner = provider
             
             history.append({
+                'service_id': handshake.service.id,
                 'service_title': handshake.service.title,
                 'service_type': handshake.service.type,
+                'schedule_type': handshake.service.schedule_type,
+                'max_participants': handshake.service.max_participants,
                 'duration': handshake.provisioned_hours,
                 'partner_name': f"{partner.first_name} {partner.last_name}".strip(),
                 'partner_id': partner.id,
@@ -1520,10 +1524,18 @@ class ServiceViewSet(viewsets.ModelViewSet):
         
         queryset = search_engine.search(queryset, search_params)
 
-        # Filter by owner user (for profile pages)
         user_param = self.request.query_params.get('user')
+        # Filter by owner user (for profile pages)
         if user_param:
             queryset = queryset.filter(user_id=user_param)
+        else:
+            queryset = queryset.exclude(
+                type='Offer',
+                schedule_type='One-Time',
+                max_participants__gt=1,
+                scheduled_time__isnull=False,
+                scheduled_time__lte=timezone.now(),
+            )
         
         # Apply ordering based on sort parameter
         # Must validate that lat/lng are valid numbers, not just truthy strings
@@ -2451,6 +2463,44 @@ class HandshakeViewSet(viewsets.ModelViewSet):
                 code=ErrorCodes.ALREADY_EXISTS,
                 status_code=status.HTTP_400_BAD_REQUEST
             )
+
+        service = handshake.service
+        is_fixed_group_offer = (
+            service.type == 'Offer'
+            and service.schedule_type == 'One-Time'
+            and service.max_participants > 1
+        )
+
+        if is_fixed_group_offer:
+            if not service.location_area or not service.scheduled_time:
+                return create_error_response(
+                    'This group offer is missing its fixed meeting details.',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            handshake.provider_initiated = True
+            handshake.exact_location = service.location_area
+            handshake.exact_duration = service.duration
+            handshake.scheduled_time = service.scheduled_time
+            handshake.save()
+
+            service_owner = handshake.service.user
+            other_party = handshake.requester
+            invalidate_conversations(str(service_owner.id))
+            invalidate_conversations(str(other_party.id))
+
+            create_notification(
+                user=other_party,
+                notification_type='handshake_request',
+                title='Group Offer Details Shared',
+                message=f"{user.first_name} shared the fixed session details for '{handshake.service.title}'. Please review and approve.",
+                handshake=handshake,
+                service=handshake.service
+            )
+
+            serializer = self.get_serializer(handshake)
+            return Response(serializer.data, status=200)
 
         # Require all details from provider
         exact_location = request.data.get('exact_location', '').strip()
@@ -3458,7 +3508,7 @@ class ChatViewSet(viewsets.ViewSet):
     @track_performance
     def list(self, request):
         """Get all conversations for the user"""
-        from django.db.models import Q, Prefetch, Subquery, OuterRef
+        from django.db.models import Q, Prefetch, Subquery, OuterRef, Count
         from .cache_utils import get_cached_conversations, cache_conversations
         user = request.user
         
@@ -3504,6 +3554,17 @@ class ChatViewSet(viewsets.ViewSet):
             last_message_prefetch,
             reputation_prefetch
         ).order_by('-updated_at')
+
+        service_ids = list({handshake.service_id for handshake in handshakes})
+        accepted_counts_by_service = {
+            row['service_id']: row['accepted_count']
+            for row in Handshake.objects.filter(
+                service_id__in=service_ids,
+                status='accepted',
+            ).values('service_id').annotate(
+                accepted_count=Count('requester_id', distinct=True)
+            )
+        }
 
         conversations = []
         for handshake in handshakes:
@@ -3555,10 +3616,13 @@ class ChatViewSet(viewsets.ViewSet):
                 'exact_location': handshake.exact_location,
                 'exact_duration': float(handshake.exact_duration) if handshake.exact_duration else None,
                 'scheduled_time': handshake.scheduled_time.isoformat() if handshake.scheduled_time else None,
+                'service_location_area': handshake.service.location_area,
+                'service_scheduled_time': handshake.service.scheduled_time.isoformat() if handshake.service.scheduled_time else None,
                 'provisioned_hours': float(handshake.provisioned_hours) if handshake.provisioned_hours else None,
                 'user_has_reviewed': user_has_reviewed,
                 'max_participants': handshake.service.max_participants,
                 'schedule_type': handshake.service.schedule_type,
+                'service_member_count': 1 + accepted_counts_by_service.get(handshake.service_id, 0),
             })
 
         page = paginator.paginate_queryset(conversations, request)
@@ -5152,7 +5216,11 @@ class GroupChatViewSet(viewsets.ViewSet):
 
         user = request.user
         is_owner = service.user == user
-        active_statuses = ['accepted', 'checked_in', 'attended'] if is_event else ['accepted']
+        active_statuses = (
+            ['accepted', 'checked_in', 'attended']
+            if is_event
+            else ['accepted']
+        )
         has_access = Handshake.objects.filter(
             service=service, requester=user, status__in=active_statuses
         ).exists()
@@ -5167,6 +5235,16 @@ class GroupChatViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         """Get the last 50 messages for the group chat."""
         service = self._get_service_or_403(request, pk)
+        participant_users = [service.user]
+        accepted_participants = list(
+            User.objects.filter(
+                id__in=Handshake.objects.filter(service=service, status='accepted')
+                .values_list('requester_id', flat=True)
+            ).distinct()
+        )
+        participant_users.extend(
+            user for user in accepted_participants if user.id != service.user_id
+        )
         msgs = (
             ServiceGroupChatMessage.objects
             .filter(service=service)
@@ -5174,7 +5252,13 @@ class GroupChatViewSet(viewsets.ViewSet):
             .order_by('-created_at')[:50]
         )
         serializer = ServiceGroupChatMessageSerializer(list(reversed(list(msgs))), many=True)
-        return Response({'service_id': str(service.id), 'messages': serializer.data})
+        participants_serializer = GroupChatParticipantSerializer(participant_users, many=True)
+        return Response({
+            'service_id': str(service.id),
+            'service_title': service.title,
+            'participants': participants_serializer.data,
+            'messages': serializer.data,
+        })
 
     @track_performance
     def create(self, request, pk=None):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -3556,15 +3556,27 @@ class ChatViewSet(viewsets.ViewSet):
         ).order_by('-updated_at')
 
         service_ids = list({handshake.service_id for handshake in handshakes})
-        accepted_counts_by_service = {
-            row['service_id']: row['accepted_count']
-            for row in Handshake.objects.filter(
+        active_member_counts_by_service = {}
+        if service_ids:
+            candidate_rows = Handshake.objects.filter(
                 service_id__in=service_ids,
-                status='accepted',
-            ).values('service_id').annotate(
-                accepted_count=Count('requester_id', distinct=True)
+                status__in=['accepted', 'checked_in', 'attended'],
+            ).values('service_id', 'service__type', 'status').annotate(
+                member_count=Count('requester_id', distinct=True)
             )
-        }
+
+            for row in candidate_rows:
+                service_id = row['service_id']
+                service_type = row['service__type']
+                status_value = row['status']
+                if service_type == 'Event':
+                    active_member_counts_by_service[service_id] = (
+                        active_member_counts_by_service.get(service_id, 0) + row['member_count']
+                    )
+                elif status_value == 'accepted':
+                    active_member_counts_by_service[service_id] = (
+                        active_member_counts_by_service.get(service_id, 0) + row['member_count']
+                    )
 
         conversations = []
         for handshake in handshakes:
@@ -3622,7 +3634,7 @@ class ChatViewSet(viewsets.ViewSet):
                 'user_has_reviewed': user_has_reviewed,
                 'max_participants': handshake.service.max_participants,
                 'schedule_type': handshake.service.schedule_type,
-                'service_member_count': 1 + accepted_counts_by_service.get(handshake.service_id, 0),
+                'service_member_count': 1 + active_member_counts_by_service.get(handshake.service_id, 0),
             })
 
         page = paginator.paginate_queryset(conversations, request)

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 from api.models import (
     ChatMessage, Handshake, Notification, ReputationRep, Comment,
     Service, Tag, User, UserBadge, ForumCategory, ForumTopic, ForumPost,
-    Report, AdminAuditLog,
+    Report, AdminAuditLog, ServiceMedia,
 )
 from api.achievement_utils import check_and_assign_badges
 from api.services import HandshakeService
@@ -42,6 +42,7 @@ demo_users = User.objects.filter(email__in=demo_emails)
 if demo_users.exists():
     print(f"  Removing data for {demo_users.count()} demo users...")
     user_ids = list(demo_users.values_list('id', flat=True))
+    ServiceMedia.objects.filter(service__user_id__in=user_ids).delete()
     Service.objects.filter(user_id__in=user_ids).delete()
     Handshake.objects.filter(Q(requester_id__in=user_ids) | Q(service__user_id__in=user_ids)).delete()
     Notification.objects.filter(user_id__in=user_ids).delete()
@@ -94,7 +95,59 @@ print(f"  Processed {len(tags_data)} tags ({created_count} created)")
 
 print("\n[3/8] Creating demo users with Turkish names...")
 
-def create_or_update_user(email, first_name, last_name, bio, balance, karma, date_joined_offset_days=0):
+def dicebear_avatar(seed):
+    return f"https://api.dicebear.com/9.x/avataaars/svg?seed={seed}"
+
+
+def picsum_image(seed, width, height):
+    return f"https://picsum.photos/seed/{seed}/{width}/{height}"
+
+
+def semantic_service_image(service, width=800, height=600):
+    title = service.title.lower()
+    semantic_presets = [
+        (('manti', 'börek', 'coffee', 'cooking'), ('turkish-food,cooking', 101)),
+        (('guitar', 'music'), ('guitar,music', 102)),
+        (('jogging', 'running', 'sports'), ('running,fitness', 103)),
+        (('watercolor', 'painting', 'art'), ('painting,art', 104)),
+        (('gardening', 'plant', 'balcony'), ('gardening,plants', 105)),
+        (('photography', 'camera', 'photo'), ('photography,camera', 106)),
+        (('chess',), ('chess,board-game', 107)),
+        (('language', 'english', 'turkish', 'french'), ('language,conversation', 108)),
+        (('genealogy', 'history', 'archive'), ('books,history', 109)),
+        (('smartphone', 'tech', 'app', 'printer'), ('technology,devices', 110)),
+    ]
+
+    category = 'community,workshop'
+    lock = 199
+    for keywords, preset in semantic_presets:
+        if any(keyword in title for keyword in keywords):
+            category, lock = preset
+            break
+
+    return f"https://loremflickr.com/{width}/{height}/{category}?lock={lock}"
+
+
+def is_fixed_group_offer(service):
+    return (
+        service.type == 'Offer'
+        and service.schedule_type == 'One-Time'
+        and service.max_participants > 1
+    )
+
+
+def create_or_update_user(
+    email,
+    first_name,
+    last_name,
+    bio,
+    balance,
+    karma,
+    date_joined_offset_days=0,
+    avatar_url=None,
+    banner_url=None,
+    location=None,
+):
     user, created = User.objects.get_or_create(
         email=email,
         defaults={
@@ -102,6 +155,9 @@ def create_or_update_user(email, first_name, last_name, bio, balance, karma, dat
             'first_name': first_name,
             'last_name': last_name,
             'bio': bio,
+            'avatar_url': avatar_url,
+            'banner_url': banner_url,
+            'location': location,
             'timebank_balance': balance,
             'karma_score': karma,
             'role': 'member',
@@ -116,6 +172,9 @@ def create_or_update_user(email, first_name, last_name, bio, balance, karma, dat
         user.first_name = first_name
         user.last_name = last_name
         user.bio = bio
+        user.avatar_url = avatar_url
+        user.banner_url = banner_url
+        user.location = location
         user.is_verified = True
         user.is_onboarded = True
         user.set_password('demo123')
@@ -128,49 +187,73 @@ def create_or_update_user(email, first_name, last_name, bio, balance, karma, dat
 elif_user = create_or_update_user(
     'elif@demo.com', 'Elif', 'Yılmaz',
     'Freelance designer and cooking enthusiast living in Beşiktaş. Love sharing traditional Turkish recipes and learning about Istanbul\'s food culture!',
-    Decimal('6.50'), 35, date_joined_offset_days=45
+    Decimal('6.50'), 35, date_joined_offset_days=45,
+    avatar_url=dicebear_avatar('elif'),
+    banner_url=picsum_image('elif-banner', 1200, 400),
+    location='Beşiktaş, Istanbul',
 )
 
 cem = create_or_update_user(
     'cem@demo.com', 'Cem', 'Demir',
     'University student in Kadıköy passionate about chess and genealogy research. Always happy to teach beginners and help trace family histories!',
-    Decimal('4.00'), 18, date_joined_offset_days=30
+    Decimal('4.00'), 18, date_joined_offset_days=30,
+    avatar_url=dicebear_avatar('cem'),
+    banner_url=picsum_image('cem-banner', 1200, 400),
+    location='Kadıköy, Istanbul',
 )
 
 ayse = create_or_update_user(
     'ayse@demo.com', 'Ayşe', 'Kaya',
     'Gardening enthusiast and community organizer in Üsküdar. Passionate about sustainable living and urban farming. Love sharing knowledge about growing food in small spaces!',
-    Decimal('7.00'), 42, date_joined_offset_days=60
+    Decimal('7.00'), 42, date_joined_offset_days=60,
+    avatar_url=dicebear_avatar('ayse'),
+    banner_url=picsum_image('ayse-banner', 1200, 400),
+    location='Üsküdar, Istanbul',
 )
 
 mehmet = create_or_update_user(
     'mehmet@demo.com', 'Mehmet', 'Özkan',
     'Retired teacher living in Şişli. Expert in genealogy research and Istanbul history. Enjoy helping others discover their family roots and learn about our city\'s rich past.',
-    Decimal('8.50'), 55, date_joined_offset_days=90
+    Decimal('8.50'), 55, date_joined_offset_days=90,
+    avatar_url=dicebear_avatar('mehmet'),
+    banner_url=picsum_image('mehmet-banner', 1200, 400),
+    location='Şişli, Istanbul',
 )
 
 zeynep = create_or_update_user(
     'zeynep@demo.com', 'Zeynep', 'Arslan',
     'Language teacher and cultural exchange enthusiast. Fluent in Turkish, English, and French. Love connecting people through language and helping others practice conversation in a friendly, relaxed setting.',
-    Decimal('9.00'), 68, date_joined_offset_days=75
+    Decimal('9.00'), 68, date_joined_offset_days=75,
+    avatar_url=dicebear_avatar('zeynep'),
+    banner_url=picsum_image('zeynep-banner', 1200, 400),
+    location='Beyoğlu, Istanbul',
 )
 
 can = create_or_update_user(
     'can@demo.com', 'Can', 'Şahin',
     'Photography hobbyist based in Beşiktaş. Specialize in Istanbul landmarks and street photography. Happy to share tips on composition, lighting, and capturing the city\'s unique character.',
-    Decimal('5.50'), 28, date_joined_offset_days=25
+    Decimal('5.50'), 28, date_joined_offset_days=25,
+    avatar_url=dicebear_avatar('can'),
+    banner_url=picsum_image('can-banner', 1200, 400),
+    location='Beşiktaş, Istanbul',
 )
 
 deniz = create_or_update_user(
     'deniz@demo.com', 'Deniz', 'Aydın',
     'Tech-savvy professional in Kadıköy. Enjoy helping others with smartphones, apps, and basic tech troubleshooting. Patient teacher for all skill levels!',
-    Decimal('5.00'), 22, date_joined_offset_days=20
+    Decimal('5.00'), 22, date_joined_offset_days=20,
+    avatar_url=dicebear_avatar('deniz'),
+    banner_url=picsum_image('deniz-banner', 1200, 400),
+    location='Kadıköy, Istanbul',
 )
 
 burak = create_or_update_user(
     'burak@demo.com', 'Burak', 'Kurt',
     'Chess player and music lover. Intermediate level chess player looking to improve and teach others. Also enjoy discussing music and sharing recommendations.',
-    Decimal('4.50'), 15, date_joined_offset_days=15
+    Decimal('4.50'), 15, date_joined_offset_days=15,
+    avatar_url=dicebear_avatar('burak'),
+    banner_url=picsum_image('burak-banner', 1200, 400),
+    location='Kadıköy, Istanbul',
 )
 
 all_users = [elif_user, cem, ayse, mehmet, zeynep, can, deniz, burak]
@@ -184,6 +267,9 @@ def get_tag(tag_id, tag_name):
         return Tag.objects.get(name=tag_name)
 
 cooking_tag = get_tag('Q8476', 'Cooking')
+music_tag = get_tag('Q11424', 'Music')
+sports_tag = get_tag('Q11461', 'Sports')
+art_tag = get_tag('Q11019', 'Art')
 chess_tag = get_tag('Q7186', 'Chess')
 education_tag = get_tag('Q11465', 'Education')
 technology_tag = get_tag('Q11466', 'Technology')
@@ -191,7 +277,53 @@ gardening_tag = get_tag('Q11467', 'Gardening')
 language_tag = get_tag('Q2013', 'Language')
 photography_tag = get_tag('Q11631', 'Photography')
 
+print("  Enriching user profiles...")
+user_skill_map = {
+    'elif@demo.com': [cooking_tag, art_tag],
+    'cem@demo.com': [chess_tag, education_tag],
+    'ayse@demo.com': [gardening_tag, art_tag, education_tag],
+    'mehmet@demo.com': [education_tag, technology_tag],
+    'zeynep@demo.com': [language_tag, education_tag, cooking_tag],
+    'can@demo.com': [photography_tag, art_tag],
+    'deniz@demo.com': [technology_tag, sports_tag],
+    'burak@demo.com': [music_tag, chess_tag],
+}
+user_portfolio_map = {
+    'elif@demo.com': [
+        picsum_image('elif-portfolio-1', 600, 400),
+        picsum_image('elif-portfolio-2', 600, 400),
+    ],
+    'ayse@demo.com': [
+        picsum_image('ayse-portfolio-1', 600, 400),
+        picsum_image('ayse-portfolio-2', 600, 400),
+        picsum_image('ayse-portfolio-3', 600, 400),
+    ],
+    'can@demo.com': [
+        picsum_image('can-portfolio-1', 600, 400),
+        picsum_image('can-portfolio-2', 600, 400),
+    ],
+    'zeynep@demo.com': [
+        picsum_image('zeynep-portfolio-1', 600, 400),
+    ],
+}
+
+for user in all_users:
+    user.skills.set(user_skill_map[user.email])
+    user.portfolio_images = user_portfolio_map.get(user.email, [])
+    user.save(update_fields=['portfolio_images'])
+
 services = []
+now = timezone.now()
+
+manti_demo_time = now - timedelta(days=1, hours=2)
+borek_demo_time = now - timedelta(days=3, hours=1)
+gardening_demo_time = now - timedelta(days=2, hours=3)
+photography_demo_time = now - timedelta(days=1, hours=5)
+
+manti_seed_time = now + timedelta(days=2)
+borek_seed_time = now + timedelta(days=3)
+gardening_seed_time = now + timedelta(days=4)
+photography_seed_time = now + timedelta(days=5)
 
 elif_manti = Service.objects.create(
     user=elif_user,
@@ -205,6 +337,8 @@ elif_manti = Service.objects.create(
     location_lng=Decimal('29.0089'),
     max_participants=3,
     schedule_type='One-Time',
+    scheduled_time=manti_seed_time,
+    schedule_details='This week at 18:30 in my Beşiktaş kitchen',
     status='Active',
     created_at=timezone.now() - timedelta(days=20),
 )
@@ -224,7 +358,8 @@ elif_borek = Service.objects.create(
     location_lng=Decimal('29.0089'),
     max_participants=2,
     schedule_type='One-Time',
-    schedule_details='Next Saturday at 14:00',
+    scheduled_time=borek_seed_time,
+    schedule_details='This week at 14:00 in Beşiktaş',
     status='Active',
     created_at=timezone.now() - timedelta(days=5),
 )
@@ -301,7 +436,8 @@ ayse_gardening = Service.objects.create(
     location_lng=Decimal('29.0125'),
     max_participants=3,
     schedule_type='One-Time',
-    schedule_details='Next Saturday at 10:00',
+    scheduled_time=gardening_seed_time,
+    schedule_details='This week at 10:00 in Üsküdar',
     status='Active',
     created_at=timezone.now() - timedelta(days=8),
 )
@@ -412,7 +548,8 @@ can_photography = Service.objects.create(
     location_lng=Decimal('29.0089'),
     max_participants=2,
     schedule_type='One-Time',
-    schedule_details='Next Sunday morning for best light',
+    scheduled_time=photography_seed_time,
+    schedule_details='This week at golden hour in Beşiktaş',
     status='Active',
     created_at=timezone.now() - timedelta(days=7),
 )
@@ -480,7 +617,88 @@ burak_chess.tags.set([chess_tag])
 services.append(burak_chess)
 print(f"  Created: {burak_chess.title}")
 
+burak_guitar = Service.objects.create(
+    user=burak,
+    title='Guitar Basics for Beginners',
+    description='Friendly beginner guitar session covering tuning, basic chords, strumming rhythm, and a simple song to practice at home. Bring your own guitar if you have one, or I can provide a spare acoustic for the lesson.',
+    type='Offer',
+    duration=Decimal('1.50'),
+    location_type='In-Person',
+    location_area='Kadıköy',
+    location_lat=Decimal('40.9819'),
+    location_lng=Decimal('29.0244'),
+    max_participants=2,
+    schedule_type='One-Time',
+    scheduled_time=now + timedelta(days=5, hours=2),
+    schedule_details='Next Tuesday at 19:00 in Kadıköy',
+    status='Active',
+    created_at=timezone.now() - timedelta(days=11),
+)
+burak_guitar.tags.set([music_tag])
+services.append(burak_guitar)
+print(f"  Created: {burak_guitar.title}")
+
+deniz_jogging = Service.objects.create(
+    user=deniz,
+    title='Morning Jogging Partner in Kadıköy',
+    description='Looking for a reliable jogging partner for easy-paced morning runs along the Kadıköy coast. Hoping to stay consistent, keep each other motivated, and gradually build up endurance together.',
+    type='Need',
+    duration=Decimal('1.00'),
+    location_type='In-Person',
+    location_area='Kadıköy',
+    location_lat=Decimal('40.9819'),
+    location_lng=Decimal('29.0244'),
+    max_participants=1,
+    schedule_type='Recurrent',
+    schedule_details='Weekdays at 07:00',
+    status='Active',
+    created_at=timezone.now() - timedelta(days=4),
+)
+deniz_jogging.tags.set([sports_tag])
+services.append(deniz_jogging)
+print(f"  Created: {deniz_jogging.title}")
+
+ayse_watercolor = Service.objects.create(
+    user=ayse,
+    title='Watercolor Painting for Beginners',
+    description='A calm beginner-friendly watercolor session focused on brush control, color mixing, and simple botanical illustrations. Great for anyone curious about painting and looking for a relaxed creative workshop.',
+    type='Offer',
+    duration=Decimal('2.00'),
+    location_type='In-Person',
+    location_area='Üsküdar',
+    location_lat=Decimal('41.0214'),
+    location_lng=Decimal('29.0125'),
+    max_participants=3,
+    schedule_type='One-Time',
+    scheduled_time=now + timedelta(days=7, hours=1),
+    schedule_details='Next Sunday at 13:00 in Üsküdar',
+    status='Active',
+    created_at=timezone.now() - timedelta(days=13),
+)
+ayse_watercolor.tags.set([art_tag])
+services.append(ayse_watercolor)
+print(f"  Created: {ayse_watercolor.title}")
+
 print(f"\n  Created {len(services)} services")
+
+print("  Adding service cover images...")
+service_media_specs = [
+    elif_manti,
+    elif_borek,
+    ayse_gardening,
+    can_photography,
+    burak_guitar,
+    deniz_jogging,
+    ayse_watercolor,
+]
+for service in service_media_specs:
+    ServiceMedia.objects.create(
+        service=service,
+        media_type='image',
+        file_url=semantic_service_image(service),
+        display_order=0,
+    )
+print(f"  Added {len(service_media_specs)} service cover images")
 
 print("\n[5/8] Creating handshakes and completing workflows...")
 
@@ -505,9 +723,14 @@ def simulate_handshake_workflow(service, requester, provider_initiated_days_ago=
         }
         
         handshake.provider_initiated = True
-        handshake.exact_location = exact_locations.get(service.location_area, f'{service.location_area} area')
-        handshake.exact_duration = service.duration
-        handshake.scheduled_time = timezone.now() + timedelta(days=3)
+        if is_fixed_group_offer(service):
+            handshake.exact_location = service.location_area
+            handshake.exact_duration = service.duration
+            handshake.scheduled_time = service.scheduled_time
+        else:
+            handshake.exact_location = exact_locations.get(service.location_area, f'{service.location_area} area')
+            handshake.exact_duration = service.duration
+            handshake.scheduled_time = timezone.now() + timedelta(days=3)
         handshake.updated_at = created_at_time + timedelta(hours=2)
         handshake.save()
         
@@ -607,6 +830,20 @@ def simulate_handshake_workflow(service, requester, provider_initiated_days_ago=
         traceback.print_exc()
         return None, False
 
+
+def sync_fixed_group_offer_time(service, scheduled_time):
+    """Backdate the demo-facing session time after seed workflows are created."""
+    Service.objects.filter(pk=service.pk).update(scheduled_time=scheduled_time)
+    Handshake.objects.filter(
+        service=service,
+        status__in=['pending', 'accepted', 'completed', 'reported', 'paused'],
+    ).update(
+        scheduled_time=scheduled_time,
+        exact_location=service.location_area,
+        exact_duration=service.duration,
+    )
+    service.refresh_from_db(fields=['scheduled_time'])
+
 completed_handshakes = []
 accepted_handshakes = []
 pending_handshakes = []
@@ -626,6 +863,8 @@ handshake1, completed = simulate_handshake_workflow(
 if handshake1 and completed:
     completed_handshakes.append(handshake1)
     print(f"  Completed: {elif_manti.title} (Elif -> Cem)")
+if handshake15 or handshake1:
+    sync_fixed_group_offer_time(elif_manti, manti_demo_time)
 
 handshake2, completed = simulate_handshake_workflow(
     cem_genealogy, mehmet, provider_initiated_days_ago=10, completed_days_ago=5
@@ -640,6 +879,8 @@ handshake3, completed = simulate_handshake_workflow(
 if handshake3 and completed:
     completed_handshakes.append(handshake3)
     print(f"  Completed: {ayse_gardening.title} (Ayşe -> Elif)")
+if handshake3:
+    sync_fixed_group_offer_time(ayse_gardening, gardening_demo_time)
 
 handshake4, completed = simulate_handshake_workflow(
     mehmet_tech, deniz, provider_initiated_days_ago=4, completed_days_ago=1
@@ -661,6 +902,8 @@ handshake6, completed = simulate_handshake_workflow(
 if handshake6 and completed:
     completed_handshakes.append(handshake6)
     print(f"  Completed: {can_photography.title} (Can -> Burak)")
+if handshake6:
+    sync_fixed_group_offer_time(can_photography, photography_demo_time)
 
 handshake7, completed = simulate_handshake_workflow(
     elif_borek, zeynep, provider_initiated_days_ago=3, completed_days_ago=0
@@ -668,6 +911,8 @@ handshake7, completed = simulate_handshake_workflow(
 if handshake7 and completed:
     completed_handshakes.append(handshake7)
     print(f"  Completed: {elif_borek.title} (Elif -> Zeynep)")
+if handshake7:
+    sync_fixed_group_offer_time(elif_borek, borek_demo_time)
 
 handshake8, completed = simulate_handshake_workflow(
     cem_chess_offer, burak, provider_initiated_days_ago=16, completed_days_ago=12
@@ -728,9 +973,11 @@ except Exception as e:
     print(f"  Could not create pending handshake: {e}")
 
 try:
-    pending2 = HandshakeService.express_interest(mehmet_tech, deniz)
+    pending2 = HandshakeService.express_interest(burak_guitar, deniz)
+    pending2.created_at = timezone.now() - timedelta(hours=12)
+    pending2.save(update_fields=['created_at'])
     pending_handshakes.append(pending2)
-    print(f"  Pending: {mehmet_tech.title} (Mehmet -> Deniz)")
+    print(f"  Pending: {burak_guitar.title} (Burak -> Deniz)")
 except Exception as e:
     print(f"  Could not create pending handshake: {e}")
 
@@ -752,6 +999,8 @@ reputation_data = [
 ]
 
 for handshake, giver, receiver, punctual, helpful, kind, comment in reputation_data:
+    if handshake is None:
+        continue
     try:
         rep = ReputationRep.objects.create(
             handshake=handshake,
@@ -906,6 +1155,9 @@ admin_user = User.objects.create_superuser(
     first_name='Moderator',
     last_name='Admin',
     bio='Platform moderator and administrator',
+    avatar_url=dicebear_avatar('moderator'),
+    banner_url=picsum_image('moderator-banner', 1200, 400),
+    location='Beyoğlu, Istanbul',
     timebank_balance=Decimal('10.00'),
     karma_score=100,
     role='admin',
@@ -914,6 +1166,7 @@ admin_user = User.objects.create_superuser(
     is_verified=True,
     is_onboarded=True,
 )
+admin_user.skills.set([technology_tag, education_tag])
 print(f"  Created: {admin_email} (Admin account)")
 
 print("\n[10/10] Creating admin-testable data (reports + audit logs)...")
@@ -1029,8 +1282,9 @@ print("\n" + "=" * 60)
 print("Demo setup complete!")
 print("=" * 60)
 print(f"\nSummary:")
-print(f"  Users: {len(all_users)}")
+print(f"  Users: {len(all_users) + 1}")
 print(f"  Services: {len(services)}")
+print(f"  Service Media: {ServiceMedia.objects.count()}")
 print(f"  Completed Handshakes: {len(completed_handshakes)}")
 print(f"  Accepted Handshakes: {len(accepted_handshakes)}")
 print(f"  Pending Handshakes: {len(pending_handshakes)}")

--- a/frontend/src/components/HandshakeDetailsModal.tsx
+++ b/frontend/src/components/HandshakeDetailsModal.tsx
@@ -16,9 +16,14 @@ interface Props {
   onSubmit: (data: InitiatePayload) => Promise<void>
   serviceType?: string
   scheduledTime?: string | null
+  presetDetails?: {
+    exactLocation: string
+    exactDuration: number
+    scheduledTime: string
+  } | null
 }
 
-export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, scheduledTime }: Props) {
+export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, scheduledTime, presetDetails }: Props) {
   const [location, setLocation] = useState('')
   const [duration, setDuration] = useState<number>(1)
   const [date, setDate] = useState('')
@@ -59,10 +64,30 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
     )
   }
 
+  const isPresetMode = !!presetDetails
+
   const minDate = new Date().toISOString().slice(0, 10)
 
   const handleSubmit = async () => {
     setError(null)
+    if (isPresetMode && presetDetails) {
+      setLoading(true)
+      try {
+        await onSubmit({
+          exact_location: presetDetails.exactLocation,
+          exact_duration: presetDetails.exactDuration,
+          scheduled_time: presetDetails.scheduledTime,
+        })
+        onClose()
+      } catch (e: unknown) {
+        const err = e as { response?: { data?: { detail?: string } }; message?: string }
+        setError(err?.response?.data?.detail ?? err?.message ?? 'Failed to initiate handshake.')
+      } finally {
+        setLoading(false)
+      }
+      return
+    }
+
     if (!location.trim()) { setError('Location is required.'); return }
     if (!date || !time) { setError('Scheduled date and time are required.'); return }
     if (duration <= 0) { setError('Duration must be greater than 0.'); return }
@@ -105,67 +130,93 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
         onClick={(e) => e.stopPropagation()}
       >
         <Text fontSize="17px" fontWeight={700} color="gray.800" mb={1}>
-          Initiate Handshake
+          {isPresetMode ? 'Use Group Offer Details' : 'Initiate Handshake'}
         </Text>
         <Text fontSize="13px" color="gray.500" mb={5}>
-          Provide session details. The requester will review and approve.
+          {isPresetMode
+            ? 'This group offer already has a fixed location and date. The requester will review and approve these preset details.'
+            : 'Provide session details. The requester will review and approve.'
+          }
         </Text>
 
-        <Stack gap={4}>
-          <Box>
-            <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
-              Exact Location
-            </Text>
-            <Input
-              placeholder="e.g. Beşiktaş Library, Room 3"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              size="sm"
-              borderRadius="8px"
-            />
-          </Box>
-
-          <Box>
-            <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
-              Duration (hours)
-            </Text>
-            <Input
-              type="number"
-              min={0.5}
-              step={0.5}
-              value={duration}
-              onChange={(e) => setDuration(parseFloat(e.target.value) || 0)}
-              size="sm"
-              borderRadius="8px"
-              w="120px"
-            />
-          </Box>
-
-          <Box>
-            <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
-              Scheduled Date & Time
-            </Text>
-            <Flex gap={2}>
+        {isPresetMode && presetDetails ? (
+          <Stack gap={4}>
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>Location</Text>
+              <Box px={3} py={2.5} borderRadius="8px" bg="gray.50" border="1px solid" borderColor="gray.200">
+                <Text fontSize="13px" color="gray.800">{presetDetails.exactLocation}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>Duration</Text>
+              <Box px={3} py={2.5} borderRadius="8px" bg="gray.50" border="1px solid" borderColor="gray.200">
+                <Text fontSize="13px" color="gray.800">{presetDetails.exactDuration}h</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>Scheduled Date & Time</Text>
+              <Box px={3} py={2.5} borderRadius="8px" bg="gray.50" border="1px solid" borderColor="gray.200">
+                <Text fontSize="13px" color="gray.800">{formatEventDateTime(presetDetails.scheduledTime)}</Text>
+              </Box>
+            </Box>
+          </Stack>
+        ) : (
+          <Stack gap={4}>
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
+                Exact Location
+              </Text>
               <Input
-                type="date"
-                min={minDate}
-                value={date}
-                onChange={(e) => setDate(e.target.value)}
+                placeholder="e.g. Beşiktaş Library, Room 3"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
                 size="sm"
                 borderRadius="8px"
-                flex={1}
               />
+            </Box>
+
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
+                Duration (hours)
+              </Text>
               <Input
-                type="time"
-                value={time}
-                onChange={(e) => setTime(e.target.value)}
+                type="number"
+                min={0.5}
+                step={0.5}
+                value={duration}
+                onChange={(e) => setDuration(parseFloat(e.target.value) || 0)}
                 size="sm"
                 borderRadius="8px"
                 w="120px"
               />
-            </Flex>
-          </Box>
-        </Stack>
+            </Box>
+
+            <Box>
+              <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
+                Scheduled Date & Time
+              </Text>
+              <Flex gap={2}>
+                <Input
+                  type="date"
+                  min={minDate}
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  size="sm"
+                  borderRadius="8px"
+                  flex={1}
+                />
+                <Input
+                  type="time"
+                  value={time}
+                  onChange={(e) => setTime(e.target.value)}
+                  size="sm"
+                  borderRadius="8px"
+                  w="120px"
+                />
+              </Flex>
+            </Box>
+          </Stack>
+        )}
 
         {error && (
           <Text fontSize="12px" color="red.500" mt={3}>
@@ -184,7 +235,7 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
             loading={loading}
             style={{ background: '#16a34a', color: 'white' }}
           >
-            Send Details
+            {isPresetMode ? 'Share Fixed Details' : 'Send Details'}
           </Button>
         </Flex>
       </Box>

--- a/frontend/src/components/HandshakeDetailsModal.tsx
+++ b/frontend/src/components/HandshakeDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Box,
   Text,
@@ -21,15 +21,35 @@ interface Props {
     exactDuration: number
     scheduledTime: string
   } | null
+  /** Original post duration (hours). Used for Offer/Need to guide/validate agreed duration. */
+  serviceDuration?: number | null
 }
 
-export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, scheduledTime, presetDetails }: Props) {
+const isOfferOrNeed = (t?: string) => t === 'Offer' || t === 'Need'
+
+export function HandshakeDetailsModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  serviceType,
+  scheduledTime,
+  presetDetails,
+  serviceDuration,
+}: Props) {
   const [location, setLocation] = useState('')
   const [duration, setDuration] = useState<number>(1)
   const [date, setDate] = useState('')
   const [time, setTime] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const useStrictDuration = isOfferOrNeed(serviceType) && serviceDuration != null
+
+  useEffect(() => {
+    if (!isOpen || presetDetails) return
+    if (useStrictDuration && serviceDuration != null) {
+      setDuration(serviceDuration)
+    }
+  }, [isOpen, presetDetails, serviceDuration, useStrictDuration])
 
   if (!isOpen) return null
 
@@ -91,6 +111,10 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
     if (!location.trim()) { setError('Location is required.'); return }
     if (!date || !time) { setError('Scheduled date and time are required.'); return }
     if (duration <= 0) { setError('Duration must be greater than 0.'); return }
+    if (useStrictDuration && serviceDuration != null && duration !== serviceDuration) {
+      setError(`Duration must match the original post duration of ${serviceDuration}h.`)
+      return
+    }
 
     const scheduled_time = `${date}T${time}:00`
     const now = new Date()
@@ -179,6 +203,11 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
               <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
                 Duration (hours)
               </Text>
+              {useStrictDuration && serviceDuration != null && (
+                <Text fontSize="11px" color="gray.500" mb={2}>
+                  Original post: {serviceDuration}h
+                </Text>
+              )}
               <Input
                 type="number"
                 min={0.5}
@@ -188,6 +217,7 @@ export function HandshakeDetailsModal({ isOpen, onClose, onSubmit, serviceType, 
                 size="sm"
                 borderRadius="8px"
                 w="120px"
+                disabled={useStrictDuration}
               />
             </Box>
 

--- a/frontend/src/components/MultiUseDetailsModal.tsx
+++ b/frontend/src/components/MultiUseDetailsModal.tsx
@@ -1,0 +1,141 @@
+import { Box, Flex, Text } from '@chakra-ui/react'
+import { FiX } from 'react-icons/fi'
+import {
+  GRAY100, GRAY200, GRAY400, GRAY500, GRAY700, GRAY800, GRAY900, GREEN, GREEN_LT, WHITE,
+} from '@/theme/tokens'
+
+export interface MultiUseDetailItem {
+  id: string
+  title: string
+  subtitle?: string
+  meta?: string
+  value?: string
+  avatarUrl?: string | null
+  onClick?: () => void
+}
+
+function initials(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('') || '?'
+}
+
+export default function MultiUseDetailsModal({
+  isOpen,
+  title,
+  subtitle,
+  items,
+  onClose,
+}: {
+  isOpen: boolean
+  title: string
+  subtitle?: string
+  items: MultiUseDetailItem[]
+  onClose: () => void
+}) {
+  if (!isOpen) return null
+
+  return (
+    <Box position="fixed" inset="0" zIndex={1400}>
+      <Box position="absolute" inset="0" bg="rgba(15,23,42,0.48)" onClick={onClose} />
+      <Flex position="relative" h="100%" align="center" justify="center" p={4}>
+        <Box
+          w="100%"
+          maxW="560px"
+          maxH="min(80vh, 720px)"
+          overflow="hidden"
+          borderRadius="20px"
+          bg={WHITE}
+          border={`1px solid ${GRAY200}`}
+          boxShadow="0 24px 64px rgba(15,23,42,0.24)"
+        >
+          <Flex px={5} py={4} align="flex-start" justify="space-between" gap={4} borderBottom={`1px solid ${GRAY100}`}>
+            <Box>
+              <Text fontSize="18px" fontWeight={800} color={GRAY900}>{title}</Text>
+              {subtitle && <Text mt={1} fontSize="13px" color={GRAY500}>{subtitle}</Text>}
+            </Box>
+            <Box
+              as="button"
+              onClick={onClose}
+              w="36px"
+              h="36px"
+              borderRadius="10px"
+              bg={GRAY100}
+              color={GRAY700}
+              border={`1px solid ${GRAY200}`}
+              style={{ cursor: 'pointer' }}
+            >
+              <Flex align="center" justify="center" h="100%">
+                <FiX size={16} />
+              </Flex>
+            </Box>
+          </Flex>
+
+          <Box px={5} py={3} overflowY="auto" maxH="calc(min(80vh, 720px) - 88px)">
+            {items.map((item, index) => (
+              <Flex
+                key={item.id}
+                align="center"
+                gap={3}
+                py={3}
+                borderTop={index === 0 ? 'none' : `1px solid ${GRAY100}`}
+                onClick={item.onClick}
+                style={{ cursor: item.onClick ? 'pointer' : 'default' }}
+              >
+                {item.avatarUrl ? (
+                  <Box
+                    w="38px"
+                    h="38px"
+                    borderRadius="full"
+                    flexShrink={0}
+                    style={{ backgroundImage: `url(${item.avatarUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+                  />
+                ) : (
+                  <Flex
+                    w="38px"
+                    h="38px"
+                    borderRadius="full"
+                    flexShrink={0}
+                    align="center"
+                    justify="center"
+                    bg={GREEN_LT}
+                    color={GREEN}
+                    fontSize="12px"
+                    fontWeight={800}
+                  >
+                    {initials(item.title)}
+                  </Flex>
+                )}
+
+                <Box flex={1} minW={0}>
+                  <Text fontSize="13px" fontWeight={700} color={GRAY800} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
+                    {item.title}
+                  </Text>
+                  {item.subtitle && (
+                    <Text fontSize="12px" color={GRAY500} mt="2px">
+                      {item.subtitle}
+                    </Text>
+                  )}
+                  {item.meta && (
+                    <Text fontSize="11px" color={GRAY400} mt="2px">
+                      {item.meta}
+                    </Text>
+                  )}
+                </Box>
+
+                {item.value && (
+                  <Text fontSize="12px" fontWeight={800} color={GRAY700} flexShrink={0}>
+                    {item.value}
+                  </Text>
+                )}
+              </Flex>
+            ))}
+          </Box>
+        </Box>
+      </Flex>
+    </Box>
+  )
+}

--- a/frontend/src/components/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm.tsx
@@ -433,13 +433,23 @@ export default function ServiceForm({
   const [eventDateTimeError, setEventDateTimeError] = useState<string | undefined>()
 
   const schema = useMemo(() => getSchema(type), [type])
-  const { register, handleSubmit, control, watch, trigger, reset, formState: { errors } } = useForm<FormValues>({
+  const { register, handleSubmit, control, watch, trigger, reset, setValue, formState: { errors } } = useForm<FormValues>({
     resolver: zodResolver(schema) as Resolver<FormValues>,
     defaultValues: { location_type: 'In-Person', schedule_type: 'One-Time', max_participants: 1 },
   })
 
   const locType   = watch('location_type')
   const schedType = watch('schedule_type')
+  const maxParticipants = watch('max_participants')
+  const isGroupOffer = type === 'Offer' && Number(maxParticipants) > 1
+  const isFixedGroupOffer = type === 'Offer' && schedType === 'One-Time' && Number(maxParticipants) > 1
+  const [onlineLocation, setOnlineLocation] = useState('')
+
+  useEffect(() => {
+    if (isGroupOffer && schedType === 'Recurrent') {
+      setValue('schedule_type', 'One-Time', { shouldDirty: true, shouldValidate: true })
+    }
+  }, [isGroupOffer, schedType, setValue])
 
   const addTag = (tag: Tag) => {
     setSelectedTags((prev) => {
@@ -473,9 +483,15 @@ export default function ServiceForm({
           lng,
         })
       }
+    } else if (initialService.location_type === 'Online') {
+      setOnlineLocation(initialService.location_area ?? '')
     }
 
-    if (initialService.type === 'Event' && initialService.scheduled_time) {
+    if ((initialService.type === 'Event' || (
+      initialService.type === 'Offer'
+      && initialService.schedule_type === 'One-Time'
+      && initialService.max_participants > 1
+    )) && initialService.scheduled_time) {
       const scheduledDate = new Date(initialService.scheduled_time)
       if (!Number.isNaN(scheduledDate.getTime())) {
         const year = scheduledDate.getFullYear()
@@ -606,18 +622,25 @@ export default function ServiceForm({
         setLocationError('Please search and select a location')
         return
       }
+    } else if (isFixedGroupOffer && !onlineLocation.trim()) {
+      setLocationError('Please enter the meeting link or platform')
+      return
     }
     setLocationError(undefined)
 
-    // Validate scheduled_time for Events
-    if (type === 'Event') {
+    // Validate scheduled_time for Events and fixed group offers
+    if (type === 'Event' || isFixedGroupOffer) {
       if (!eventDate || !eventTime) {
-        setEventDateTimeError('Please select both a date and time for the event')
+        setEventDateTimeError(type === 'Event'
+          ? 'Please select both a date and time for the event'
+          : 'Please select the exact date and time for this group offer')
         return
       }
       const scheduledMs = new Date(`${eventDate}T${eventTime}:00`).getTime()
       if (scheduledMs <= Date.now()) {
-        setEventDateTimeError('Event date/time must be in the future')
+        setEventDateTimeError(type === 'Event'
+          ? 'Event date/time must be in the future'
+          : 'Group offer date/time must be in the future')
         return
       }
       setEventDateTimeError(undefined)
@@ -661,10 +684,12 @@ export default function ServiceForm({
           fd.append('location_area', locationValue.label.slice(0, 100))
           fd.append('location_lat', locationValue.lat.toFixed(6))
           fd.append('location_lng', locationValue.lng.toFixed(6))
+        } else if (values.location_type === 'Online' && isFixedGroupOffer) {
+          fd.append('location_area', onlineLocation.trim().slice(0, 100))
         } else {
           fd.append('location_area', '')
         }
-        if (type === 'Event' && eventDate && eventTime) {
+        if ((type === 'Event' || isFixedGroupOffer) && eventDate && eventTime) {
           fd.append('scheduled_time', new Date(`${eventDate}T${eventTime}:00`).toISOString())
         }
         tagIds.forEach((id) => fd.append('tag_ids', id))
@@ -704,11 +729,13 @@ export default function ServiceForm({
           // Round to 6 decimal places — backend DecimalField(max_digits=9, decimal_places=6)
           fd.append('location_lat',  locationValue.lat.toFixed(6))
           fd.append('location_lng',  locationValue.lng.toFixed(6))
+        } else if (values.location_type === 'Online' && isFixedGroupOffer) {
+          fd.append('location_area', onlineLocation.trim().slice(0, 100))
         }
         fd.append('max_participants', type === 'Need' ? '1' : String(values.max_participants))
         fd.append('schedule_type', type === 'Event' ? 'One-Time' : values.schedule_type)
         if (values.schedule_details) fd.append('schedule_details', values.schedule_details)
-        if (type === 'Event' && eventDate && eventTime) {
+        if ((type === 'Event' || isFixedGroupOffer) && eventDate && eventTime) {
           // Send as UTC ISO string so the backend stores the correct absolute time
           // regardless of the server's TIME_ZONE setting.
           fd.append('scheduled_time', new Date(`${eventDate}T${eventTime}:00`).toISOString())
@@ -815,6 +842,11 @@ export default function ServiceForm({
                   _focus={{ borderColor: accent, boxShadow: `0 0 0 2px ${accent}18` }}
                 />
                 <ErrTxt msg={errors.max_participants?.message} />
+                {isGroupOffer && (
+                  <Text fontSize="11px" color={GRAY400} mt="5px">
+                    Group offers are one-time only. Recurring is disabled when max participants is greater than 1.
+                  </Text>
+                )}
               </Box>
               )}
             </Grid>
@@ -853,11 +885,28 @@ export default function ServiceForm({
               </Box>
             )}
 
-            {type === 'Event' ? (
+            {locType === 'Online' && isFixedGroupOffer && (
+              <Box>
+                <Label required>
+                  <FiMapPin size={12} style={{ display: 'inline', marginRight: 5 }} />
+                  Meeting link or platform
+                </Label>
+                <Input
+                  placeholder="e.g. Zoom link, Google Meet, Discord server"
+                  value={onlineLocation}
+                  onChange={(e) => { setOnlineLocation(e.target.value); setLocationError(undefined) }}
+                  style={inputStyle}
+                  _focus={{ borderColor: accent, boxShadow: `0 0 0 2px ${accent}18` }}
+                />
+                <ErrTxt msg={locationError} />
+              </Box>
+            )}
+
+            {(type === 'Event' || isFixedGroupOffer) ? (
               <Box>
                 <Label required>
                   <FiCalendar size={12} style={{ display: 'inline', marginRight: 5 }} />
-                  Event Date & Time
+                  {type === 'Event' ? 'Event Date & Time' : 'Group Offer Date & Time'}
                 </Label>
                 <Flex gap={3}>
                   <Box flex={1}>
@@ -880,7 +929,9 @@ export default function ServiceForm({
                 </Flex>
                 {eventDateTimeError && <ErrTxt msg={eventDateTimeError} />}
                 <Text fontSize="11px" color={GRAY400} mt="5px">
-                  Participants can join up until the event starts. 24 hours before the event, check-in opens and self-cancellation is disabled.
+                  {type === 'Event'
+                    ? 'Participants can join up until the event starts. 24 hours before the event, check-in opens and self-cancellation is disabled.'
+                    : 'This exact date/time will be reused for every approved participant. It cannot be customized per handshake.'}
                 </Text>
               </Box>
             ) : (
@@ -897,7 +948,9 @@ export default function ServiceForm({
                       <SegmentedControl
                         value={field.value}
                         onChange={field.onChange}
-                        options={[{ value: 'One-Time', label: 'One-Time' }, { value: 'Recurrent', label: 'Recurring' }]}
+                        options={isGroupOffer
+                          ? [{ value: 'One-Time', label: 'One-Time' }]
+                          : [{ value: 'One-Time', label: 'One-Time' }, { value: 'Recurrent', label: 'Recurring' }]}
                         accent={accent}
                       />
                     )}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -27,6 +27,7 @@ import {
   buildGroupChatWsUrl,
   type ApiChatMessage,
   type ChatConversation,
+  type GroupChatParticipant,
   type GroupChatMessage,
 } from '@/services/conversationAPI'
 import { handshakeAPI, type InitiatePayload } from '@/services/handshakeAPI'
@@ -202,6 +203,14 @@ function isServiceOwner(conv: ChatConversation): boolean {
   return isOffer ? conv.is_provider : !conv.is_provider
 }
 
+function isFixedGroupOffer(conv: ChatConversation): boolean {
+  return conv.service_type === 'Offer' && conv.schedule_type === 'One-Time' && conv.max_participants > 1
+}
+
+function isGroupChatVisibleStatus(status: string): boolean {
+  return ['accepted'].includes(status)
+}
+
 function ConvRow({
   conv, isSelected, onClick,
 }: { conv: ChatConversation; isSelected: boolean; onClick: () => void }) {
@@ -305,12 +314,18 @@ function ServiceGroup({
     isEvent ||
     (representativeConv?.schedule_type === 'One-Time' &&
     representativeConv?.max_participants > 1)
-  const hasActiveParticipant = convs.some((c) =>
+  const hasEligibleParticipant = convs.some((c) =>
     isEvent
       ? ['accepted', 'checked_in', 'attended'].includes(c.status)
-      : c.status === 'accepted'
+      : isGroupChatVisibleStatus(c.status)
   )
-  const showGroupRow = isGroupEligible && hasActiveParticipant
+  const groupMembers = convs.filter((c) =>
+    isEvent
+      ? ['accepted', 'checked_in', 'attended'].includes(c.status)
+      : isGroupChatVisibleStatus(c.status)
+  )
+  const groupMemberCount = representativeConv?.service_member_count ?? groupMembers.length
+  const showGroupRow = isGroupEligible && hasEligibleParticipant
   const groupServiceId = representativeConv?.service_id ?? null
   const isGroupSelected = groupServiceId !== null && selectedGroupServiceId === groupServiceId
 
@@ -389,7 +404,7 @@ function ServiceGroup({
                     {title}
                   </Text>
                   <Text fontSize="11px" color={GRAY500}>
-                    {convs.filter((c) => c.status === 'accepted').length} participant{convs.filter((c) => c.status === 'accepted').length !== 1 ? 's' : ''}
+                    {groupMemberCount} member{groupMemberCount !== 1 ? 's' : ''}
                   </Text>
                 </Box>
                 <Box
@@ -729,6 +744,9 @@ function ActionCard({
     provider_confirmed_complete, receiver_confirmed_complete,
     scheduled_time, exact_location, exact_duration, provisioned_hours,
   } = conv
+  const fixedGroupOffer = isFixedGroupOffer(conv)
+  const previewScheduledTime = scheduled_time ?? conv.service_scheduled_time ?? null
+  const previewLocation = exact_location ?? conv.service_location_area ?? null
 
   // Service owner always initiates (Offer or Want) — requester approves
   const iAmServiceOwner = isServiceOwner(conv)
@@ -911,9 +929,9 @@ function ActionCard({
               <Text fontSize="12px" color={GRAY500}>
                 Waiting for <b>{conv.other_user.name}</b> to approve
               </Text>
-              {scheduled_time && (
+              {previewScheduledTime && (
                 <Text fontSize="11px" color={GRAY400} mt="3px">
-                  📅 {fmtDateTime(scheduled_time)}{exact_location ? `  •  📍 ${exact_location}` : ''}
+                  📅 {fmtDateTime(previewScheduledTime)}{previewLocation ? `  •  📍 ${previewLocation}` : ''}
                 </Text>
               )}
             </Box>
@@ -927,12 +945,18 @@ function ActionCard({
                 <FiZap size={15} />
               </Box>
               <Box>
-                <Text fontSize="13px" fontWeight={700} color={GRAY800}>Propose a session</Text>
-                <Text fontSize="12px" color={GRAY500}>Set a location, date and duration</Text>
+                <Text fontSize="13px" fontWeight={700} color={GRAY800}>
+                  {fixedGroupOffer ? 'Share fixed group details' : 'Propose a session'}
+                </Text>
+                <Text fontSize="12px" color={GRAY500}>
+                  {fixedGroupOffer
+                    ? 'This offer already has a fixed location, date and duration.'
+                    : 'Set a location, date and duration'}
+                </Text>
               </Box>
             </Flex>
             <Flex align="center" gap={2}>
-              <CTA label="Initiate Handshake" bg={GREEN} onClick={onInitiate} />
+              <CTA label={fixedGroupOffer ? 'Share Offer Details' : 'Initiate Handshake'} bg={GREEN} onClick={onInitiate} />
               <CancelBtn onClick={onCancel} loading={isCancelling} />
             </Flex>
           </Flex>
@@ -949,10 +973,12 @@ function ActionCard({
               </Box>
               <Box>
                 <Text fontSize="13px" fontWeight={700} color={GRAY800}>Service owner proposed a session</Text>
-                <Text fontSize="12px" color={GRAY500}>Review the details and approve or decline</Text>
-                {scheduled_time && (
+                <Text fontSize="12px" color={GRAY500}>
+                  {fixedGroupOffer ? 'Review the fixed group-offer details and approve or decline' : 'Review the details and approve or decline'}
+                </Text>
+                {previewScheduledTime && (
                   <Text fontSize="11px" color={GRAY400} mt="3px">
-                    📅 {fmtDateTime(scheduled_time)}{exact_location ? `  •  📍 ${exact_location}` : ''}
+                    📅 {fmtDateTime(previewScheduledTime)}{previewLocation ? `  •  📍 ${previewLocation}` : ''}
                   </Text>
                 )}
               </Box>
@@ -972,7 +998,7 @@ function ActionCard({
             <Box flex={1}>
               <Text fontSize="13px" fontWeight={700} color={GRAY800}>Waiting for the service owner</Text>
               <Text fontSize="12px" color={GRAY500}>
-                <b>{conv.other_user.name}</b> will propose a session time and location
+                <b>{conv.other_user.name}</b> will {fixedGroupOffer ? 'share the fixed group-offer details' : 'propose a session time and location'}
               </Text>
             </Box>
             <CancelBtn onClick={onCancel} loading={isCancelling} />
@@ -1054,13 +1080,14 @@ function MsgBubble({ msg, isMine }: { msg: ApiChatMessage; isMine: boolean }) {
 // ─── Group Chat Thread ────────────────────────────────────────────────────────
 
 function GroupChatThread({
-  serviceId, messages, user, conversations, wsConnected, draft, setDraft, isSending,
+  serviceId, serviceTitle, participants, messages, user, wsConnected, draft, setDraft, isSending,
   sendError, onSend, onKeyDown, inputRef, bottomRef, onBack,
 }: {
   serviceId: string
+  serviceTitle: string
+  participants: GroupChatParticipant[]
   messages: GroupChatMessage[]
   user: { id?: string } | null
-  conversations: ChatConversation[]
   wsConnected: boolean
   draft: string
   setDraft: (v: string) => void
@@ -1072,10 +1099,6 @@ function GroupChatThread({
   bottomRef: React.RefObject<HTMLDivElement | null>
   onBack: () => void
 }) {
-  const serviceConvs = conversations.filter((c) => c.service_id === serviceId)
-  const serviceTitle = serviceConvs[0]?.service_title ?? 'Group Chat'
-  const participants = serviceConvs.filter((c) => c.status === 'accepted')
-
   return (
     <>
       {/* Header */}
@@ -1128,19 +1151,19 @@ function GroupChatThread({
 
           {/* Participant avatars */}
           <Flex align="center" gap={1} flexShrink={0}>
-            {participants.slice(0, 3).map((c) => (
+            {participants.slice(0, 3).map((participant) => (
               <Box
-                key={c.handshake_id}
+                key={participant.id}
                 w="26px" h="26px" borderRadius="full"
                 bg={GREEN} color={WHITE}
                 display="flex" alignItems="center" justifyContent="center"
                 fontSize="10px" fontWeight={700}
                 style={{ overflow: 'hidden', marginLeft: '-6px', border: `2px solid ${WHITE}` }}
-                title={c.other_user.name}
+                title={participant.name}
               >
-                {c.other_user.avatar_url
-                  ? <img src={c.other_user.avatar_url} alt={c.other_user.name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-                  : c.other_user.name.split(' ').map((p: string) => p[0]).join('').toUpperCase().slice(0, 2)
+                {participant.avatar_url
+                  ? <img src={participant.avatar_url} alt={participant.name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                  : participant.name.split(' ').map((p: string) => p[0]).join('').toUpperCase().slice(0, 2)
                 }
               </Box>
             ))}
@@ -1319,6 +1342,8 @@ export default function ChatPage() {
   const [selectedId,           setSelectedId]           = useState<string | null>(paramId ?? null)
   const [groupServiceId,       setGroupServiceId]       = useState<string | null>(null)
   const [groupMessages,        setGroupMessages]        = useState<GroupChatMessage[]>([])
+  const [groupParticipants,    setGroupParticipants]    = useState<GroupChatParticipant[]>([])
+  const [groupServiceTitle,    setGroupServiceTitle]    = useState('Group Chat')
   const [draft,                setDraft]                = useState('')
   const [isSending,            setIsSending]            = useState(false)
   const [sendError,            setSendError]            = useState<string | null>(null)
@@ -1380,7 +1405,11 @@ export default function ChatPage() {
     }
   }, [messages.length, groupMessages.length])
   useEffect(() => { setMessages([]); setSendError(null) }, [selectedId])
-  useEffect(() => { setGroupMessages([]) }, [groupServiceId])
+  useEffect(() => {
+    setGroupMessages([])
+    setGroupParticipants([])
+    setGroupServiceTitle('Group Chat')
+  }, [groupServiceId])
 
   const fetchMessages = useCallback(async (signal: AbortSignal) => {
     if (!selectedId) return
@@ -1391,7 +1420,9 @@ export default function ChatPage() {
   const fetchGroupMessages = useCallback(async (signal: AbortSignal) => {
     if (!groupServiceId) return
     const fetched = await groupChatAPI.getMessages(groupServiceId, signal)
-    setGroupMessages(fetched)
+    setGroupMessages(fetched.messages)
+    setGroupParticipants(fetched.participants)
+    setGroupServiceTitle(fetched.service_title || 'Group Chat')
   }, [groupServiceId])
 
   // Initial load from DB when conversation is selected (so old messages show even when polling is off in dev)
@@ -1668,9 +1699,10 @@ export default function ChatPage() {
             /* ── Group Chat Thread ─────────────────────────────────────────── */
             <GroupChatThread
               serviceId={groupServiceId}
+              serviceTitle={groupServiceTitle}
+              participants={groupParticipants}
               messages={groupMessages}
               user={user}
-              conversations={conversations}
               wsConnected={groupWsConnected}
               draft={draft}
               setDraft={setDraft}
@@ -1852,6 +1884,13 @@ export default function ChatPage() {
         isOpen={showInitiateModal}
         onClose={() => setShowInitiateModal(false)}
         onSubmit={handleInitiate}
+        presetDetails={selectedConv && isFixedGroupOffer(selectedConv) && selectedConv.service_scheduled_time && selectedConv.service_location_area
+          ? {
+              exactLocation: selectedConv.service_location_area,
+              exactDuration: selectedConv.provisioned_hours ?? 0,
+              scheduledTime: selectedConv.service_scheduled_time,
+            }
+          : null}
       />
       {selectedConv?.provider_initiated && (
         <ProviderDetailsModal

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1884,6 +1884,9 @@ export default function ChatPage() {
         isOpen={showInitiateModal}
         onClose={() => setShowInitiateModal(false)}
         onSubmit={handleInitiate}
+        serviceType={selectedConv?.service_type}
+        scheduledTime={selectedConv?.scheduled_time}
+        serviceDuration={selectedConv?.provisioned_hours ?? null}
         presetDetails={selectedConv && isFixedGroupOffer(selectedConv) && selectedConv.service_scheduled_time && selectedConv.service_location_area
           ? {
               exactLocation: selectedConv.service_location_area,

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Box, Flex, Text, Spinner, Stack } from '@chakra-ui/react'
 import {
@@ -19,6 +19,7 @@ import {
   GRAY50, GRAY100, GRAY200, GRAY300, GRAY400, GRAY500, GRAY600, GRAY700, GRAY800,
   WHITE,
 } from '@/theme/tokens'
+import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 
 const AVATAR_PALETTE = [GREEN, BLUE, PURPLE, AMBER, '#0D9488', '#EA580C']
 const avatarBg    = (name: string) => AVATAR_PALETTE[name.charCodeAt(0) % AVATAR_PALETTE.length]
@@ -31,6 +32,68 @@ const fmtDur      = (d: number | string) => `${Number(d)}h`
 function isOwnHistoryItem(item: UserHistoryItem) {
   if (item.service_type === 'Need') return item.was_provider === false
   return item.was_provider === true
+}
+
+interface GroupedHistoryEntry {
+  key: string
+  serviceId: string
+  serviceTitle: string
+  duration: number
+  completedDate: string
+  items: UserHistoryItem[]
+  partnerName: string
+  partnerId: string
+  partnerAvatarUrl?: string | null
+  useCount: number
+  isMultiUse: boolean
+}
+
+function numericDuration(value: number | string) {
+  return Number(value ?? 0)
+}
+
+function isMultiUseHistoryItem(item: UserHistoryItem) {
+  return item.schedule_type === 'One-Time' && item.max_participants > 1
+}
+
+function groupHistoryItems(items: UserHistoryItem[]): GroupedHistoryEntry[] {
+  const groups = new Map<string, GroupedHistoryEntry>()
+
+  for (const item of items) {
+    const isMultiUse = isMultiUseHistoryItem(item)
+    const key = isMultiUse
+      ? item.service_id
+      : `${item.service_id}:${item.partner_id}:${item.completed_date}`
+
+    const existing = groups.get(key)
+    if (existing) {
+      existing.items.push(item)
+      existing.useCount += 1
+      existing.duration = Math.max(existing.duration, numericDuration(item.duration))
+      if (new Date(item.completed_date).getTime() > new Date(existing.completedDate).getTime()) {
+        existing.completedDate = item.completed_date
+      }
+      continue
+    }
+
+    groups.set(key, {
+      key,
+      serviceId: item.service_id,
+      serviceTitle: item.service_title,
+      duration: numericDuration(item.duration),
+      completedDate: item.completed_date,
+      items: [item],
+      partnerName: item.partner_name,
+      partnerId: item.partner_id,
+      partnerAvatarUrl: item.partner_avatar_url,
+      useCount: 1,
+      isMultiUse,
+    })
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) => new Date(b.completedDate).getTime() - new Date(a.completedDate).getTime(),
+  )
 }
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
@@ -90,26 +153,42 @@ function ServiceCard({ service, onNav }: { service: Service; onNav: () => void }
 }
 
 // ── History row ───────────────────────────────────────────────────────────────
-function HistoryRow({ item, canClick, onClick, contextLabel }: { item: UserHistoryItem; canClick: boolean; onClick: () => void; contextLabel: string }) {
-  const col = AVATAR_PALETTE[item.partner_name.charCodeAt(0) % AVATAR_PALETTE.length]
-  const ini = item.partner_name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+function HistoryRow({
+  item,
+  canClick,
+  onClick,
+  onOpenDetails,
+  contextLabel,
+}: {
+  item: GroupedHistoryEntry
+  canClick: boolean
+  onClick: () => void
+  onOpenDetails: () => void
+  contextLabel: string
+}) {
+  const displayPartner = item.isMultiUse ? `${item.useCount} members` : item.partnerName
+  const col = AVATAR_PALETTE[displayPartner.charCodeAt(0) % AVATAR_PALETTE.length]
+  const ini = displayPartner.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+  const handleClick = item.isMultiUse ? onOpenDetails : onClick
   return (
     <Flex align="center" gap={3} py="10px" borderBottom={`1px solid ${GRAY100}`}
       style={{ cursor: canClick ? 'pointer' : 'default' }}
       onMouseEnter={e => { if (canClick) (e.currentTarget as HTMLElement).style.background = GRAY50 }}
       onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = '' }}
-      onClick={canClick ? onClick : undefined}>
-      {item.partner_avatar_url
-        ? <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${item.partner_avatar_url})`, backgroundSize: 'cover' }} />
+      onClick={canClick ? handleClick : undefined}>
+      {item.partnerAvatarUrl
+        ? <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${item.partnerAvatarUrl})`, backgroundSize: 'cover' }} />
         : <Flex w="32px" h="32px" borderRadius="full" flexShrink={0} align="center" justify="center" style={{ background: col, color: WHITE, fontSize: '11px', fontWeight: 700 }}>{ini}</Flex>
       }
       <Box flex={1} minW={0}>
-        <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.service_title}</Text>
-        <Text fontSize="11px" color={GRAY500}>{contextLabel} {item.partner_name}</Text>
+        <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.serviceTitle}</Text>
+        <Text fontSize="11px" color={GRAY500}>
+          {item.isMultiUse ? `${item.useCount} participants in this one-time session` : `${contextLabel} ${item.partnerName}`}
+        </Text>
       </Box>
       <Box textAlign="right" flexShrink={0}>
         <Text fontSize="12px" fontWeight={600} color={GREEN}>{fmtDur(item.duration)}</Text>
-        <Text fontSize="10px" color={GRAY400}>{fmtDate(item.completed_date)}</Text>
+        <Text fontSize="10px" color={GRAY400}>{fmtDate(item.completedDate)}</Text>
       </Box>
     </Flex>
   )
@@ -166,6 +245,7 @@ const PublicProfile = () => {
   const [badges, setBadges]           = useState<BadgeProgress[]>([])
   const [loading, setLoading]         = useState(true)
   const [notFound, setNotFound]       = useState(false)
+  const [selectedHistoryGroup, setSelectedHistoryGroup] = useState<GroupedHistoryEntry | null>(null)
 
   useEffect(() => {
     if (!userId) return
@@ -201,6 +281,9 @@ const PublicProfile = () => {
     return () => ac.abort()
   }, [userId, currentUser, navigate])
 
+  const ownHistory = history.filter(isOwnHistoryItem)
+  const groupedOwnHistory = useMemo(() => groupHistoryItems(ownHistory), [ownHistory])
+
   if (loading || (!notFound && !profileUser)) {
     return <Flex h="calc(100vh - 64px)" align="center" justify="center"><Spinner color={GREEN} size="lg" /></Flex>
   }
@@ -216,7 +299,6 @@ const PublicProfile = () => {
   const offersCount = services.filter(s => s.type === 'Offer').length
   const needsCount  = services.filter(s => s.type === 'Need').length
   const earnedBadges = badges.filter(b => b.earned)
-  const ownHistory = history.filter(isOwnHistoryItem)
   const punctual    = profileUser.punctual_count ?? 0
   const helpful     = profileUser.helpful_count  ?? 0
   const kind        = profileUser.kind_count     ?? 0
@@ -305,7 +387,7 @@ const PublicProfile = () => {
             {([
               [offersCount,         'Offers',    GREEN,  GREEN_LT,  <FiZap    size={14} />],
               [needsCount,          'Needs',     BLUE,   BLUE_LT,   <FiLayers size={14} />],
-              [ownHistory.length,   'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
+              [groupedOwnHistory.length,   'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
               [earnedBadges.length, 'Badges',    PURPLE, PURPLE_LT, <FiAward  size={14} />],
             ] as [number, string, string, string, React.ReactNode][]).map(([val, label, color, bg, icon]) => (
               <Box key={label} bg={WHITE}
@@ -354,17 +436,23 @@ const PublicProfile = () => {
 
               {profileUser.show_history && (
                 <SectionCard mb={0}>
-                  <SectionHead label={`Time Activity (${ownHistory.length})`} />
-                  {ownHistory.length === 0 ? (
+                  <SectionHead label={`Time Activity (${groupedOwnHistory.length})`} />
+                  {groupedOwnHistory.length === 0 ? (
                     <Flex py={8} direction="column" align="center" gap={2}>
                       <FiCheckCircle size={18} color={GRAY300} />
                       <Text fontSize="13px" color={GRAY400}>No time activity on this user&apos;s own services yet</Text>
                     </Flex>
                   ) : (
                     <Box px={4}>
-                      {ownHistory.map((item, i) => (
-                        <HistoryRow key={i} item={item} canClick={!!currentUser} contextLabel="Own service with"
-                          onClick={() => navigate(`/public-profile/${item.partner_id}`)} />
+                      {groupedOwnHistory.map((item) => (
+                        <HistoryRow
+                          key={item.key}
+                          item={item}
+                          canClick={!!currentUser}
+                          contextLabel="Own service with"
+                          onClick={() => navigate(`/public-profile/${item.partnerId}`)}
+                          onOpenDetails={() => setSelectedHistoryGroup(item)}
+                        />
                       ))}
                     </Box>
                   )}
@@ -408,6 +496,27 @@ const PublicProfile = () => {
           </Flex>
         </Box>
       </Box>
+
+      <MultiUseDetailsModal
+        isOpen={!!selectedHistoryGroup}
+        title={selectedHistoryGroup?.serviceTitle ?? 'Session details'}
+        subtitle={selectedHistoryGroup
+          ? `${selectedHistoryGroup.useCount} participants completed this one-time session.`
+          : undefined}
+        onClose={() => setSelectedHistoryGroup(null)}
+        items={(selectedHistoryGroup?.items ?? []).map((item) => ({
+          id: `${item.service_id}:${item.partner_id}:${item.completed_date}`,
+          title: item.partner_name,
+          subtitle: 'Joined this session',
+          meta: fmtDate(item.completed_date),
+          value: fmtDur(item.duration),
+          avatarUrl: item.partner_avatar_url,
+          onClick: currentUser ? () => {
+            setSelectedHistoryGroup(null)
+            navigate(`/public-profile/${item.partner_id}`)
+          } : undefined,
+        }))}
+      />
     </Box>
   )
 }

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -11,6 +11,7 @@ import { userAPI } from '@/services/userAPI'
 import { serviceAPI } from '@/services/serviceAPI'
 import type { User, Service, BadgeProgress } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
+import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
 import {
   GREEN, GREEN_LT,
   AMBER, AMBER_LT,
@@ -28,73 +29,6 @@ const getInitials = (f: string, l: string, e: string) =>
 const joinedYear  = (d?: string) => d ? new Date(d).getFullYear() : null
 const fmtDate     = (d: string) => new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur      = (d: number | string) => `${Number(d)}h`
-
-function isOwnHistoryItem(item: UserHistoryItem) {
-  if (item.service_type === 'Need') return item.was_provider === false
-  return item.was_provider === true
-}
-
-interface GroupedHistoryEntry {
-  key: string
-  serviceId: string
-  serviceTitle: string
-  duration: number
-  completedDate: string
-  items: UserHistoryItem[]
-  partnerName: string
-  partnerId: string
-  partnerAvatarUrl?: string | null
-  useCount: number
-  isMultiUse: boolean
-}
-
-function numericDuration(value: number | string) {
-  return Number(value ?? 0)
-}
-
-function isMultiUseHistoryItem(item: UserHistoryItem) {
-  return item.schedule_type === 'One-Time' && item.max_participants > 1
-}
-
-function groupHistoryItems(items: UserHistoryItem[]): GroupedHistoryEntry[] {
-  const groups = new Map<string, GroupedHistoryEntry>()
-
-  for (const item of items) {
-    const isMultiUse = isMultiUseHistoryItem(item)
-    const key = isMultiUse
-      ? item.service_id
-      : `${item.service_id}:${item.partner_id}:${item.completed_date}`
-
-    const existing = groups.get(key)
-    if (existing) {
-      existing.items.push(item)
-      existing.useCount += 1
-      existing.duration = Math.max(existing.duration, numericDuration(item.duration))
-      if (new Date(item.completed_date).getTime() > new Date(existing.completedDate).getTime()) {
-        existing.completedDate = item.completed_date
-      }
-      continue
-    }
-
-    groups.set(key, {
-      key,
-      serviceId: item.service_id,
-      serviceTitle: item.service_title,
-      duration: numericDuration(item.duration),
-      completedDate: item.completed_date,
-      items: [item],
-      partnerName: item.partner_name,
-      partnerId: item.partner_id,
-      partnerAvatarUrl: item.partner_avatar_url,
-      useCount: 1,
-      isMultiUse,
-    })
-  }
-
-  return Array.from(groups.values()).sort(
-    (a, b) => new Date(b.completedDate).getTime() - new Date(a.completedDate).getTime(),
-  )
-}
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5 }: { children: React.ReactNode; mb?: number }) => (

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -42,6 +42,7 @@ interface ExpectedAgreement {
   counterpart_avatar_url?: string | null
   status: Handshake['status']
   provisioned_hours: number
+  reserved_delta: number
   expected_delta: number
   note: string
 }
@@ -133,7 +134,8 @@ function toExpectedAgreement(handshake: Handshake, currentUserName?: string): Ex
   const counterpartName = handshakeCounterpartName(handshake, currentUserName)
   const counterpartEmail = handshake.counterpart?.email ?? ''
   const isProvider = handshake.is_current_user_provider === true
-  const expectedDelta = isProvider ? hours : -hours
+  const expectedDelta = isProvider ? hours : 0
+  const reservedDelta = isProvider ? 0 : -hours
 
   return {
     id: handshake.id,
@@ -145,10 +147,11 @@ function toExpectedAgreement(handshake: Handshake, currentUserName?: string): Ex
     counterpart_avatar_url: handshake.counterpart?.avatar_url ?? null,
     status: handshake.status,
     provisioned_hours: hours,
+    reserved_delta: reservedDelta,
     expected_delta: expectedDelta,
     note: isProvider
       ? `Time expected after completion`
-      : `Time expected to be deducted after completion`,
+      : `Already reserved at acceptance`,
   }
 }
 
@@ -574,7 +577,7 @@ const TransactionHistoryPage = () => {
                   Active Agreements
                 </Text>
                 <Text fontSize="12px" color={GRAY600}>
-                  Ongoing accepted exchanges. This shows how your available time is expected to change when these sessions are completed.
+                  Ongoing accepted exchanges. Reserved hours are already reflected in your available time; upcoming time only shows what will still change when these sessions are completed.
                 </Text>
               </Box>
               <Box px="10px" py="5px" borderRadius="999px" bg={WHITE} color={BLUE} fontSize="12px" fontWeight={700}>
@@ -631,6 +634,14 @@ const TransactionHistoryPage = () => {
                     flexShrink={0}
                   >
                     <Box textAlign={{ base: 'left', md: 'right' }}>
+                      {agreement.reserved_delta !== 0 && (
+                        <>
+                          <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Reserved now</Text>
+                          <Text fontSize="13px" fontWeight={800} color={RED}>
+                            {formatAmount(agreement.reserved_delta)}
+                          </Text>
+                        </>
+                      )}
                       <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Upcoming</Text>
                       <Text fontSize="13px" fontWeight={800} color={agreement.expected_delta > 0 ? GREEN : agreement.expected_delta < 0 ? RED : GRAY700}>
                         {agreement.expected_delta !== 0 ? formatAmount(agreement.expected_delta) : 'No change'}

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -9,6 +9,7 @@ import { transactionAPI, type TransactionDirection } from '@/services/transactio
 import { handshakeAPI, type Handshake } from '@/services/handshakeAPI'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { Transaction, TransactionSummary } from '@/types'
+import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 import {
   AMBER, AMBER_LT, BLUE, BLUE_LT, GRAY100, GRAY200, GRAY400,
   GRAY50, GRAY500, GRAY600, GRAY700, GRAY800, GRAY900, GREEN, GREEN_LT,
@@ -45,6 +46,20 @@ interface ExpectedAgreement {
   note: string
 }
 
+interface GroupedTransactionRow {
+  key: string
+  serviceId?: string | null
+  primary: Transaction
+  items: Transaction[]
+  amount: number
+  balanceAfter: number
+  createdAt: string
+  counterpartLabel: string
+  counterpartAvatarUrl?: string | null
+  description: string
+  isMultiUse: boolean
+}
+
 function formatHours(value: number): string {
   const absolute = Math.abs(value)
   const formatted = Number.isInteger(absolute) ? absolute.toString() : absolute.toFixed(2).replace(/\.?0+$/, '')
@@ -78,6 +93,20 @@ function counterpartName(transaction: Transaction): string {
   return fullName || counterpart.email || 'Unknown user'
 }
 
+function isMultiUseHandshake(handshake: Handshake) {
+  return handshake.schedule_type === 'One-Time' && (handshake.max_participants ?? 0) > 1
+}
+
+function isMultiUseTransaction(transaction: Transaction, completedCount: number) {
+  return (
+    transaction.transaction_type === 'transfer'
+    && transaction.is_current_user_provider === true
+    && transaction.schedule_type === 'One-Time'
+    && (transaction.max_participants ?? 0) > 1
+    && completedCount > 1
+  )
+}
+
 function handshakeCounterpartName(handshake: Handshake, currentUserName?: string): string {
   const counterpart = handshake.counterpart
   const fullName = counterpart
@@ -104,6 +133,7 @@ function toExpectedAgreement(handshake: Handshake, currentUserName?: string): Ex
   const counterpartName = handshakeCounterpartName(handshake, currentUserName)
   const counterpartEmail = handshake.counterpart?.email ?? ''
   const isProvider = handshake.is_current_user_provider === true
+  const expectedDelta = isProvider ? hours : -hours
 
   return {
     id: handshake.id,
@@ -115,10 +145,10 @@ function toExpectedAgreement(handshake: Handshake, currentUserName?: string): Ex
     counterpart_avatar_url: handshake.counterpart?.avatar_url ?? null,
     status: handshake.status,
     provisioned_hours: hours,
-    expected_delta: isProvider ? hours : 0,
+    expected_delta: expectedDelta,
     note: isProvider
       ? `Time expected after completion`
-      : `Hours already reflected in your available time`,
+      : `Time expected to be deducted after completion`,
   }
 }
 
@@ -174,11 +204,13 @@ function SummaryCard({
   value,
   color,
   bg,
+  signed = false,
 }: {
   label: string
   value: number
   color: string
   bg: string
+  signed?: boolean
 }) {
   return (
     <Box
@@ -205,7 +237,7 @@ function SummaryCard({
         color={color}
         bg={bg}
       >
-        {formatHours(value)}
+        {signed ? formatAmount(value) : formatHours(value)}
       </Box>
     </Box>
   )
@@ -245,6 +277,7 @@ const TransactionHistoryPage = () => {
   const requestIdRef = useRef(0)
   const agreementRequestIdRef = useRef(0)
   const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [handshakes, setHandshakes] = useState<Handshake[]>([])
   const [activeAgreements, setActiveAgreements] = useState<ExpectedAgreement[]>([])
   const [summary, setSummary] = useState<TransactionSummary>(EMPTY_SUMMARY)
   const [direction, setDirection] = useState<TransactionDirection>('all')
@@ -253,6 +286,7 @@ const TransactionHistoryPage = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [isExporting, setIsExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [selectedTransactionGroup, setSelectedTransactionGroup] = useState<GroupedTransactionRow | null>(null)
 
   const totalPages = useMemo(() => Math.max(1, Math.ceil(count / PAGE_SIZE)), [count])
   const exportDisabled = isLoading || isExporting || transactions.length === 0
@@ -262,10 +296,80 @@ const TransactionHistoryPage = () => {
     () => `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim(),
     [user?.first_name, user?.last_name],
   )
-  const expectedBalance = useMemo(
-    () => summary.current_balance + activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0),
-    [summary.current_balance, activeAgreements],
+  const upcomingDelta = useMemo(
+    () => activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0),
+    [activeAgreements],
   )
+  const expectedBalance = useMemo(
+    () => summary.current_balance + upcomingDelta,
+    [summary.current_balance, upcomingDelta],
+  )
+  const completedMultiUseByService = useMemo(() => {
+    const map = new Map<string, Handshake[]>()
+
+    for (const handshake of handshakes) {
+      if (
+        handshake.status !== 'completed'
+        || handshake.is_current_user_provider !== true
+        || !handshake.service_id
+        || !isMultiUseHandshake(handshake)
+      ) {
+        continue
+      }
+
+      const current = map.get(handshake.service_id) ?? []
+      current.push(handshake)
+      map.set(handshake.service_id, current)
+    }
+
+    return map
+  }, [handshakes])
+  const groupedTransactions = useMemo(() => {
+    const groups = new Map<string, GroupedTransactionRow>()
+
+    for (const transaction of transactions) {
+      const completedCount = transaction.service_id
+        ? (completedMultiUseByService.get(transaction.service_id)?.length ?? 0)
+        : 0
+      const shouldGroup = isMultiUseTransaction(transaction, completedCount)
+      const key = shouldGroup ? `${transaction.transaction_type}:${transaction.service_id}` : transaction.id
+      const existing = groups.get(key)
+
+      if (existing) {
+        existing.items.push(transaction)
+        existing.createdAt = new Date(transaction.created_at).getTime() > new Date(existing.createdAt).getTime()
+          ? transaction.created_at
+          : existing.createdAt
+        existing.balanceAfter = transaction.balance_after
+        existing.amount = Math.max(existing.amount, transaction.amount)
+        continue
+      }
+
+      const label = shouldGroup
+        ? `${completedCount} members`
+        : counterpartName(transaction)
+
+      groups.set(key, {
+        key,
+        serviceId: transaction.service_id,
+        primary: transaction,
+        items: [transaction],
+        amount: transaction.amount,
+        balanceAfter: transaction.balance_after,
+        createdAt: transaction.created_at,
+        counterpartLabel: label,
+        counterpartAvatarUrl: shouldGroup ? null : (transaction.counterpart?.avatar_url ?? null),
+        description: shouldGroup
+          ? `Settled once for ${completedCount} participants. Open details to view everyone in this session.`
+          : transaction.description,
+        isMultiUse: shouldGroup,
+      })
+    }
+
+    return Array.from(groups.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    )
+  }, [completedMultiUseByService, transactions])
 
   const fetchTransactions = useCallback(async (signal?: AbortSignal) => {
     const requestId = ++requestIdRef.current
@@ -303,6 +407,7 @@ const TransactionHistoryPage = () => {
     try {
       const handshakes = await handshakeAPI.list(signal)
       if (requestId !== agreementRequestIdRef.current) return
+      setHandshakes(handshakes)
 
       const nextAgreements = handshakes
         .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
@@ -447,7 +552,7 @@ const TransactionHistoryPage = () => {
 
         <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)', xl: 'repeat(4, 1fr)' }} gap={4} mb={6}>
           <SummaryCard label="Time Available" value={summary.current_balance} color={PURPLE} bg={PURPLE_LT} />
-          <SummaryCard label="Upcoming Time" value={expectedBalance} color={BLUE} bg={BLUE_LT} />
+          <SummaryCard label="Upcoming Time" value={expectedBalance} color={BLUE} bg={BLUE_LT} signed />
           <SummaryCard label="Time Received" value={summary.total_earned} color={GREEN} bg={GREEN_LT} />
           <SummaryCard label="Time Shared" value={summary.total_spent} color={RED} bg={RED_LT} />
         </Grid>
@@ -469,13 +574,11 @@ const TransactionHistoryPage = () => {
                   Active Agreements
                 </Text>
                 <Text fontSize="12px" color={GRAY600}>
-                  Ongoing accepted exchanges. Reserved hours are already reflected in your available time; only pending incoming time increases your upcoming time.
+                  Ongoing accepted exchanges. This shows how your available time is expected to change when these sessions are completed.
                 </Text>
               </Box>
               <Box px="10px" py="5px" borderRadius="999px" bg={WHITE} color={BLUE} fontSize="12px" fontWeight={700}>
-                {activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0) > 0
-                  ? `Upcoming +${formatHours(activeAgreements.reduce((sum, item) => sum + item.expected_delta, 0))}`
-                  : 'No upcoming time'}
+                {upcomingDelta !== 0 ? `Upcoming ${formatAmount(upcomingDelta)}` : 'No upcoming change'}
               </Box>
             </Flex>
 
@@ -529,8 +632,11 @@ const TransactionHistoryPage = () => {
                   >
                     <Box textAlign={{ base: 'left', md: 'right' }}>
                       <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase">Upcoming</Text>
-                      <Text fontSize="13px" fontWeight={800} color={agreement.expected_delta > 0 ? GREEN : GRAY700}>
-                        {agreement.expected_delta > 0 ? formatAmount(agreement.expected_delta) : 'No additional change'}
+                      <Text fontSize="13px" fontWeight={800} color={agreement.expected_delta > 0 ? GREEN : agreement.expected_delta < 0 ? RED : GRAY700}>
+                        {agreement.expected_delta !== 0 ? formatAmount(agreement.expected_delta) : 'No change'}
+                      </Text>
+                      <Text fontSize="11px" color={GRAY500} mt="2px">
+                        {agreement.note}
                       </Text>
                     </Box>
                   </Flex>
@@ -575,7 +681,7 @@ const TransactionHistoryPage = () => {
           </Flex>
 
           <Text fontSize="13px" color={GRAY500}>
-            {count === 0 ? '0 entries' : `${count} ${count === 1 ? 'entry' : 'entries'}`}
+            {groupedTransactions.length === 0 ? '0 entries' : `${groupedTransactions.length} ${groupedTransactions.length === 1 ? 'entry' : 'entries'}`}
           </Text>
         </Flex>
 
@@ -607,7 +713,7 @@ const TransactionHistoryPage = () => {
               </Flex>
             </Box>
           </Box>
-        ) : transactions.length === 0 ? (
+        ) : groupedTransactions.length === 0 ? (
           <Box borderRadius="24px" border={`1px solid ${GRAY200}`} bg={WHITE}>
             <EmptyLedgerIllustration />
           </Box>
@@ -624,18 +730,21 @@ const TransactionHistoryPage = () => {
             </Box>
 
             <Box>
-              {transactions.map((transaction, index) => {
-                const tone = amountTone(transaction.amount)
-                const accent = transactionAccent(transaction)
+              {groupedTransactions.map((row, index) => {
+                const tone = amountTone(row.amount)
+                const accent = transactionAccent(row.primary)
                 const Icon = accent.icon
-                const name = counterpartName(transaction)
+                const name = row.counterpartLabel
+                const isClickable = row.isMultiUse
 
                 return (
                   <Box
-                    key={transaction.id}
+                    key={row.key}
                     px={{ base: 4, md: 6 }}
                     py={{ base: 4, md: 5 }}
                     borderTop={index === 0 ? 'none' : `1px solid ${GRAY100}`}
+                    onClick={() => { if (isClickable) setSelectedTransactionGroup(row) }}
+                    style={{ cursor: isClickable ? 'pointer' : 'default' }}
                   >
                     <Box display={{ base: 'block', md: 'none' }}>
                       <Flex justify="space-between" align="flex-start" gap={3} mb={3}>
@@ -644,14 +753,14 @@ const TransactionHistoryPage = () => {
                             <Icon size={16} />
                           </Box>
                           <Box>
-                            <Text fontSize="14px" fontWeight={700} color={GRAY800}>{transaction.service_title ?? transaction.transaction_type_display}</Text>
+                            <Text fontSize="14px" fontWeight={700} color={GRAY800}>{row.primary.service_title ?? row.primary.transaction_type_display}</Text>
                             <Text fontSize="12px" color={GRAY500}>
-                              {formatDate(transaction.created_at)} · {accent.stateLabel}
+                              {formatDate(row.createdAt)} · {accent.stateLabel}
                             </Text>
                           </Box>
                         </Flex>
                         <Box px="10px" py="6px" borderRadius="999px" bg={tone.bg} color={tone.color} fontSize="12px" fontWeight={800}>
-                          {formatAmount(transaction.amount)}
+                          {formatAmount(row.amount)}
                         </Box>
                       </Flex>
 
@@ -659,9 +768,9 @@ const TransactionHistoryPage = () => {
                         <Box>
                           <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Counterpart</Text>
                           <Flex align="center" gap={2}>
-                            {transaction.counterpart ? (
+                            {row.counterpartAvatarUrl ? (
                               <Avatar.Root size="xs">
-                                <Avatar.Image src={transaction.counterpart.avatar_url ?? undefined} alt={name} />
+                                <Avatar.Image src={row.counterpartAvatarUrl ?? undefined} alt={name} />
                                 <Avatar.Fallback name={name} />
                               </Avatar.Root>
                             ) : (
@@ -672,19 +781,19 @@ const TransactionHistoryPage = () => {
                         </Box>
                         <Box>
                           <Text fontSize="11px" color={GRAY400} fontWeight={700} textTransform="uppercase" mb={1}>Time Available</Text>
-                          <Text fontSize="13px" fontWeight={700} color={GRAY800}>{formatHours(transaction.balance_after)}</Text>
+                          <Text fontSize="13px" fontWeight={700} color={GRAY800}>{formatHours(row.balanceAfter)}</Text>
                         </Box>
                       </Grid>
 
-                      <Text fontSize="12px" color={GRAY500} mt={3}>{transaction.description}</Text>
+                      <Text fontSize="12px" color={GRAY500} mt={3}>{row.description}</Text>
                       <Text fontSize="11px" color={GRAY500} mt={1}>
-                        {serviceMeta(transaction.service_type, transaction.is_current_user_provider)}
+                        {serviceMeta(row.primary.service_type, row.primary.is_current_user_provider)}
                       </Text>
                     </Box>
 
                     <Grid display={{ base: 'none', md: 'grid' }} templateColumns="180px 220px minmax(220px, 1fr) 140px 140px" gap={4} alignItems="center">
                       <Box>
-                        <Text fontSize="13px" fontWeight={600} color={GRAY800}>{formatDate(transaction.created_at)}</Text>
+                        <Text fontSize="13px" fontWeight={600} color={GRAY800}>{formatDate(row.createdAt)}</Text>
                         <Text fontSize="11px" color={GRAY500} mt={1}>{accent.stateLabel}</Text>
                       </Box>
 
@@ -693,9 +802,9 @@ const TransactionHistoryPage = () => {
                           <Icon size={16} />
                         </Box>
                         <Flex align="center" gap={2} minW={0}>
-                          {transaction.counterpart ? (
+                          {row.counterpartAvatarUrl ? (
                             <Avatar.Root size="xs">
-                              <Avatar.Image src={transaction.counterpart.avatar_url ?? undefined} alt={name} />
+                              <Avatar.Image src={row.counterpartAvatarUrl ?? undefined} alt={name} />
                               <Avatar.Fallback name={name} />
                             </Avatar.Root>
                           ) : (
@@ -713,7 +822,7 @@ const TransactionHistoryPage = () => {
                               {name}
                             </Text>
                             <Text fontSize="11px" color={GRAY500}>
-                              {transaction.counterpart?.email ?? 'System entry'}
+                              {row.isMultiUse ? `${row.items.length} linked records` : (row.primary.counterpart?.email ?? 'System entry')}
                             </Text>
                           </Box>
                         </Flex>
@@ -721,22 +830,22 @@ const TransactionHistoryPage = () => {
 
                       <Box minW={0}>
                         <Text fontSize="13px" fontWeight={700} color={GRAY800} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
-                          {transaction.service_title ?? 'Manual adjustment'}
+                          {row.primary.service_title ?? 'Manual adjustment'}
                         </Text>
                         <Text fontSize="11px" color={GRAY500} mt={1} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
-                          {serviceMeta(transaction.service_type, transaction.is_current_user_provider)}
+                          {serviceMeta(row.primary.service_type, row.primary.is_current_user_provider)}
                         </Text>
                         <Text fontSize="11px" color={GRAY500} mt={1} whiteSpace="nowrap" overflow="hidden" textOverflow="ellipsis">
-                          {transaction.description}
+                          {row.description}
                         </Text>
                       </Box>
 
                       <Text fontSize="14px" fontWeight={800} color={tone.color}>
-                        {formatAmount(transaction.amount)}
+                        {formatAmount(row.amount)}
                       </Text>
 
                       <Text fontSize="14px" fontWeight={700} color={GRAY800}>
-                        {formatHours(transaction.balance_after)}
+                        {formatHours(row.balanceAfter)}
                       </Text>
                     </Grid>
                   </Box>
@@ -746,7 +855,7 @@ const TransactionHistoryPage = () => {
           </Box>
         )}
 
-        {!isLoading && !error && transactions.length > 0 && (
+        {!isLoading && !error && groupedTransactions.length > 0 && (
           <Flex direction={{ base: 'column', sm: 'row' }} align={{ base: 'stretch', sm: 'center' }} justify="space-between" gap={3} mt={5}>
             <Text fontSize="13px" color={GRAY500}>
               Page {page} of {totalPages}
@@ -800,6 +909,29 @@ const TransactionHistoryPage = () => {
           </Flex>
         )}
       </Box>
+
+      <MultiUseDetailsModal
+        isOpen={!!selectedTransactionGroup}
+        title={selectedTransactionGroup?.primary.service_title ?? 'Session details'}
+        subtitle={selectedTransactionGroup
+          ? `${completedMultiUseByService.get(selectedTransactionGroup.serviceId ?? '')?.length ?? 0} participants completed this one-time session.`
+          : undefined}
+        onClose={() => setSelectedTransactionGroup(null)}
+        items={(
+          selectedTransactionGroup?.serviceId
+            ? (completedMultiUseByService.get(selectedTransactionGroup.serviceId) ?? [])
+            : []
+        ).map((handshake) => ({
+          id: handshake.id,
+          title: handshake.counterpart
+            ? `${handshake.counterpart.first_name} ${handshake.counterpart.last_name}`.trim() || handshake.counterpart.email
+            : handshake.requester_name,
+          subtitle: 'Completed participant',
+          meta: formatDate(handshake.updated_at),
+          value: formatHours(handshake.provisioned_hours),
+          avatarUrl: handshake.counterpart?.avatar_url ?? null,
+        }))}
+      />
     </Box>
   )
 }

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Box, Flex, Text, Input, Textarea, Spinner, Stack } from '@chakra-ui/react'
 import {
@@ -25,6 +25,7 @@ import {
 } from '@/theme/tokens'
 import { getErrorMessage } from '@/services/api'
 import ImageCropModal from '@/components/ImageCropModal'
+import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 
 const AVATAR_PALETTE = [GREEN, BLUE, PURPLE, AMBER, '#0D9488', '#EA580C']
 const avatarBg   = (name: string) => AVATAR_PALETTE[name.charCodeAt(0) % AVATAR_PALETTE.length]
@@ -39,6 +40,68 @@ type ServiceTab = 'offers' | 'needs' | 'history' | 'settings'
 function isOwnHistoryItem(item: UserHistoryItem) {
   if (item.service_type === 'Need') return item.was_provider === false
   return item.was_provider === true
+}
+
+interface GroupedHistoryEntry {
+  key: string
+  serviceId: string
+  serviceTitle: string
+  duration: number
+  completedDate: string
+  items: UserHistoryItem[]
+  partnerName: string
+  partnerId: string
+  partnerAvatarUrl?: string | null
+  useCount: number
+  isMultiUse: boolean
+}
+
+function numericDuration(value: number | string) {
+  return Number(value ?? 0)
+}
+
+function isMultiUseHistoryItem(item: UserHistoryItem) {
+  return item.schedule_type === 'One-Time' && item.max_participants > 1
+}
+
+function groupHistoryItems(items: UserHistoryItem[]): GroupedHistoryEntry[] {
+  const groups = new Map<string, GroupedHistoryEntry>()
+
+  for (const item of items) {
+    const isMultiUse = isMultiUseHistoryItem(item)
+    const key = isMultiUse
+      ? item.service_id
+      : `${item.service_id}:${item.partner_id}:${item.completed_date}`
+
+    const existing = groups.get(key)
+    if (existing) {
+      existing.items.push(item)
+      existing.useCount += 1
+      existing.duration = Math.max(existing.duration, numericDuration(item.duration))
+      if (new Date(item.completed_date).getTime() > new Date(existing.completedDate).getTime()) {
+        existing.completedDate = item.completed_date
+      }
+      continue
+    }
+
+    groups.set(key, {
+      key,
+      serviceId: item.service_id,
+      serviceTitle: item.service_title,
+      duration: numericDuration(item.duration),
+      completedDate: item.completed_date,
+      items: [item],
+      partnerName: item.partner_name,
+      partnerId: item.partner_id,
+      partnerAvatarUrl: item.partner_avatar_url,
+      useCount: 1,
+      isMultiUse,
+    })
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) => new Date(b.completedDate).getTime() - new Date(a.completedDate).getTime(),
+  )
 }
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
@@ -111,25 +174,40 @@ function ServiceCard({ service, onNav }: { service: Service; onNav: () => void }
 }
 
 // ── History row ───────────────────────────────────────────────────────────────
-function HistoryRow({ item, onClick, contextLabel }: { item: UserHistoryItem; onClick: () => void; contextLabel: string }) {
-  const col = AVATAR_PALETTE[item.partner_name.charCodeAt(0) % AVATAR_PALETTE.length]
-  const ini = item.partner_name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+function HistoryRow({
+  item,
+  onNavigate,
+  onOpenDetails,
+  contextLabel,
+}: {
+  item: GroupedHistoryEntry
+  onNavigate: () => void
+  onOpenDetails: () => void
+  contextLabel: string
+}) {
+  const displayPartner = item.isMultiUse ? `${item.useCount} members` : item.partnerName
+  const col = AVATAR_PALETTE[displayPartner.charCodeAt(0) % AVATAR_PALETTE.length]
+  const ini = displayPartner.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+  const handleClick = item.isMultiUse ? onOpenDetails : onNavigate
+
   return (
     <Flex align="center" gap={3} py="10px" borderBottom={`1px solid ${GRAY100}`} style={{ cursor: 'pointer' }}
       onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = GRAY50 }}
       onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = '' }}
-      onClick={onClick}>
-      {item.partner_avatar_url
-        ? <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${item.partner_avatar_url})`, backgroundSize: 'cover', backgroundPosition: 'center' }} />
+      onClick={handleClick}>
+      {item.partnerAvatarUrl
+        ? <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${item.partnerAvatarUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }} />
         : <Flex w="32px" h="32px" borderRadius="full" flexShrink={0} align="center" justify="center" style={{ background: col, color: WHITE, fontSize: '11px', fontWeight: 700 }}>{ini}</Flex>
       }
       <Box flex={1} minW={0}>
-        <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.service_title}</Text>
-        <Text fontSize="11px" color={GRAY500}>{contextLabel} {item.partner_name}</Text>
+        <Text fontSize="13px" fontWeight={600} color={GRAY800} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.serviceTitle}</Text>
+        <Text fontSize="11px" color={GRAY500}>
+          {item.isMultiUse ? `${item.useCount} participants in this one-time session` : `${contextLabel} ${item.partnerName}`}
+        </Text>
       </Box>
       <Box textAlign="right" flexShrink={0}>
         <Text fontSize="12px" fontWeight={600} color={GREEN}>{fmtDur(item.duration)}</Text>
-        <Text fontSize="10px" color={GRAY400}>{fmtDate(item.completed_date)}</Text>
+        <Text fontSize="10px" color={GRAY400}>{fmtDate(item.completedDate)}</Text>
       </Box>
     </Flex>
   )
@@ -206,6 +284,7 @@ const UserProfile = () => {
   const [servicesLoading, setServicesLoading] = useState(true)
   const [historyLoading, setHistoryLoading]   = useState(true)
   const [activeTab, setActiveTab]         = useState<ServiceTab>('offers')
+  const [selectedHistoryGroup, setSelectedHistoryGroup] = useState<GroupedHistoryEntry | null>(null)
 
   // ── Settings / password-change state ─────────────────────────────────────────
   const [pwCurrent, setPwCurrent]       = useState('')
@@ -273,6 +352,9 @@ const UserProfile = () => {
     setCropModal(m => ({ ...m, open: false }))
   }, [])
 
+  const ownHistory = history.filter(isOwnHistoryItem)
+  const groupedOwnHistory = useMemo(() => groupHistoryItems(ownHistory), [ownHistory])
+
   if (!user) {
     return <Flex h="calc(100vh - 64px)" align="center" justify="center"><Spinner color={GREEN} size="lg" /></Flex>
   }
@@ -285,7 +367,6 @@ const UserProfile = () => {
 
   const offersTab  = services.filter(s => s.type === 'Offer' && s.status === 'Active')
   const needsTab   = services.filter(s => s.type === 'Need'  && s.status === 'Active')
-  const ownHistory = history.filter(isOwnHistoryItem)
 
   const handleSave = async () => {
     setSaving(true)
@@ -481,7 +562,7 @@ const UserProfile = () => {
             {([
               [offersTab.length,  'Offers',    GREEN,  GREEN_LT,  <FiZap    size={14} />],
               [needsTab.length,   'Needs',     BLUE,   BLUE_LT,   <FiLayers size={14} />],
-              [ownHistory.length, 'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
+              [groupedOwnHistory.length, 'Exchanges', AMBER,  AMBER_LT,  <FiRepeat size={14} />],
               [badges.filter(b => b.earned).length, 'Badges', PURPLE, PURPLE_LT, <FiAward size={14} />],
             ] as [number, string, string, string, React.ReactNode][]).map(([val, label, color, bg, icon]) => (
               <Box key={label} bg={WHITE}
@@ -618,7 +699,7 @@ const UserProfile = () => {
                 <Flex px={4} pt={3} gap={0} borderBottom={`1px solid ${GRAY100}`} style={{ overflowX: 'auto' }}>
                   <TabBtn active={activeTab === 'offers'}   label={`Offers (${offersTab.length})`}  onClick={() => setActiveTab('offers')} />
                   <TabBtn active={activeTab === 'needs'}    label={`Needs (${needsTab.length})`}    onClick={() => setActiveTab('needs')} />
-                  <TabBtn active={activeTab === 'history'}  label={`History (${ownHistory.length})`}   onClick={() => setActiveTab('history')} />
+                  <TabBtn active={activeTab === 'history'}  label={`History (${groupedOwnHistory.length})`}   onClick={() => setActiveTab('history')} />
                   <TabBtn active={activeTab === 'settings'} label="Settings"                        onClick={() => setActiveTab('settings')} icon={<FiSettings size={12} />} />
                 </Flex>
 
@@ -659,15 +740,21 @@ const UserProfile = () => {
                 {/* ── History ── */}
                 {activeTab === 'history' && (historyLoading ? (
                   <Flex py={10} justify="center"><Spinner color={GREEN} /></Flex>
-                ) : ownHistory.length === 0 ? (
+                ) : groupedOwnHistory.length === 0 ? (
                   <Flex py={10} direction="column" align="center" gap={2}>
                     <FiRepeat size={22} color={GRAY300} />
                     <Text fontSize="13px" color={GRAY400}>No time activity on your own services yet</Text>
                   </Flex>
                 ) : (
                   <Box px={4}>
-                    {ownHistory.map((item, i) => (
-                      <HistoryRow key={i} item={item} contextLabel="Own service with" onClick={() => navigate(`/public-profile/${item.partner_id}`)} />
+                    {groupedOwnHistory.map((item) => (
+                      <HistoryRow
+                        key={item.key}
+                        item={item}
+                        contextLabel="Own service with"
+                        onNavigate={() => navigate(`/public-profile/${item.partnerId}`)}
+                        onOpenDetails={() => setSelectedHistoryGroup(item)}
+                      />
                     ))}
                   </Box>
                 ))}
@@ -865,6 +952,27 @@ const UserProfile = () => {
         title={cropModal.type === 'avatar' ? 'Crop Profile Photo' : 'Crop Banner Image'}
         onConfirm={handleCropConfirm}
         onCancel={handleCropCancel}
+      />
+
+      <MultiUseDetailsModal
+        isOpen={!!selectedHistoryGroup}
+        title={selectedHistoryGroup?.serviceTitle ?? 'Session details'}
+        subtitle={selectedHistoryGroup
+          ? `${selectedHistoryGroup.useCount} participants completed this one-time session.`
+          : undefined}
+        onClose={() => setSelectedHistoryGroup(null)}
+        items={(selectedHistoryGroup?.items ?? []).map((item) => ({
+          id: `${item.service_id}:${item.partner_id}:${item.completed_date}`,
+          title: item.partner_name,
+          subtitle: 'Joined this session',
+          meta: fmtDate(item.completed_date),
+          value: fmtDur(item.duration),
+          avatarUrl: item.partner_avatar_url,
+          onClick: () => {
+            setSelectedHistoryGroup(null)
+            navigate(`/public-profile/${item.partner_id}`)
+          },
+        }))}
       />
     </Box>
   )

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -15,6 +15,7 @@ import type { Service, BadgeProgress, Tag } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import WikidataTagAutocomplete from '@/components/WikidataTagAutocomplete'
 import { tagAPI } from '@/services/tagAPI'
+import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
 import {
   GREEN, GREEN_LT,
   AMBER, AMBER_LT,
@@ -36,73 +37,6 @@ const fmtDate     = (d: string)  => new Date(d).toLocaleDateString('en-GB', { da
 const fmtDur      = (d: number | string) => `${Number(d)}h`
 
 type ServiceTab = 'offers' | 'needs' | 'history' | 'settings'
-
-function isOwnHistoryItem(item: UserHistoryItem) {
-  if (item.service_type === 'Need') return item.was_provider === false
-  return item.was_provider === true
-}
-
-interface GroupedHistoryEntry {
-  key: string
-  serviceId: string
-  serviceTitle: string
-  duration: number
-  completedDate: string
-  items: UserHistoryItem[]
-  partnerName: string
-  partnerId: string
-  partnerAvatarUrl?: string | null
-  useCount: number
-  isMultiUse: boolean
-}
-
-function numericDuration(value: number | string) {
-  return Number(value ?? 0)
-}
-
-function isMultiUseHistoryItem(item: UserHistoryItem) {
-  return item.schedule_type === 'One-Time' && item.max_participants > 1
-}
-
-function groupHistoryItems(items: UserHistoryItem[]): GroupedHistoryEntry[] {
-  const groups = new Map<string, GroupedHistoryEntry>()
-
-  for (const item of items) {
-    const isMultiUse = isMultiUseHistoryItem(item)
-    const key = isMultiUse
-      ? item.service_id
-      : `${item.service_id}:${item.partner_id}:${item.completed_date}`
-
-    const existing = groups.get(key)
-    if (existing) {
-      existing.items.push(item)
-      existing.useCount += 1
-      existing.duration = Math.max(existing.duration, numericDuration(item.duration))
-      if (new Date(item.completed_date).getTime() > new Date(existing.completedDate).getTime()) {
-        existing.completedDate = item.completed_date
-      }
-      continue
-    }
-
-    groups.set(key, {
-      key,
-      serviceId: item.service_id,
-      serviceTitle: item.service_title,
-      duration: numericDuration(item.duration),
-      completedDate: item.completed_date,
-      items: [item],
-      partnerName: item.partner_name,
-      partnerId: item.partner_id,
-      partnerAvatarUrl: item.partner_avatar_url,
-      useCount: 1,
-      isMultiUse,
-    })
-  }
-
-  return Array.from(groups.values()).sort(
-    (a, b) => new Date(b.completedDate).getTime() - new Date(a.completedDate).getTime(),
-  )
-}
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5, overflow = 'hidden' }: { children: React.ReactNode; mb?: number; overflow?: string }) => (

--- a/frontend/src/services/conversationAPI.ts
+++ b/frontend/src/services/conversationAPI.ts
@@ -56,10 +56,13 @@ export interface ChatConversation {
   exact_location: string | null
   exact_duration: number | null
   scheduled_time: string | null
+  service_location_area?: string | null
+  service_scheduled_time?: string | null
   provisioned_hours: number | null
   user_has_reviewed: boolean
   max_participants: number
   schedule_type: string  // 'One-Time' | 'Recurrent'
+  service_member_count?: number
 }
 
 export interface GroupChatMessage {
@@ -70,6 +73,19 @@ export interface GroupChatMessage {
   sender_avatar_url: string | null
   body: string
   created_at: string
+}
+
+export interface GroupChatParticipant {
+  id: string
+  name: string
+  avatar_url: string | null
+}
+
+export interface GroupChatThreadData {
+  service_id: string
+  service_title: string
+  participants: GroupChatParticipant[]
+  messages: GroupChatMessage[]
 }
 
 interface MessagesResponse {
@@ -129,12 +145,17 @@ export const groupChatAPI = {
    * GET /api/group-chat/{serviceId}/ — last 50 messages for the private group chat.
    * Only accessible to users with an accepted handshake (or the service owner).
    */
-  getMessages: async (serviceId: string, signal?: AbortSignal): Promise<GroupChatMessage[]> => {
-    const res = await apiClient.get<{ service_id: string; messages: GroupChatMessage[] }>(
+  getMessages: async (serviceId: string, signal?: AbortSignal): Promise<GroupChatThreadData> => {
+    const res = await apiClient.get<GroupChatThreadData>(
       `/group-chat/${serviceId}/`,
       { signal },
     )
-    return res.data.messages ?? []
+    return {
+      service_id: res.data.service_id,
+      service_title: res.data.service_title,
+      participants: res.data.participants ?? [],
+      messages: res.data.messages ?? [],
+    }
   },
 
   /**

--- a/frontend/src/services/handshakeAPI.ts
+++ b/frontend/src/services/handshakeAPI.ts
@@ -3,8 +3,11 @@ import apiClient from './api'
 export interface Handshake {
   id: string
   service: string | { id: string }
+  service_id?: string
   service_title: string
   service_type?: 'Offer' | 'Need' | 'Event'
+  schedule_type?: 'One-Time' | 'Recurrent'
+  max_participants?: number
   requester: string
   requester_name: string
   provider_name: string

--- a/frontend/src/services/userAPI.ts
+++ b/frontend/src/services/userAPI.ts
@@ -2,8 +2,11 @@ import apiClient from './api'
 import type { User, BadgeProgress, AchievementProgressItem } from '@/types'
 
 export interface UserHistoryItem {
+  service_id: string
   service_title: string
   service_type: 'Offer' | 'Need' | 'Event'
+  schedule_type: 'One-Time' | 'Recurrent'
+  max_participants: number
   duration: number | string
   partner_name: string
   partner_id: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -252,9 +252,13 @@ export interface Notification {
 
 export interface Transaction {
   id: string
+  handshake_id?: string | null
+  service_id?: string | null
   transaction_type: 'provision' | 'transfer' | 'refund' | 'adjustment'
   transaction_type_display: string
   service_type?: 'Offer' | 'Need' | 'Event' | null
+  schedule_type?: 'One-Time' | 'Recurrent' | null
+  max_participants?: number | null
   is_current_user_provider?: boolean
   counterpart: {
     id: string

--- a/frontend/src/utils/historyGrouping.ts
+++ b/frontend/src/utils/historyGrouping.ts
@@ -1,0 +1,68 @@
+import type { UserHistoryItem } from '@/services/userAPI'
+
+export interface GroupedHistoryEntry {
+  key: string
+  serviceId: string
+  serviceTitle: string
+  duration: number
+  completedDate: string
+  items: UserHistoryItem[]
+  partnerName: string
+  partnerId: string
+  partnerAvatarUrl?: string | null
+  useCount: number
+  isMultiUse: boolean
+}
+
+function numericDuration(value: number | string) {
+  return Number(value ?? 0)
+}
+
+function isMultiUseHistoryItem(item: UserHistoryItem) {
+  return item.schedule_type === 'One-Time' && item.max_participants > 1
+}
+
+export function isOwnHistoryItem(item: UserHistoryItem) {
+  if (item.service_type === 'Need') return item.was_provider === false
+  return item.was_provider === true
+}
+
+export function groupHistoryItems(items: UserHistoryItem[]): GroupedHistoryEntry[] {
+  const groups = new Map<string, GroupedHistoryEntry>()
+
+  for (const item of items) {
+    const isMultiUse = isMultiUseHistoryItem(item)
+    const key = isMultiUse
+      ? item.service_id
+      : `${item.service_id}:${item.partner_id}:${item.completed_date}`
+
+    const existing = groups.get(key)
+    if (existing) {
+      existing.items.push(item)
+      existing.useCount += 1
+      existing.duration = Math.max(existing.duration, numericDuration(item.duration))
+      if (new Date(item.completed_date).getTime() > new Date(existing.completedDate).getTime()) {
+        existing.completedDate = item.completed_date
+      }
+      continue
+    }
+
+    groups.set(key, {
+      key,
+      serviceId: item.service_id,
+      serviceTitle: item.service_title,
+      duration: numericDuration(item.duration),
+      completedDate: item.completed_date,
+      items: [item],
+      partnerName: item.partner_name,
+      partnerId: item.partner_id,
+      partnerAvatarUrl: item.partner_avatar_url,
+      useCount: 1,
+      isMultiUse,
+    })
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) => new Date(b.completedDate).getTime() - new Date(a.completedDate).getTime(),
+  )
+}

--- a/scripts/quick-ci.sh
+++ b/scripts/quick-ci.sh
@@ -6,6 +6,7 @@ MODE="${1:-quick}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BACKEND="$ROOT/backend"
 FRONTEND="$ROOT/frontend"
+QUICK_CI_ENV="$ROOT/.env.quick-ci"
 
 log() {
   printf '\n\033[1;34m==> %s\033[0m\n' "$1"
@@ -44,11 +45,16 @@ wait_for_http() {
 wait_for_compose_health() {
   local compose_file="$1"
   local attempts="${2:-30}"
+  local env_args=()
+
+  if [ -n "${COMPOSE_ENV_FILE:-}" ]; then
+    env_args=(--env-file "$COMPOSE_ENV_FILE")
+  fi
 
   for i in $(seq 1 "$attempts"); do
     local unhealthy
     unhealthy="$(
-      docker compose -f "$compose_file" ps --format json \
+      docker compose "${env_args[@]}" -f "$compose_file" ps --format json \
         | python3 -c '
 import sys, json
 rows = [json.loads(line) for line in sys.stdin if line.strip()]
@@ -67,7 +73,7 @@ print("\n".join(bad))
   done
 
   echo "Containers did not become healthy in time." >&2
-  docker compose -f "$compose_file" ps || true
+  docker compose "${env_args[@]}" -f "$compose_file" ps || true
   return 1
 }
 
@@ -174,9 +180,9 @@ run_frontend_quick() {
 }
 
 prepare_root_env_for_docker() {
-  log "Writing root .env for docker"
-  cp "$ROOT/.env.example" "$ROOT/.env"
-  python3 - "$ROOT/.env" <<'PY'
+  log "Writing temporary quick CI env file"
+  cp "$ROOT/.env.example" "$QUICK_CI_ENV"
+  python3 - "$QUICK_CI_ENV" <<'PY'
 from pathlib import Path
 import sys
 
@@ -219,13 +225,13 @@ run_e2e_like_workflow() {
   log "Starting full stack"
   (
     cd "$ROOT"
-    DJANGO_E2E=1 VITE_E2E=1 docker compose up -d --build
+    DJANGO_E2E=1 VITE_E2E=1 docker compose --env-file "$QUICK_CI_ENV" up -d --build
   )
 
-  trap 'cd "$ROOT" && docker compose down -v || true' EXIT
+  trap 'cd "$ROOT" && docker compose --env-file "$QUICK_CI_ENV" down -v || true; rm -f "$QUICK_CI_ENV"' EXIT
 
   log "Waiting for containers"
-  wait_for_compose_health "$ROOT/docker-compose.yml" 24
+  COMPOSE_ENV_FILE="$QUICK_CI_ENV" wait_for_compose_health "$ROOT/docker-compose.yml" 24
 
   log "Smoke API"
   wait_for_http "http://localhost/api/health/" "API health" 20
@@ -236,14 +242,13 @@ run_e2e_like_workflow() {
   log "Seed demo data"
   (
     cd "$ROOT"
-    DJANGO_E2E=1 docker compose exec -T backend \
+    DJANGO_E2E=1 docker compose --env-file "$QUICK_CI_ENV" exec -T backend \
       bash -lc "cd /code && DJANGO_SETTINGS_MODULE=hive_project.settings python setup_demo.py"
   )
 
   log "Frontend install for Playwright"
   (
     cd "$FRONTEND"
-    sudo rm -rf node_modules
     npm ci
     npx playwright install --with-deps chromium
   )

--- a/scripts/quick-ci.sh
+++ b/scripts/quick-ci.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-quick}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND="$ROOT/backend"
+FRONTEND="$ROOT/frontend"
+
+log() {
+  printf '\n\033[1;34m==> %s\033[0m\n' "$1"
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+http_ready() {
+  local url="$1"
+  curl --fail --silent "$url" >/dev/null 2>&1
+}
+
+wait_for_http() {
+  local url="$1"
+  local label="$2"
+  local attempts="${3:-30}"
+
+  for i in $(seq 1 "$attempts"); do
+    if curl --fail --silent "$url" >/dev/null 2>&1; then
+      echo "$label is ready"
+      return 0
+    fi
+    echo "Waiting for $label... ($i/$attempts)"
+    sleep 2
+  done
+
+  echo "$label did not become ready: $url" >&2
+  return 1
+}
+
+wait_for_compose_health() {
+  local compose_file="$1"
+  local attempts="${2:-30}"
+
+  for i in $(seq 1 "$attempts"); do
+    local unhealthy
+    unhealthy="$(
+      docker compose -f "$compose_file" ps --format json \
+        | python3 -c '
+import sys, json
+rows = [json.loads(line) for line in sys.stdin if line.strip()]
+bad = [r["Name"] for r in rows if r.get("Health", "") not in ("healthy", "")]
+print("\n".join(bad))
+'
+    )"
+
+    if [ -z "$unhealthy" ]; then
+      echo "All containers healthy."
+      return 0
+    fi
+
+    echo "Still waiting: $unhealthy ($i/$attempts)"
+    sleep 5
+  done
+
+  echo "Containers did not become healthy in time." >&2
+  docker compose -f "$compose_file" ps || true
+  return 1
+}
+
+ensure_backend_infra() {
+  need_cmd docker
+  need_cmd curl
+  need_cmd python3
+
+  if http_ready "http://localhost:9000/minio/health/live"; then
+    log "Reusing existing local infra"
+    return 0
+  fi
+
+  log "Starting backend infra"
+  docker compose -f "$ROOT/docker-compose.infra.yml" up -d db redis minio
+
+  log "Waiting for backend infra"
+  wait_for_http "http://localhost:9000/minio/health/live" "MinIO" 30
+}
+
+export_backend_local_env() {
+  if [ ! -f "$ROOT/.env" ]; then
+    echo "Missing $ROOT/.env" >&2
+    exit 1
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  . "$ROOT/.env"
+  set +a
+
+  export DB_HOST="${DB_HOST:-localhost}"
+  export DB_PORT="${DB_PORT:-5432}"
+  export REDIS_HOST="${REDIS_HOST:-localhost}"
+  export REDIS_PORT="${REDIS_PORT:-6379}"
+  export MINIO_ENDPOINT="${MINIO_ENDPOINT:-localhost:9000}"
+  export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-hive_project.settings}"
+}
+
+run_backend_quick() {
+  need_cmd python3
+  export_backend_local_env
+
+  log "Backend migrate"
+  (
+    cd "$BACKEND"
+    ./.venv/bin/python manage.py migrate --no-input
+  )
+
+  log "Backend migration checks"
+  (
+    cd "$BACKEND"
+    ./.venv/bin/python manage.py makemigrations --check --dry-run
+    ./.venv/bin/python manage.py migrate --check
+  )
+
+  log "Backend tests"
+  (
+    cd "$BACKEND"
+    mkdir -p tests/reports/coverage
+    ./.venv/bin/pytest -c pytest-ci.ini
+  )
+}
+
+run_frontend_quick() {
+  need_cmd npm
+  need_cmd npx
+
+  log "Frontend install"
+  (
+    cd "$FRONTEND"
+    npm ci
+  )
+
+  log "Frontend audit"
+  (
+    cd "$FRONTEND"
+    npm audit --audit-level=high
+  )
+
+  log "Frontend lint"
+  (
+    cd "$FRONTEND"
+    npm run lint
+  )
+
+  log "Frontend typecheck"
+  (
+    cd "$FRONTEND"
+    npx tsc --noEmit -p tsconfig.app.json
+  )
+
+  log "Frontend unit tests"
+  (
+    cd "$FRONTEND"
+    npm run test -- --run
+  )
+
+  log "Frontend build"
+  (
+    cd "$FRONTEND"
+    VITE_API_URL=/api npm run build
+  )
+}
+
+prepare_root_env_for_docker() {
+  log "Writing root .env for docker"
+  cp "$ROOT/.env.example" "$ROOT/.env"
+  python3 - "$ROOT/.env" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+replacements = {
+    "DB_HOST=localhost": "DB_HOST=db",
+    "REDIS_HOST=localhost": "REDIS_HOST=redis",
+    "MINIO_ENDPOINT=localhost:9000": "MINIO_ENDPOINT=minio:9000",
+}
+
+for old, new in replacements.items():
+    text = text.replace(old, new)
+
+if "SECRET_KEY=ci-e2e-secret-key-not-used-in-production" not in text:
+    text += "\nSECRET_KEY=ci-e2e-secret-key-not-used-in-production"
+if "DEBUG=True" not in text:
+    text += "\nDEBUG=True"
+if "ALLOWED_HOSTS=localhost,127.0.0.1" not in text:
+    text += "\nALLOWED_HOSTS=localhost,127.0.0.1"
+if "DJANGO_E2E=1" not in text:
+    text += "\nDJANGO_E2E=1"
+if "DISABLE_THROTTLING=1" not in text:
+    text += "\nDISABLE_THROTTLING=1"
+
+path.write_text(text + "\n")
+PY
+}
+
+run_e2e_like_workflow() {
+  need_cmd docker
+  need_cmd curl
+  need_cmd npm
+  need_cmd npx
+  need_cmd python3
+
+  prepare_root_env_for_docker
+
+  log "Starting full stack"
+  (
+    cd "$ROOT"
+    DJANGO_E2E=1 VITE_E2E=1 docker compose up -d --build
+  )
+
+  trap 'cd "$ROOT" && docker compose down -v || true' EXIT
+
+  log "Waiting for containers"
+  wait_for_compose_health "$ROOT/docker-compose.yml" 24
+
+  log "Smoke API"
+  wait_for_http "http://localhost/api/health/" "API health" 20
+
+  log "Smoke media proxy"
+  wait_for_http "http://localhost/hive-media/" "MinIO media proxy" 20
+
+  log "Seed demo data"
+  (
+    cd "$ROOT"
+    DJANGO_E2E=1 docker compose exec -T backend \
+      bash -lc "cd /code && DJANGO_SETTINGS_MODULE=hive_project.settings python setup_demo.py"
+  )
+
+  log "Frontend install for Playwright"
+  (
+    cd "$FRONTEND"
+    sudo rm -rf node_modules
+    npm ci
+    npx playwright install --with-deps chromium
+  )
+
+  log "Run Playwright"
+  (
+    cd "$FRONTEND"
+    PLAYWRIGHT_BASE_URL=http://localhost CI=true npm run test:e2e
+  )
+}
+
+case "$MODE" in
+  quick)
+    ensure_backend_infra
+    run_backend_quick
+    run_frontend_quick
+    ;;
+  quick-live)
+    log "Using already running local stack"
+    run_backend_quick
+    run_frontend_quick
+    ;;
+  e2e)
+    run_e2e_like_workflow
+    ;;
+  full)
+    ensure_backend_infra
+    run_backend_quick
+    run_frontend_quick
+    run_e2e_like_workflow
+    ;;
+  *)
+    echo "Usage: $0 [quick|quick-live|e2e|full]" >&2
+    exit 1
+    ;;
+esac
+
+log "Done"


### PR DESCRIPTION
## Summary

Closes #144

- Strengthened the group-offer flow by enforcing fixed date/location requirements for one-time multi-participant offers, preventing handshake-time overrides, and tightening expired-offer visibility and interest rules.
- Enriched chat and conversation payloads with service-level schedule/location data, canonical group participants, and accurate member counts so group chat UI renders consistently for all users.
- Improved multi-use/group-offer accounting and UX across transaction history, active agreements, grouped detail modals, and profile/history surfaces.
- Expanded demo data realism and added a local `quick-ci.sh` helper to run workflow-like checks more easily during development.

## Key changes

- Backend:
  - Added fixed group-offer validation in `ServiceSerializer` for future `scheduled_time` and exact `location_area`.
  - Updated group-offer handshake initiation to always reuse service-level fixed details.
  - Excluded expired one-time group offers from the public feed and blocked new interest on expired offers.
  - Extended group chat responses with canonical participant data and service metadata.
  - Extended conversation list responses with canonical service member counts.
  - Improved multi-use/group transaction handling and related serializer payloads.
  - Updated and expanded integration/unit coverage around services, handshakes, group chat, and transaction behavior.

- Frontend:
  - Updated `ServiceForm` for fixed-schedule group-offer rules and improved online meeting/location handling.
  - Added preset/read-only support to `HandshakeDetailsModal` for fixed group offers.
  - Fixed `ChatPage` group header and left sidebar to use backend-provided participant/member data instead of user-local conversation assumptions.
  - Enhanced `TransactionHistoryPage` with grouped multi-use details, improved active-agreement handling, and corrected upcoming balance delta display.
  - Added `MultiUseDetailsModal`.
  - Updated `UserProfile` and `PublicProfile` to surface grouped/multi-use history details.
  - Extended frontend conversation/handshake/user typings to match the new backend payload shape.

- Tooling and demo data:
  - Enriched `backend/setup_demo.py` with more realistic avatars, banners, skills, media, and semantic service cover images.
  - Added `scripts/quick-ci.sh` with `quick`, `quick-live`, `e2e`, and `full` modes for faster workflow-style local verification.

## Test plan

- Backend:
  - `./backend/.venv/bin/pytest --reuse-db --no-cov api/tests/integration/test_service_api.py`
  - `./backend/.venv/bin/pytest --reuse-db --no-cov api/tests/integration/test_handshake_api.py`
  - `./backend/.venv/bin/pytest --reuse-db --no-cov api/tests/integration/test_chat_api.py api/tests/unit/test_group_chat.py`
  - `./backend/.venv/bin/pytest --reuse-db --no-cov api/tests/unit/test_serializers.py api/tests/unit/test_utils.py`

- Frontend:
  - `cd frontend && npm run lint`
  - `cd frontend && npm run test -- --run`
  - `cd frontend && npm run build`

- Local workflow helper:
  - `./scripts/quick-ci.sh quick-live`