### PR TITLE
feat: categorize profile reviews by role (As Provider / As Taker)

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -20,6 +20,8 @@ import json
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer, OpenApiExample
 from drf_spectacular.types import OpenApiTypes
 
+from .utils import get_provider_and_receiver
+
 logger = logging.getLogger(__name__)
 
 
@@ -2058,6 +2060,7 @@ class CommentSerializer(serializers.ModelSerializer):
     replies = serializers.SerializerMethodField()
     handshake_hours = serializers.SerializerMethodField()
     handshake_completed_at = serializers.SerializerMethodField()
+    reviewed_user_role = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
@@ -2066,6 +2069,7 @@ class CommentSerializer(serializers.ModelSerializer):
             'user_karma_score', 'user_badges', 'user_featured_achievement_id',
             'parent', 'parent_id', 'body', 'is_deleted', 'is_verified_review',
             'handshake_id', 'handshake_hours', 'handshake_completed_at',
+            'reviewed_user_role',
             'reply_count', 'replies', 'created_at', 'updated_at'
         ]
         read_only_fields = [
@@ -2123,6 +2127,20 @@ class CommentSerializer(serializers.ModelSerializer):
         if obj.is_verified_review and obj.related_handshake:
             return obj.related_handshake.updated_at
         return None
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_reviewed_user_role(self, obj):
+        """For verified reviews: role the reviewed user had in the handshake ('provider' or 'receiver')."""
+        if not obj.is_verified_review or not obj.related_handshake:
+            return None
+        handshake = obj.related_handshake
+        service = getattr(handshake, 'service', None) or getattr(obj, 'service', None)
+        if not service or service.type not in ('Offer', 'Need'):
+            return None
+        provider, receiver = get_provider_and_receiver(handshake)
+        if obj.user_id == provider.id:
+            return 'receiver'
+        return 'provider'
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_reply_count(self, obj):

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -197,6 +197,147 @@ class TestUserVerifiedReviewsView:
         assert revealed_response.status_code == status.HTTP_200_OK
         assert revealed_response.data['count'] == 1
 
+    def test_role_filter_offer_provider(self):
+        """Offer: target user is provider; role=provider returns review, role=receiver returns none."""
+        provider = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(user=provider, type='Offer')
+        handshake = HandshakeFactory(service=service, requester=requester, status='completed')
+        ReputationRep.objects.create(
+            handshake=handshake, giver=requester, receiver=provider,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        ReputationRep.objects.create(
+            handshake=handshake, giver=provider, receiver=requester,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        Comment.objects.create(
+            service=service, user=requester, body='Great provider!',
+            is_verified_review=True, related_handshake=handshake,
+        )
+        client = AuthenticatedAPIClient().authenticate_user(provider)
+        r_provider = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'provider'})
+        r_receiver = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'receiver'})
+        assert r_provider.status_code == status.HTTP_200_OK
+        assert r_receiver.status_code == status.HTTP_200_OK
+        assert r_provider.data['count'] == 1
+        assert r_receiver.data['count'] == 0
+        assert r_provider.data['results'][0].get('reviewed_user_role') == 'provider'
+
+    def test_role_filter_offer_receiver(self):
+        """Offer: target user is receiver (requester); role=receiver returns review, role=provider returns none."""
+        provider = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(user=provider, type='Offer')
+        handshake = HandshakeFactory(service=service, requester=requester, status='completed')
+        ReputationRep.objects.create(
+            handshake=handshake, giver=provider, receiver=requester,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        ReputationRep.objects.create(
+            handshake=handshake, giver=requester, receiver=provider,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        Comment.objects.create(
+            service=service, user=provider, body='Great taker!',
+            is_verified_review=True, related_handshake=handshake,
+        )
+        client = AuthenticatedAPIClient().authenticate_user(requester)
+        r_provider = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'provider'})
+        r_receiver = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'receiver'})
+        assert r_provider.status_code == status.HTTP_200_OK
+        assert r_receiver.status_code == status.HTTP_200_OK
+        assert r_provider.data['count'] == 0
+        assert r_receiver.data['count'] == 1
+        assert r_receiver.data['results'][0].get('reviewed_user_role') == 'receiver'
+
+    def test_role_filter_need_provider(self):
+        """Need: target user is provider (requester); role=provider returns review."""
+        need_owner = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(user=need_owner, type='Need')
+        handshake = HandshakeFactory(service=service, requester=requester, status='completed')
+        ReputationRep.objects.create(
+            handshake=handshake, giver=need_owner, receiver=requester,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        ReputationRep.objects.create(
+            handshake=handshake, giver=requester, receiver=need_owner,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        Comment.objects.create(
+            service=service, user=need_owner, body='Great help!',
+            is_verified_review=True, related_handshake=handshake,
+        )
+        client = AuthenticatedAPIClient().authenticate_user(requester)
+        r_provider = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'provider'})
+        r_receiver = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'receiver'})
+        assert r_provider.status_code == status.HTTP_200_OK
+        assert r_receiver.status_code == status.HTTP_200_OK
+        assert r_provider.data['count'] == 1
+        assert r_receiver.data['count'] == 0
+        assert r_provider.data['results'][0].get('reviewed_user_role') == 'provider'
+
+    def test_role_filter_need_receiver(self):
+        """Need: target user is receiver (service owner); role=receiver returns review."""
+        need_owner = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(user=need_owner, type='Need')
+        handshake = HandshakeFactory(service=service, requester=requester, status='completed')
+        ReputationRep.objects.create(
+            handshake=handshake, giver=requester, receiver=need_owner,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        ReputationRep.objects.create(
+            handshake=handshake, giver=need_owner, receiver=requester,
+            is_punctual=True, is_helpful=False, is_kind=False,
+        )
+        Comment.objects.create(
+            service=service, user=requester, body='Thanks for the need!',
+            is_verified_review=True, related_handshake=handshake,
+        )
+        client = AuthenticatedAPIClient().authenticate_user(need_owner)
+        r_provider = client.get(f'/api/users/{need_owner.id}/verified-reviews/', {'role': 'provider'})
+        r_receiver = client.get(f'/api/users/{need_owner.id}/verified-reviews/', {'role': 'receiver'})
+        assert r_provider.status_code == status.HTTP_200_OK
+        assert r_receiver.status_code == status.HTTP_200_OK
+        assert r_provider.data['count'] == 0
+        assert r_receiver.data['count'] == 1
+        assert r_receiver.data['results'][0].get('reviewed_user_role') == 'receiver'
+
+    def test_role_filter_blind_review_visibility_unchanged(self):
+        """Blind review visibility still applies when role filter is used."""
+        provider = UserFactory()
+        requester = UserFactory()
+        service = ServiceFactory(user=provider, type='Offer')
+        handshake = HandshakeFactory(
+            service=service,
+            requester=requester,
+            status='completed',
+            evaluation_window_starts_at=timezone.now() - timedelta(hours=1),
+            evaluation_window_ends_at=timezone.now() + timedelta(hours=47),
+            evaluation_window_closed_at=None,
+        )
+        Comment.objects.create(
+            service=service,
+            user=requester,
+            body='Hidden until reciprocal.',
+            is_verified_review=True,
+            related_handshake=handshake,
+        )
+        ReputationRep.objects.create(
+            handshake=handshake,
+            giver=provider,
+            receiver=requester,
+            is_punctual=True,
+            is_helpful=False,
+            is_kind=False,
+        )
+        client = AuthenticatedAPIClient().authenticate_user(provider)
+        r = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'provider'})
+        assert r.status_code == status.HTTP_200_OK
+        assert r.data['count'] == 1
+
 
 @pytest.mark.django_db
 @pytest.mark.integration

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -7,7 +7,7 @@ import logging
 from decimal import Decimal
 from contextlib import nullcontext
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Q
 
 from .models import Handshake, Notification, Service, User, TransactionHistory
 
@@ -39,6 +39,47 @@ def get_provider_and_receiver(handshake: Handshake) -> tuple[User, User]:
         provider = handshake.requester
         receiver = service.user
     return provider, receiver
+
+
+def get_verified_reviews_role_filter(target_user, role: str):
+    """
+    Return a Q object to filter Comment querysets for verified reviews where the
+    reviewed user (profile owner) had the given role in the handshake.
+    
+    - target_user: User instance or user id (UUID).
+    - role: 'provider' or 'receiver'.
+    
+    Offer: provider = service.user, receiver = requester.
+    Need: provider = requester, receiver = service.user.
+    """
+    target_id = target_user.pk if hasattr(target_user, 'pk') else target_user
+    if role == 'provider':
+        return (
+            Q(
+                related_handshake__service__type='Offer',
+                service__user_id=target_id,
+                related_handshake__requester=F('user'),
+            )
+            | Q(
+                related_handshake__service__type='Need',
+                related_handshake__requester_id=target_id,
+                service__user=F('user'),
+            )
+        )
+    if role == 'receiver':
+        return (
+            Q(
+                related_handshake__service__type='Offer',
+                related_handshake__requester_id=target_id,
+                service__user=F('user'),
+            )
+            | Q(
+                related_handshake__service__type='Need',
+                service__user_id=target_id,
+                related_handshake__requester=F('user'),
+            )
+        )
+    return Q()
 
 
 def provision_timebank(handshake: Handshake) -> bool:

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -73,7 +73,7 @@ from .serializers import (
 from .achievement_utils import get_achievement_progress
 from .utils import (
     can_user_post_offer, provision_timebank, complete_timebank_transfer,
-    cancel_timebank_transfer, create_notification
+    cancel_timebank_transfer, create_notification, get_verified_reviews_role_filter,
 )
 from .services import HandshakeService, EventHandshakeService, EventEvaluationService, EventNoShowAppealService
 from .event_permissions import IsNotEventBanned, IsNotOrganizerBanned
@@ -1297,6 +1297,9 @@ class UserVerifiedReviewsView(APIView):
     
     **GET /api/users/{id}/verified-reviews/** - Get user's verified reviews
     
+    **Query params:** Optional `role=provider` or `role=receiver` to filter by the
+    reviewed user's role in the handshake (provider vs taker/receiver).
+    
     **Response Format:**
     ```json
     {
@@ -1336,14 +1339,20 @@ class UserVerifiedReviewsView(APIView):
         # - Reviews about the requester: handshake.requester == target_user AND comment.user == service.owner
         from django.db.models import F, Q
         from .models import Comment
+        base_filter = (
+            Q(service__user=target_user, related_handshake__requester=F('user'))
+            | Q(related_handshake__requester=target_user, service__user=F('user'))
+        )
+        role_param = (request.query_params.get('role') or '').strip().lower()
+        if role_param in ('provider', 'receiver'):
+            base_filter = base_filter & get_verified_reviews_role_filter(target_user, role_param)
         comments = Comment.objects.filter(
             is_verified_review=True,
             is_deleted=False,
             related_handshake__isnull=False,
-        ).filter(
-            Q(service__user=target_user, related_handshake__requester=F('user'))
-            | Q(related_handshake__requester=target_user, service__user=F('user'))
-        ).select_related('user', 'service', 'related_handshake').prefetch_related(
+        ).filter(base_filter).select_related(
+            'user', 'service', 'related_handshake', 'related_handshake__service'
+        ).prefetch_related(
             Prefetch(
                 'user__badges',
                 queryset=UserBadge.objects.select_related('badge')

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -9,7 +9,7 @@ import {
 import { useAuthStore } from '@/store/useAuthStore'
 import { userAPI } from '@/services/userAPI'
 import { serviceAPI } from '@/services/serviceAPI'
-import type { User, Service, BadgeProgress } from '@/types'
+import type { User, Service, BadgeProgress, ProfileReview } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
 import {
@@ -29,6 +29,41 @@ const getInitials = (f: string, l: string, e: string) =>
 const joinedYear  = (d?: string) => d ? new Date(d).getFullYear() : null
 const fmtDate     = (d: string) => new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur      = (d: number | string) => `${Number(d)}h`
+const timeAgo    = (d: string) => {
+  const sec = (Date.now() - new Date(d).getTime()) / 1000
+  if (sec < 60) return 'just now'
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
+  if (sec < 2592000) return `${Math.floor(sec / 86400)}d ago`
+  return fmtDate(d)
+}
+
+// ── Profile review row ───────────────────────────────────────────────────────
+function ProfileReviewRow({ review }: { review: ProfileReview }) {
+  const col = AVATAR_PALETTE[review.user_name.charCodeAt(0) % AVATAR_PALETTE.length]
+  const ini = review.user_name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+  return (
+    <Flex gap={3} py="10px" borderBottom={`1px solid ${GRAY100}`}>
+      {review.user_avatar_url ? (
+        <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${review.user_avatar_url})`, backgroundSize: 'cover' }} />
+      ) : (
+        <Flex w="32px" h="32px" borderRadius="full" flexShrink={0} align="center" justify="center" style={{ background: col, color: WHITE, fontSize: '11px', fontWeight: 700 }}>{ini}</Flex>
+      )}
+      <Box flex={1} minW={0}>
+        <Flex align="center" gap={2} flexWrap="wrap" mb="4px">
+          <Text fontSize="13px" fontWeight={600} color={GRAY800}>{review.user_name}</Text>
+          <Box px="6px" py="2px" borderRadius="full" fontSize="10px" fontWeight={700} style={{ background: GREEN_LT, color: GREEN }}><FiCheckCircle size={9} style={{ display: 'inline', verticalAlign: 'middle', marginRight: 2 }} />Verified</Box>
+          {review.handshake_hours != null && (
+            <Box px="6px" py="2px" borderRadius="full" fontSize="10px" fontWeight={600} style={{ background: AMBER_LT, color: AMBER }}>{fmtDur(review.handshake_hours)} exchange</Box>
+          )}
+          <Text fontSize="11px" color={GRAY400}>{timeAgo(review.created_at)}</Text>
+        </Flex>
+        {review.service_title && <Text fontSize="11px" color={GRAY500} mb="4px">{review.service_title}</Text>}
+        <Text fontSize="13px" color={GRAY700} lineHeight={1.55}>{review.body}</Text>
+      </Box>
+    </Flex>
+  )
+}
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5 }: { children: React.ReactNode; mb?: number }) => (
@@ -177,6 +212,9 @@ const PublicProfile = () => {
   const [services, setServices]       = useState<Service[]>([])
   const [history, setHistory]         = useState<UserHistoryItem[]>([])
   const [badges, setBadges]           = useState<BadgeProgress[]>([])
+  const [reviewsAsProvider, setReviewsAsProvider] = useState<ProfileReview[]>([])
+  const [reviewsAsTaker, setReviewsAsTaker]       = useState<ProfileReview[]>([])
+  const [reviewsLoading, setReviewsLoading]       = useState(false)
   const [loading, setLoading]         = useState(true)
   const [notFound, setNotFound]       = useState(false)
   const [selectedHistoryGroup, setSelectedHistoryGroup] = useState<GroupedHistoryEntry | null>(null)
@@ -202,6 +240,14 @@ const PublicProfile = () => {
           userAPI.getHistory(userId, ac.signal).then(setHistory).catch(() => {})
         }
         userAPI.getBadgeProgress(userId, ac.signal).then(setBadges).catch(() => {})
+        setReviewsLoading(true)
+        Promise.all([
+          userAPI.getVerifiedReviews(userId, { role: 'provider', signal: ac.signal }),
+          userAPI.getVerifiedReviews(userId, { role: 'receiver', signal: ac.signal }),
+        ]).then(([rProvider, rTaker]) => {
+          setReviewsAsProvider(rProvider.results)
+          setReviewsAsTaker(rTaker.results)
+        }).catch(() => {}).finally(() => setReviewsLoading(false))
       } catch (err) {
         const status = (err as { response?: { status?: number } })?.response?.status
         if (status === 404) setNotFound(true)
@@ -369,7 +415,7 @@ const PublicProfile = () => {
               )}
 
               {profileUser.show_history && (
-                <SectionCard mb={0}>
+                <SectionCard>
                   <SectionHead label={`Time Activity (${groupedOwnHistory.length})`} />
                   {groupedOwnHistory.length === 0 ? (
                     <Flex py={8} direction="column" align="center" gap={2}>
@@ -392,6 +438,32 @@ const PublicProfile = () => {
                   )}
                 </SectionCard>
               )}
+
+              <SectionCard mb={0}>
+                <SectionHead label="Reviews" />
+                {reviewsLoading ? (
+                  <Flex py={8} justify="center"><Spinner color={GREEN} size="sm" /></Flex>
+                ) : (
+                  <Box px={4} py={3}>
+                    <Text fontSize="10px" fontWeight={600} color={GRAY400} textTransform="uppercase" letterSpacing="0.06em" mb={2}>As a Provider</Text>
+                    {reviewsAsProvider.length === 0 ? (
+                      <Text fontSize="12px" color={GRAY400} py={3}>No reviews yet for exchanges where they provided the service.</Text>
+                    ) : (
+                      <Box mb={4}>
+                        {reviewsAsProvider.map((r) => <ProfileReviewRow key={r.id} review={r} />)}
+                      </Box>
+                    )}
+                    <Text fontSize="10px" fontWeight={600} color={GRAY400} textTransform="uppercase" letterSpacing="0.06em" mb={2} mt={4}>As a Taker</Text>
+                    {reviewsAsTaker.length === 0 ? (
+                      <Text fontSize="12px" color={GRAY400} py={3}>No reviews yet for exchanges where they received the service.</Text>
+                    ) : (
+                      <Box>
+                        {reviewsAsTaker.map((r) => <ProfileReviewRow key={r.id} review={r} />)}
+                      </Box>
+                    )}
+                  </Box>
+                )}
+              </SectionCard>
             </Box>
 
             {/* Right column */}

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -4,14 +4,14 @@ import { Box, Flex, Text, Input, Textarea, Spinner, Stack } from '@chakra-ui/rea
 import {
   FiEdit2, FiCamera, FiSave, FiX, FiAward, FiClock, FiMapPin,
   FiCalendar, FiArrowUpRight, FiPlus, FiCheckCircle, FiStar,
-  FiZap, FiLayers, FiRepeat, FiLock, FiSettings, FiMail, FiShield, FiEye, FiEyeOff, FiTag,
+  FiZap, FiLayers, FiRepeat, FiLock, FiSettings, FiMail, FiShield, FiEye, FiEyeOff, FiTag, FiMessageSquare,
 } from 'react-icons/fi'
 import { toast } from 'sonner'
 import { useAuthStore } from '@/store/useAuthStore'
 import { userAPI, dataURLtoBlob } from '@/services/userAPI'
 import { serviceAPI } from '@/services/serviceAPI'
 import { authAPI } from '@/services/authAPI'
-import type { Service, BadgeProgress, Tag } from '@/types'
+import type { Service, BadgeProgress, Tag, ProfileReview } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import WikidataTagAutocomplete from '@/components/WikidataTagAutocomplete'
 import { tagAPI } from '@/services/tagAPI'
@@ -35,8 +35,43 @@ const getInitials = (f: string, l: string, e: string) =>
 const joinedYear  = (d?: string) => d ? new Date(d).getFullYear() : null
 const fmtDate     = (d: string)  => new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur      = (d: number | string) => `${Number(d)}h`
+const timeAgo    = (d: string) => {
+  const sec = (Date.now() - new Date(d).getTime()) / 1000
+  if (sec < 60) return 'just now'
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
+  if (sec < 2592000) return `${Math.floor(sec / 86400)}d ago`
+  return fmtDate(d)
+}
 
-type ServiceTab = 'offers' | 'needs' | 'history' | 'settings'
+// ── Profile review row ───────────────────────────────────────────────────────
+function ProfileReviewRow({ review }: { review: ProfileReview }) {
+  const col = AVATAR_PALETTE[review.user_name.charCodeAt(0) % AVATAR_PALETTE.length]
+  const ini = review.user_name.split(' ').map((n) => n[0]).join('').slice(0, 2).toUpperCase() || '?'
+  return (
+    <Flex gap={3} py="10px" borderBottom={`1px solid ${GRAY100}`}>
+      {review.user_avatar_url ? (
+        <Box w="32px" h="32px" borderRadius="full" flexShrink={0} style={{ backgroundImage: `url(${review.user_avatar_url})`, backgroundSize: 'cover' }} />
+      ) : (
+        <Flex w="32px" h="32px" borderRadius="full" flexShrink={0} align="center" justify="center" style={{ background: col, color: WHITE, fontSize: '11px', fontWeight: 700 }}>{ini}</Flex>
+      )}
+      <Box flex={1} minW={0}>
+        <Flex align="center" gap={2} flexWrap="wrap" mb="4px">
+          <Text fontSize="13px" fontWeight={600} color={GRAY800}>{review.user_name}</Text>
+          <Box px="6px" py="2px" borderRadius="full" fontSize="10px" fontWeight={700} style={{ background: GREEN_LT, color: GREEN }}><FiCheckCircle size={9} style={{ display: 'inline', verticalAlign: 'middle', marginRight: 2 }} />Verified</Box>
+          {review.handshake_hours != null && (
+            <Box px="6px" py="2px" borderRadius="full" fontSize="10px" fontWeight={600} style={{ background: AMBER_LT, color: AMBER }}>{fmtDur(review.handshake_hours)} exchange</Box>
+          )}
+          <Text fontSize="11px" color={GRAY400}>{timeAgo(review.created_at)}</Text>
+        </Flex>
+        {review.service_title && <Text fontSize="11px" color={GRAY500} mb="4px">{review.service_title}</Text>}
+        <Text fontSize="13px" color={GRAY700} lineHeight={1.55}>{review.body}</Text>
+      </Box>
+    </Flex>
+  )
+}
+
+type ServiceTab = 'offers' | 'needs' | 'history' | 'reviews' | 'settings'
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 const SectionCard = ({ children, mb = 5, overflow = 'hidden' }: { children: React.ReactNode; mb?: number; overflow?: string }) => (
@@ -215,6 +250,9 @@ const UserProfile = () => {
   const [services, setServices]           = useState<Service[]>([])
   const [history, setHistory]             = useState<UserHistoryItem[]>([])
   const [badges, setBadges]               = useState<BadgeProgress[]>([])
+  const [reviewsAsProvider, setReviewsAsProvider] = useState<ProfileReview[]>([])
+  const [reviewsAsTaker, setReviewsAsTaker]       = useState<ProfileReview[]>([])
+  const [reviewsLoading, setReviewsLoading]       = useState(false)
   const [servicesLoading, setServicesLoading] = useState(true)
   const [historyLoading, setHistoryLoading]   = useState(true)
   const [activeTab, setActiveTab]         = useState<ServiceTab>('offers')
@@ -249,6 +287,14 @@ const UserProfile = () => {
     userAPI.getHistory(user.id, ac.signal)
       .then(setHistory).catch(() => {}).finally(() => setHistoryLoading(false))
     userAPI.getBadgeProgress(user.id, ac.signal).then(setBadges).catch(() => {})
+    setReviewsLoading(true)
+    Promise.all([
+      userAPI.getVerifiedReviews(user.id, { role: 'provider', signal: ac.signal }),
+      userAPI.getVerifiedReviews(user.id, { role: 'receiver', signal: ac.signal }),
+    ]).then(([rProvider, rTaker]) => {
+      setReviewsAsProvider(rProvider.results)
+      setReviewsAsTaker(rTaker.results)
+    }).catch(() => {}).finally(() => setReviewsLoading(false))
     return () => ac.abort()
   }, [user])
 
@@ -634,6 +680,7 @@ const UserProfile = () => {
                   <TabBtn active={activeTab === 'offers'}   label={`Offers (${offersTab.length})`}  onClick={() => setActiveTab('offers')} />
                   <TabBtn active={activeTab === 'needs'}    label={`Needs (${needsTab.length})`}    onClick={() => setActiveTab('needs')} />
                   <TabBtn active={activeTab === 'history'}  label={`History (${groupedOwnHistory.length})`}   onClick={() => setActiveTab('history')} />
+                  <TabBtn active={activeTab === 'reviews'}  label={`Reviews (${reviewsAsProvider.length + reviewsAsTaker.length})`} onClick={() => setActiveTab('reviews')} icon={<FiMessageSquare size={12} />} />
                   <TabBtn active={activeTab === 'settings'} label="Settings"                        onClick={() => setActiveTab('settings')} icon={<FiSettings size={12} />} />
                 </Flex>
 
@@ -692,6 +739,34 @@ const UserProfile = () => {
                     ))}
                   </Box>
                 ))}
+
+                {/* ── Reviews ── */}
+                {activeTab === 'reviews' && (
+                  <Box px={4} py={3}>
+                    {reviewsLoading ? (
+                      <Flex py={10} justify="center"><Spinner color={GREEN} size="sm" /></Flex>
+                    ) : (
+                      <>
+                        <Text fontSize="10px" fontWeight={600} color={GRAY400} textTransform="uppercase" letterSpacing="0.06em" mb={2}>As a Provider</Text>
+                        {reviewsAsProvider.length === 0 ? (
+                          <Text fontSize="12px" color={GRAY400} py={3}>No reviews yet for exchanges where you provided the service.</Text>
+                        ) : (
+                          <Box mb={4}>
+                            {reviewsAsProvider.map((r) => <ProfileReviewRow key={r.id} review={r} />)}
+                          </Box>
+                        )}
+                        <Text fontSize="10px" fontWeight={600} color={GRAY400} textTransform="uppercase" letterSpacing="0.06em" mb={2} mt={4}>As a Taker</Text>
+                        {reviewsAsTaker.length === 0 ? (
+                          <Text fontSize="12px" color={GRAY400} py={3}>No reviews yet for exchanges where you received the service.</Text>
+                        ) : (
+                          <Box>
+                            {reviewsAsTaker.map((r) => <ProfileReviewRow key={r.id} review={r} />)}
+                          </Box>
+                        )}
+                      </>
+                    )}
+                  </Box>
+                )}
 
                 {/* ── Settings ── */}
                 {activeTab === 'settings' && (

--- a/frontend/src/services/userAPI.ts
+++ b/frontend/src/services/userAPI.ts
@@ -1,5 +1,5 @@
 import apiClient from './api'
-import type { User, BadgeProgress, AchievementProgressItem } from '@/types'
+import type { User, BadgeProgress, AchievementProgressItem, ProfileReviewsResponse } from '@/types'
 
 export interface UserHistoryItem {
   service_id: string
@@ -172,5 +172,27 @@ export const userAPI = {
       { signal },
     )
     return normalizeAchievementProgress(res.data)
+  },
+
+  /**
+   * Get verified reviews for a user profile. Optionally filter by the reviewed user's role
+   * in the handshake (provider vs receiver/taker).
+   */
+  getVerifiedReviews: async (
+    userId: string,
+    options?: { role?: 'provider' | 'receiver'; signal?: AbortSignal },
+  ): Promise<ProfileReviewsResponse> => {
+    const params = options?.role ? { role: options.role } : {}
+    const res = await apiClient.get<ProfileReviewsResponse>(
+      `/users/${userId}/verified-reviews/`,
+      { params, signal: options?.signal },
+    )
+    const data = res.data
+    return {
+      count: data.count ?? data.results?.length ?? 0,
+      results: data.results ?? [],
+      next: data.next ?? null,
+      previous: data.previous ?? null,
+    }
   },
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -274,6 +274,37 @@ export interface Transaction {
   created_at: string
 }
 
+// ─── Profile review (verified reviews on user profile) ───────────────────────
+
+export interface ProfileReview {
+  id: string
+  service: string
+  service_title?: string
+  user_id: string
+  user_name: string
+  user_avatar_url?: string
+  user_karma_score?: number
+  user_badges?: string[]
+  user_featured_achievement_id?: string | null
+  body: string
+  is_verified_review: boolean
+  handshake_hours?: number
+  handshake_completed_at?: string
+  /** Role the reviewed user had in the handshake: 'provider' or 'receiver' */
+  reviewed_user_role?: 'provider' | 'receiver' | null
+  reply_count: number
+  replies: unknown[]
+  created_at: string
+  updated_at: string
+}
+
+export interface ProfileReviewsResponse {
+  count: number
+  results: ProfileReview[]
+  next?: string | null
+  previous?: string | null
+}
+
 // ─── Reputation Types ─────────────────────────────────────────────────────────
 
 export interface ReputationData {


### PR DESCRIPTION
- Backend: Add role=provider|receiver query param to GET /users/:id/verified-reviews/
- Backend: Centralize role derivation in utils.get_verified_reviews_role_filter()
- Backend: Add CommentSerializer.reviewed_user_role for profile responses
- Backend: Integration tests for Offer/Need provider and receiver filtering and blind-review
- Frontend: userAPI.getVerifiedReviews(userId, { role }) and ProfileReview types
- Frontend: UserProfile Reviews tab with As a Provider / As a Taker sections
- Frontend: PublicProfile Reviews card with same role-separated sections and loading/empty states

Closes #41 