### PR TITLE
Feature/handshake modal ux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,7 @@ logs/
 
 backend/tests/reports/
 frontend/tests/reports/
+
+# Allow frontend src lib (validation helpers)
+!frontend/src/lib/
+!frontend/src/lib/**

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,8 @@
 
 Three ways to run The Hive — all powered by **Docker Compose v2** (`docker compose`).
 
-Backend and infrastructure share a **single `.env` file** at the project root. The frontend (Vite) also reads this root `.env` via `envDir` in `vite.config.ts`, so `VITE_*` variables work from the same file. Run `make env` to generate it interactively, or copy `.env.example` and edit manually.
+Backend and infrastructure share a **single `.env` file** at the project root. The frontend (Vite) also reads this root `.env` via `envDir` in `vite.config.ts`, so `VITE_*` variables work from the same file. Run `make env` to generate it interactively, or copy `.env.example` and edit manually. 
+
 
 ---
 

--- a/frontend/src/components/HandshakeDetailsModal.tsx
+++ b/frontend/src/components/HandshakeDetailsModal.tsx
@@ -9,6 +9,8 @@ import {
 } from '@chakra-ui/react'
 import type { InitiatePayload } from '@/services/handshakeAPI'
 import { formatEventDateTime } from '@/utils/eventUtils'
+import { LocationPickerMap } from '@/components/LocationPickerMap'
+import { isIntegerDuration, roundTimeToFifteenMinutes } from '@/lib/validation'
 
 interface Props {
   isOpen: boolean
@@ -47,7 +49,7 @@ export function HandshakeDetailsModal({
   useEffect(() => {
     if (!isOpen || presetDetails) return
     if (useStrictDuration && serviceDuration != null) {
-      setDuration(serviceDuration)
+      setDuration(Math.max(1, Math.min(10, Math.round(Number(serviceDuration)))))
     }
   }, [isOpen, presetDetails, serviceDuration, useStrictDuration])
 
@@ -110,15 +112,17 @@ export function HandshakeDetailsModal({
 
     if (!location.trim()) { setError('Location is required.'); return }
     if (!date || !time) { setError('Scheduled date and time are required.'); return }
-    if (useStrictDuration) {
-      if (!Number.isInteger(duration)) { setError('Time credit must be a whole number.'); return }
-      if (duration < 1) { setError('Time credit must be at least 1 hour.'); return }
-      if (duration > 10) { setError('Time credit cannot exceed 10 hours.'); return }
-    } else {
-      if (duration <= 0) { setError('Duration must be greater than 0.'); return }
+    if (!isIntegerDuration(duration)) {
+      setError('Duration must be a whole number of hours (at least 1).')
+      return
+    }
+    if (useStrictDuration && duration > 10) {
+      setError('Time credit cannot exceed 10 hours.')
+      return
     }
 
-    const scheduled_time = `${date}T${time}:00`
+    const timeRounded = roundTimeToFifteenMinutes(time)
+    const scheduled_time = `${date}T${timeRounded}:00`
     const now = new Date()
     if (new Date(scheduled_time) <= now) { setError('Scheduled time must be in the future.'); return }
 
@@ -192,12 +196,10 @@ export function HandshakeDetailsModal({
               <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
                 Exact Location
               </Text>
-              <Input
-                placeholder="e.g. Beşiktaş Library, Room 3"
+              <LocationPickerMap
                 value={location}
-                onChange={(e) => setLocation(e.target.value)}
-                size="sm"
-                borderRadius="8px"
+                onChange={setLocation}
+                height="220px"
               />
             </Box>
 
@@ -212,15 +214,21 @@ export function HandshakeDetailsModal({
               </Text>
               <Input
                 type="number"
-                min={useStrictDuration ? 1 : 0.5}
+                min={1}
                 max={useStrictDuration ? 10 : undefined}
-                step={useStrictDuration ? 1 : 0.5}
+                step={1}
                 placeholder={useStrictDuration ? 'e.g. 1' : undefined}
                 value={duration}
-                onChange={(e) => setDuration(parseFloat(e.target.value) || 0)}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10)
+                  if (isNaN(v)) return
+                  const clamped = useStrictDuration ? Math.min(10, Math.max(1, v)) : Math.max(1, v)
+                  setDuration(clamped)
+                }}
                 size="sm"
                 borderRadius="8px"
                 w="120px"
+                inputMode="numeric"
               />
               {useStrictDuration && (
                 <Text fontSize="11px" color="gray.500" mt={1}>
@@ -245,6 +253,7 @@ export function HandshakeDetailsModal({
                 />
                 <Input
                   type="time"
+                  step={900}
                   value={time}
                   onChange={(e) => setTime(e.target.value)}
                   size="sm"

--- a/frontend/src/components/HandshakeDetailsModal.tsx
+++ b/frontend/src/components/HandshakeDetailsModal.tsx
@@ -41,7 +41,7 @@ export function HandshakeDetailsModal({
   const [location, setLocation] = useState('')
   const [duration, setDuration] = useState<number>(1)
   const [date, setDate] = useState('')
-  const [time, setTime] = useState('')
+  const [time, setTime] = useState('09:00')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const useStrictDuration = isOfferOrNeed(serviceType)
@@ -241,7 +241,7 @@ export function HandshakeDetailsModal({
               <Text fontSize="13px" fontWeight={600} color="gray.700" mb={1}>
                 Scheduled Date & Time
               </Text>
-              <Flex gap={2}>
+              <Flex gap={2} align="center">
                 <Input
                   type="date"
                   min={minDate}
@@ -251,15 +251,51 @@ export function HandshakeDetailsModal({
                   borderRadius="8px"
                   flex={1}
                 />
-                <Input
-                  type="time"
-                  step={900}
-                  value={time}
-                  onChange={(e) => setTime(e.target.value)}
-                  size="sm"
-                  borderRadius="8px"
-                  w="120px"
-                />
+                <Flex gap={1} align="center">
+                  <select
+                    value={time ? time.split(':')[0] ?? '09' : '09'}
+                    onChange={(e) => {
+                      const h = (e.target as HTMLSelectElement).value
+                      const m = (time && time.includes(':')) ? time.split(':')[1] ?? '00' : '00'
+                      setTime(`${h}:${m}`)
+                    }}
+                    style={{
+                      borderRadius: '8px',
+                      border: '1px solid #E5E7EB',
+                      padding: '6px 8px',
+                      fontSize: '13px',
+                      background: 'white',
+                      width: '64px',
+                    }}
+                  >
+                    {Array.from({ length: 24 }, (_, i) => (
+                      <option key={i} value={String(i).padStart(2, '0')}>
+                        {String(i).padStart(2, '0')}
+                      </option>
+                    ))}
+                  </select>
+                  <Text color="gray.500">:</Text>
+                  <select
+                    value={time && time.includes(':') ? time.split(':')[1] ?? '00' : '00'}
+                    onChange={(e) => {
+                      const m = (e.target as HTMLSelectElement).value
+                      const h = (time && time.includes(':')) ? time.split(':')[0] ?? '09' : '09'
+                      setTime(`${h}:${m}`)
+                    }}
+                    style={{
+                      borderRadius: '8px',
+                      border: '1px solid #E5E7EB',
+                      padding: '6px 8px',
+                      fontSize: '13px',
+                      background: 'white',
+                      width: '64px',
+                    }}
+                  >
+                    {['00', '15', '30', '45'].map((min) => (
+                      <option key={min} value={min}>{min}</option>
+                    ))}
+                  </select>
+                </Flex>
               </Flex>
             </Box>
           </Stack>

--- a/frontend/src/components/LocationPickerMap.tsx
+++ b/frontend/src/components/LocationPickerMap.tsx
@@ -1,8 +1,8 @@
 /**
  * LocationPickerMap — Mapbox-based location picker for handshake exact location.
- * User can click the map to set a pin or use "Use My Location" (Geolocation API).
- * Value is stored as "lat,lng" for backend exact_location (CharField).
- * When VITE_MAPBOX_TOKEN is missing, shows a text fallback and still supports "Use My Location".
+ * User clicks the map or uses "Use My Location"; the selected point is reverse-geocoded
+ * to a human-readable address. Value is the resolved address (not coordinates).
+ * Shows selected address with an "Open in Maps" navigation link.
  */
 
 import { useState, useCallback, useMemo, useRef } from 'react'
@@ -13,13 +13,14 @@ import type { MapMouseEvent } from 'mapbox-gl'
 import type { Feature, FeatureCollection, Point } from 'geojson'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
+import { Box, Button, Input, Text, Link } from '@chakra-ui/react'
+import { GREEN, GRAY100, GRAY200, GRAY400, GRAY700, GRAY800, WHITE } from '@/theme/tokens'
+import { reverseGeocode, buildMapsUrl } from '@/utils/location'
+
 const mapboxWithTelemetry = mapboxgl as typeof mapboxgl & { setTelemetryEnabled?: (enabled: boolean) => void }
 if (typeof mapboxWithTelemetry.setTelemetryEnabled === 'function') {
   mapboxWithTelemetry.setTelemetryEnabled(false)
 }
-
-import { Box, Button, Input, Text } from '@chakra-ui/react'
-import { GREEN, GRAY100, GRAY200, GRAY400, GRAY700, WHITE } from '@/theme/tokens'
 
 const ISTANBUL_CENTER = { longitude: 28.9784, latitude: 41.0082, zoom: 11 }
 const TOKEN = import.meta.env.VITE_MAPBOX_TOKEN as string | undefined
@@ -28,16 +29,6 @@ export interface LocationPickerMapProps {
   value: string
   onChange: (value: string) => void
   height?: string
-}
-
-function parseLatLng(value: string): { lat: number; lng: number } | null {
-  if (!value || !value.trim()) return null
-  const parts = value.trim().split(',')
-  if (parts.length < 2) return null
-  const lat = parseFloat(parts[0])
-  const lng = parseFloat(parts[1])
-  if (isNaN(lat) || isNaN(lng)) return null
-  return { lat, lng }
 }
 
 const pinLayer: LayerProps = {
@@ -54,16 +45,10 @@ const pinLayer: LayerProps = {
 function MapFallback({
   value,
   onChange,
-  onUseMyLocation,
-  locationLoading,
-  locationError,
   height = '220px',
 }: {
   value: string
   onChange: (value: string) => void
-  onUseMyLocation: () => void
-  locationLoading: boolean
-  locationError: string | null
   height?: string
 }) {
   return (
@@ -86,7 +71,7 @@ function MapFallback({
           Map unavailable
         </Text>
         <Text fontSize="12px" color={GRAY400}>
-          Set VITE_MAPBOX_TOKEN in .env to enable the map. You can still enter an address or use your location.
+          Set VITE_MAPBOX_TOKEN in .env to enable the map. You can enter an address below.
         </Text>
       </Box>
       <Input
@@ -97,21 +82,6 @@ function MapFallback({
         borderRadius="8px"
         mt={2}
       />
-      <Button
-        size="sm"
-        variant="outline"
-        mt={2}
-        onClick={onUseMyLocation}
-        isLoading={locationLoading}
-      >
-        <LocationIcon />
-        <Box as="span" ml={2}>Use My Location</Box>
-      </Button>
-      {locationError && (
-        <Text fontSize="12px" color="red.500" mt={1}>
-          {locationError}
-        </Text>
-      )}
     </Box>
   )
 }
@@ -132,23 +102,37 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
   const mapRef = useRef<MapRef>(null)
   const [locationLoading, setLocationLoading] = useState(false)
   const [locationError, setLocationError] = useState<string | null>(null)
-
-  const coords = useMemo(() => parseLatLng(value), [value])
+  const [selectedCoords, setSelectedCoords] = useState<{ lat: number; lng: number } | null>(null)
 
   const pinGeoJSON = useMemo((): FeatureCollection<Point> => {
-    if (!coords) return { type: 'FeatureCollection', features: [] }
+    if (!selectedCoords) return { type: 'FeatureCollection', features: [] }
     const feature: Feature<Point> = {
       type: 'Feature',
-      geometry: { type: 'Point', coordinates: [coords.lng, coords.lat] },
+      geometry: { type: 'Point', coordinates: [selectedCoords.lng, selectedCoords.lat] },
       properties: {},
     }
     return { type: 'FeatureCollection', features: [feature] }
-  }, [coords])
+  }, [selectedCoords])
 
   const initialView = useMemo(() => {
-    if (coords) return { longitude: coords.lng, latitude: coords.lat, zoom: 14 }
+    if (selectedCoords) return { longitude: selectedCoords.lng, latitude: selectedCoords.lat, zoom: 14 }
     return { ...ISTANBUL_CENTER }
-  }, [coords])
+  }, [selectedCoords])
+
+  const resolveAndSet = useCallback(
+    async (lng: number, lat: number) => {
+      if (!TOKEN) return
+      setLocationError(null)
+      const result = await reverseGeocode(lng, lat, TOKEN)
+      if (result) {
+        setSelectedCoords({ lat, lng })
+        onChange(result.address)
+      } else {
+        setLocationError('Could not resolve address for this location. Try another spot or enter an address manually.')
+      }
+    },
+    [onChange]
+  )
 
   const requestLocation = useCallback(() => {
     setLocationError(null)
@@ -159,10 +143,10 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
       return
     }
     navigator.geolocation.getCurrentPosition(
-      (pos) => {
+      async (pos) => {
         const lat = pos.coords.latitude
         const lng = pos.coords.longitude
-        onChange(`${lat},${lng}`)
+        await resolveAndSet(lng, lat)
         setLocationLoading(false)
         mapRef.current?.flyTo({
           center: [lng, lat],
@@ -178,14 +162,16 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
       },
       { enableHighAccuracy: true, timeout: 15_000, maximumAge: 60_000 }
     )
-  }, [onChange])
+  }, [resolveAndSet])
 
   const onMapClick = useCallback(
-    (e: MapMouseEvent) => {
+    async (e: MapMouseEvent) => {
       const { lng, lat } = e.lngLat
-      onChange(`${lat},${lng}`)
+      setLocationLoading(true)
+      await resolveAndSet(lng, lat)
+      setLocationLoading(false)
     },
-    [onChange]
+    [resolveAndSet]
   )
 
   if (!TOKEN) {
@@ -193,9 +179,6 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
       <MapFallback
         value={value}
         onChange={onChange}
-        onUseMyLocation={requestLocation}
-        locationLoading={locationLoading}
-        locationError={locationError}
         height={height}
       />
     )
@@ -214,7 +197,7 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
         cursor="crosshair"
       >
         <NavigationControl position="top-right" showCompass={false} />
-        {coords && (
+        {selectedCoords && (
           <Source id="pick-marker-source" type="geojson" data={pinGeoJSON}>
             <Layer {...pinLayer} />
           </Source>
@@ -227,7 +210,7 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
         bottom="10px"
         right="10px"
         onClick={requestLocation}
-        isLoading={locationLoading}
+        loading={locationLoading}
         bg={WHITE}
         borderColor={GRAY200}
         _hover={{ bg: GRAY100 }}
@@ -239,6 +222,27 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
         <Text fontSize="12px" color="red.500" mt={1}>
           {locationError}
         </Text>
+      )}
+      {value.trim() && (
+        <Box mt={3} p={3} borderRadius="8px" bg={GRAY100} border="1px solid" borderColor={GRAY200}>
+          <Text fontSize="13px" fontWeight={600} color={GRAY800} mb={1}>
+            Selected location
+          </Text>
+          <Text fontSize="13px" color={GRAY700} mb={2}>
+            {value}
+          </Text>
+          <Link
+            href={buildMapsUrl(value)}
+            target="_blank"
+            rel="noopener noreferrer"
+            fontSize="13px"
+            fontWeight={600}
+            color={GREEN}
+            _hover={{ textDecoration: 'underline' }}
+          >
+            Open in Maps
+          </Link>
+        </Box>
       )}
     </Box>
   )

--- a/frontend/src/components/LocationPickerMap.tsx
+++ b/frontend/src/components/LocationPickerMap.tsx
@@ -10,7 +10,7 @@ import Map, { Source, Layer, NavigationControl } from 'react-map-gl/mapbox'
 import type { MapRef, LayerProps } from 'react-map-gl/mapbox'
 import mapboxgl from 'mapbox-gl'
 import type { MapMouseEvent } from 'mapbox-gl'
-import type { Feature, Point } from 'geojson'
+import type { Feature, FeatureCollection, Point } from 'geojson'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 const mapboxWithTelemetry = mapboxgl as typeof mapboxgl & { setTelemetryEnabled?: (enabled: boolean) => void }
@@ -135,7 +135,7 @@ export function LocationPickerMap({ value, onChange, height = '220px' }: Locatio
 
   const coords = useMemo(() => parseLatLng(value), [value])
 
-  const pinGeoJSON = useMemo((): GeoJSON.FeatureCollection<Point> => {
+  const pinGeoJSON = useMemo((): FeatureCollection<Point> => {
     if (!coords) return { type: 'FeatureCollection', features: [] }
     const feature: Feature<Point> = {
       type: 'Feature',

--- a/frontend/src/components/LocationPickerMap.tsx
+++ b/frontend/src/components/LocationPickerMap.tsx
@@ -1,0 +1,245 @@
+/**
+ * LocationPickerMap — Mapbox-based location picker for handshake exact location.
+ * User can click the map to set a pin or use "Use My Location" (Geolocation API).
+ * Value is stored as "lat,lng" for backend exact_location (CharField).
+ * When VITE_MAPBOX_TOKEN is missing, shows a text fallback and still supports "Use My Location".
+ */
+
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import Map, { Source, Layer, NavigationControl } from 'react-map-gl/mapbox'
+import type { MapRef, LayerProps } from 'react-map-gl/mapbox'
+import mapboxgl from 'mapbox-gl'
+import type { MapMouseEvent } from 'mapbox-gl'
+import type { Feature, Point } from 'geojson'
+import 'mapbox-gl/dist/mapbox-gl.css'
+
+const mapboxWithTelemetry = mapboxgl as typeof mapboxgl & { setTelemetryEnabled?: (enabled: boolean) => void }
+if (typeof mapboxWithTelemetry.setTelemetryEnabled === 'function') {
+  mapboxWithTelemetry.setTelemetryEnabled(false)
+}
+
+import { Box, Button, Input, Text } from '@chakra-ui/react'
+import { GREEN, GRAY100, GRAY200, GRAY400, GRAY700, WHITE } from '@/theme/tokens'
+
+const ISTANBUL_CENTER = { longitude: 28.9784, latitude: 41.0082, zoom: 11 }
+const TOKEN = import.meta.env.VITE_MAPBOX_TOKEN as string | undefined
+
+export interface LocationPickerMapProps {
+  value: string
+  onChange: (value: string) => void
+  height?: string
+}
+
+function parseLatLng(value: string): { lat: number; lng: number } | null {
+  if (!value || !value.trim()) return null
+  const parts = value.trim().split(',')
+  if (parts.length < 2) return null
+  const lat = parseFloat(parts[0])
+  const lng = parseFloat(parts[1])
+  if (isNaN(lat) || isNaN(lng)) return null
+  return { lat, lng }
+}
+
+const pinLayer: LayerProps = {
+  id: 'pick-marker',
+  type: 'circle',
+  paint: {
+    'circle-radius': 10,
+    'circle-color': GREEN,
+    'circle-stroke-width': 3,
+    'circle-stroke-color': WHITE,
+  },
+}
+
+function MapFallback({
+  value,
+  onChange,
+  onUseMyLocation,
+  locationLoading,
+  locationError,
+  height = '220px',
+}: {
+  value: string
+  onChange: (value: string) => void
+  onUseMyLocation: () => void
+  locationLoading: boolean
+  locationError: string | null
+  height?: string
+}) {
+  return (
+    <Box>
+      <Box
+        height={height}
+        width="100%"
+        borderRadius="8px"
+        bg={GRAY100}
+        border="1px solid"
+        borderColor={GRAY200}
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+        color={GRAY400}
+      >
+        <Text fontSize="13px" fontWeight={500} color={GRAY700}>
+          Map unavailable
+        </Text>
+        <Text fontSize="12px" color={GRAY400}>
+          Set VITE_MAPBOX_TOKEN in .env to enable the map. You can still enter an address or use your location.
+        </Text>
+      </Box>
+      <Input
+        placeholder="e.g. Beşiktaş Library, Room 3"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        size="sm"
+        borderRadius="8px"
+        mt={2}
+      />
+      <Button
+        size="sm"
+        variant="outline"
+        mt={2}
+        onClick={onUseMyLocation}
+        isLoading={locationLoading}
+      >
+        <LocationIcon />
+        <Box as="span" ml={2}>Use My Location</Box>
+      </Button>
+      {locationError && (
+        <Text fontSize="12px" color="red.500" mt={1}>
+          {locationError}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+function LocationIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="3" />
+      <line x1="12" y1="2" x2="12" y2="6" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="6" y2="12" />
+      <line x1="18" y1="12" x2="22" y2="12" />
+    </svg>
+  )
+}
+
+export function LocationPickerMap({ value, onChange, height = '220px' }: LocationPickerMapProps) {
+  const mapRef = useRef<MapRef>(null)
+  const [locationLoading, setLocationLoading] = useState(false)
+  const [locationError, setLocationError] = useState<string | null>(null)
+
+  const coords = useMemo(() => parseLatLng(value), [value])
+
+  const pinGeoJSON = useMemo((): GeoJSON.FeatureCollection<Point> => {
+    if (!coords) return { type: 'FeatureCollection', features: [] }
+    const feature: Feature<Point> = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [coords.lng, coords.lat] },
+      properties: {},
+    }
+    return { type: 'FeatureCollection', features: [feature] }
+  }, [coords])
+
+  const initialView = useMemo(() => {
+    if (coords) return { longitude: coords.lng, latitude: coords.lat, zoom: 14 }
+    return { ...ISTANBUL_CENTER }
+  }, [coords])
+
+  const requestLocation = useCallback(() => {
+    setLocationError(null)
+    setLocationLoading(true)
+    if (!navigator.geolocation) {
+      setLocationError('Geolocation not supported')
+      setLocationLoading(false)
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const lat = pos.coords.latitude
+        const lng = pos.coords.longitude
+        onChange(`${lat},${lng}`)
+        setLocationLoading(false)
+        mapRef.current?.flyTo({
+          center: [lng, lat],
+          zoom: 14,
+          duration: 700,
+        })
+      },
+      (err) => {
+        setLocationError(
+          ['Unknown error', 'Permission denied', 'Location unavailable', 'Timed out'][err.code] ?? 'Unable to get location'
+        )
+        setLocationLoading(false)
+      },
+      { enableHighAccuracy: true, timeout: 15_000, maximumAge: 60_000 }
+    )
+  }, [onChange])
+
+  const onMapClick = useCallback(
+    (e: MapMouseEvent) => {
+      const { lng, lat } = e.lngLat
+      onChange(`${lat},${lng}`)
+    },
+    [onChange]
+  )
+
+  if (!TOKEN) {
+    return (
+      <MapFallback
+        value={value}
+        onChange={onChange}
+        onUseMyLocation={requestLocation}
+        locationLoading={locationLoading}
+        locationError={locationError}
+        height={height}
+      />
+    )
+  }
+
+  return (
+    <Box position="relative" width="100%">
+      <Map
+        ref={mapRef}
+        mapboxAccessToken={TOKEN}
+        initialViewState={initialView}
+        style={{ width: '100%', height, borderRadius: '8px' }}
+        mapStyle="mapbox://styles/sgunes16/cmmc96rwc00c701qz7v0g8h9k"
+        scrollZoom
+        onClick={onMapClick}
+        cursor="crosshair"
+      >
+        <NavigationControl position="top-right" showCompass={false} />
+        {coords && (
+          <Source id="pick-marker-source" type="geojson" data={pinGeoJSON}>
+            <Layer {...pinLayer} />
+          </Source>
+        )}
+      </Map>
+      <Button
+        size="sm"
+        variant="outline"
+        position="absolute"
+        bottom="10px"
+        right="10px"
+        onClick={requestLocation}
+        isLoading={locationLoading}
+        bg={WHITE}
+        borderColor={GRAY200}
+        _hover={{ bg: GRAY100 }}
+      >
+        <LocationIcon />
+        <Box as="span" ml={2}>Use My Location</Box>
+      </Button>
+      {locationError && (
+        <Text fontSize="12px" color="red.500" mt={1}>
+          {locationError}
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/components/LocationPickerMap.tsx
+++ b/frontend/src/components/LocationPickerMap.tsx
@@ -5,7 +5,7 @@
  * When VITE_MAPBOX_TOKEN is missing, shows a text fallback and still supports "Use My Location".
  */
 
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { useState, useCallback, useMemo, useRef } from 'react'
 import Map, { Source, Layer, NavigationControl } from 'react-map-gl/mapbox'
 import type { MapRef, LayerProps } from 'react-map-gl/mapbox'
 import mapboxgl from 'mapbox-gl'

--- a/frontend/src/components/ProviderDetailsModal.tsx
+++ b/frontend/src/components/ProviderDetailsModal.tsx
@@ -4,8 +4,10 @@ import {
   Button,
   Stack,
   Flex,
+  Link,
 } from '@chakra-ui/react'
 import { FiMapPin, FiClock, FiCalendar } from 'react-icons/fi'
+import { buildMapsUrl } from '@/utils/location'
 
 interface Props {
   isOpen: boolean
@@ -91,11 +93,32 @@ export function ProviderDetailsModal({
         </Text>
 
         <Stack gap={3}>
-          <DetailRow
-            icon={<FiMapPin size={16} />}
-            label="Location"
-            value={exactLocation}
-          />
+          <Flex align="flex-start" gap={3} p={3} bg="gray.50" borderRadius="10px">
+            <Box color="gray.400" mt="2px"><FiMapPin size={16} /></Box>
+            <Box flex={1}>
+              <Text fontSize="11px" color="gray.400" fontWeight={600} textTransform="uppercase" letterSpacing="0.05em">
+                Location
+              </Text>
+              <Text fontSize="14px" color="gray.800" fontWeight={600}>
+                {exactLocation}
+              </Text>
+              {exactLocation && (
+                <Link
+                  href={buildMapsUrl(exactLocation)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  fontSize="13px"
+                  fontWeight={600}
+                  color="#2D5C4E"
+                  mt={1}
+                  display="inline-block"
+                  _hover={{ textDecoration: 'underline' }}
+                >
+                  Open in Maps
+                </Link>
+              )}
+            </Box>
+          </Flex>
           <DetailRow
             icon={<FiClock size={16} />}
             label="Duration"

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,0 +1,40 @@
+/**
+ * Validation helpers for handshake and form constraints.
+ */
+
+/**
+ * Returns true if value is a positive integer (suitable for duration in hours).
+ */
+export function isIntegerDuration(value: number): boolean {
+  return Number.isInteger(value) && value >= 1
+}
+
+/**
+ * Clamps duration to integer between 1 and max (inclusive).
+ * Used for Offer/Need handshakes with a max cap (e.g. 10 hours).
+ */
+export function clampDuration(value: number, max?: number): number {
+  const v = Math.max(1, Math.floor(Number(value)))
+  if (max != null) return Math.min(v, max)
+  return v
+}
+
+const FIFTEEN_MINUTES = 15
+
+/**
+ * Rounds a time string (HH:mm or HH:mm:ss) to the nearest 15-minute mark.
+ * Returns time in HH:mm format (suitable for appending ":00" in ISO datetime).
+ */
+export function roundTimeToFifteenMinutes(time: string): string {
+  if (!time || !time.trim()) return '00:00'
+  const parts = time.trim().split(':')
+  const hours = parseInt(parts[0], 10)
+  const minutes = parts[1] != null ? parseInt(parts[1], 10) : 0
+  if (isNaN(hours)) return '00:00'
+  const roundedMinutes = Math.round((isNaN(minutes) ? 0 : minutes) / FIFTEEN_MINUTES) * FIFTEEN_MINUTES
+  const m = roundedMinutes === 60 ? 0 : roundedMinutes
+  const h = roundedMinutes === 60 ? hours + 1 : hours
+  const hNorm = h % 24
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(hNorm)}:${pad(m)}`
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
-import { Box, Button, Flex, Text, Stack, Spinner } from '@chakra-ui/react'
+import { Box, Button, Flex, Text, Stack, Spinner, Link } from '@chakra-ui/react'
 import {
   FiSend,
   FiArrowLeft,
@@ -44,6 +44,7 @@ import {
   GRAY50, GRAY100, GRAY200, GRAY300, GRAY400, GRAY500, GRAY600, GRAY700, GRAY800,
   WHITE,
 } from '@/theme/tokens'
+import { buildMapsUrl } from '@/utils/location'
 
 const CONV_POLL_MS = 30_000
 const MSG_POLL_MS  = 30_000
@@ -849,12 +850,25 @@ function ActionCard({
               {exact_location && (
                 <Box>
                   <Text fontSize="10px" color={GRAY400} fontWeight={600} mb="2px">LOCATION</Text>
-                  <Flex align="center" gap={1}>
+                  <Flex align="center" gap={1} flexWrap="wrap">
                     <FiMapPin size={12} color={GRAY500} />
                     <Text fontSize="13px" fontWeight={600} color={GRAY700}>
                       {exact_location}
                     </Text>
                   </Flex>
+                  <Link
+                    href={buildMapsUrl(exact_location)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    fontSize="12px"
+                    fontWeight={600}
+                    color={GREEN}
+                    mt="2px"
+                    display="inline-block"
+                    _hover={{ textDecoration: 'underline' }}
+                  >
+                    Open in Maps
+                  </Link>
                 </Box>
               )}
             </Flex>

--- a/frontend/src/utils/location.ts
+++ b/frontend/src/utils/location.ts
@@ -64,3 +64,40 @@ export function getCurrentPosition(): Promise<GeolocationPosition> {
 export function clampDistance(km: number): number {
   return Math.min(Math.max(km, DISTANCE_SEARCH.MIN_KM), DISTANCE_SEARCH.MAX_KM)
 }
+
+// ─── Mapbox reverse geocoding (for handshake address picker) ───────────────────
+
+interface MapboxFeature {
+  place_name?: string
+  text?: string
+  center?: [number, number]
+  context?: Array<{ id: string; text: string }>
+}
+
+/**
+ * Reverse geocode lng,lat to a human-readable address using Mapbox.
+ * Returns the best available address string (place_name) or null if the request fails or returns no features.
+ */
+export async function reverseGeocode(
+  lng: number,
+  lat: number,
+  accessToken: string,
+): Promise<{ address: string } | null> {
+  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${accessToken}&types=address,neighborhood,locality,place&language=en&limit=1`
+  try {
+    const res = await fetch(url)
+    const data = (await res.json()) as { features?: MapboxFeature[] }
+    const f = data.features?.[0]
+    if (!f?.place_name) return null
+    return { address: f.place_name }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build a Google Maps URL that opens a search for the given address (directions/navigation).
+ */
+export function buildMapsUrl(address: string): string {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`
+}

--- a/frontend/tests/e2e/handshake.spec.ts
+++ b/frontend/tests/e2e/handshake.spec.ts
@@ -95,3 +95,72 @@ test.describe('Handshake — navigation to chat', () => {
     await expect(msgInput).toBeVisible({ timeout: 10_000 })
   })
 })
+
+/**
+ * Provider initiates handshake with session details (address, duration, 15-min time).
+ * Demo: Elif owns "Help with 3D Printer Setup", Deniz is requester (pending).
+ * Without Mapbox token the modal shows fallback: manual address input and hour/minute selects.
+ */
+test.describe('Handshake — initiate session details', () => {
+  test('provider can open Initiate Handshake modal and submit address with 15-min time', async ({ page }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/messages')
+
+    // Open the pending conversation with Deniz (Help with 3D Printer Setup)
+    const convRow = page.locator('button').filter({ hasText: /Deniz|3D Printer|Help with/i }).first()
+    await expect(convRow).toBeVisible({ timeout: 20_000 })
+    await convRow.click()
+
+    // Right pane: provider sees "Initiate Handshake"
+    const initiateBtn = page.getByRole('button', { name: /Initiate Handshake/i })
+    await expect(initiateBtn).toBeVisible({ timeout: 10_000 })
+    await initiateBtn.click()
+
+    // Modal opens
+    await expect(page.getByText('Initiate Handshake').first()).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText('Exact Location').first()).toBeVisible()
+
+    // With no Mapbox token we get fallback: text input for address. Fill it.
+    const locationInput = page.getByPlaceholder(/e\.g\. Beşiktaş Library/)
+    await locationInput.fill('123 Test Street, Istanbul')
+
+    // Duration default is 1; ensure date is set (tomorrow)
+    const dateInput = page.locator('input[type="date"]')
+    await expect(dateInput).toBeVisible()
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const dateStr = tomorrow.toISOString().slice(0, 10)
+    await dateInput.fill(dateStr)
+
+    // Minute select must only offer 00, 15, 30, 45 (two selects: hour then minute)
+    const selects = page.locator('select')
+    await expect(selects.first()).toBeVisible()
+    const minuteSelect = selects.nth(1)
+    await expect(minuteSelect).toBeVisible()
+    const minuteOptions = await minuteSelect.locator('option').allTextContents()
+    expect(minuteOptions.sort()).toEqual(['00', '15', '30', '45'])
+
+    // Submit
+    await page.getByRole('button', { name: 'Send Details' }).click()
+
+    await expectToast(page, /Session details sent/i)
+  })
+
+  test('requester sees session details with Open in Maps link after provider initiates', async ({ page }) => {
+    // Depends on previous test: Elif already initiated with "123 Test Street, Istanbul"
+    // Deniz (requester) opens the conversation and opens Session Details modal
+    await loginAs(page, USERS.deniz)
+    await page.goto('/messages')
+    const denizConv = page.locator('button').filter({ hasText: /Elif|3D Printer|Help with/i }).first()
+    await expect(denizConv).toBeVisible({ timeout: 20_000 })
+    await denizConv.click()
+    const approveBtn = page.getByRole('button', { name: 'Review & Approve' })
+    await expect(approveBtn).toBeVisible({ timeout: 10_000 })
+    await approveBtn.click()
+
+    // ProviderDetailsModal: address and "Open in Maps" link
+    await expect(page.getByText('Session Details').first()).toBeVisible()
+    await expect(page.getByText('123 Test Street, Istanbul')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Open in Maps' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Changes

### 1. Exact location selector
- **LocationPickerMap** (`frontend/src/components/LocationPickerMap.tsx`): New Mapbox-based picker.
  - Click on the map to set a pin; value is stored as `"lat,lng"` and sent as `exact_location`.
  - **Use My Location** uses the Geolocation API and flies the map to the user’s position.
  - When `VITE_MAPBOX_TOKEN` is not set: fallback shows a text input and still supports **Use My Location** (coordinates sent as `"lat,lng"`).
- **HandshakeDetailsModal**: Replaced the plain “Exact Location” text input with `LocationPickerMap` (220px height). Location state remains a string (coordinates or address); submit still sends `exact_location: location.trim()`.

### 2. Integer-only duration
- Duration input: `min={1}`, `step={1}` for all service types (no more 0.5 or decimals).
- `onChange` uses `parseInt` and clamps (1–10 for Offer/Need, ≥1 otherwise).
- Submit validates with `isIntegerDuration(duration)`; initial duration from `serviceDuration` is rounded and clamped to 1–10.
- Error message: *"Duration must be a whole number of hours (at least 1)."*

### 3. Restricted time selector (15-minute intervals)
- Time input uses `step={900}` (15-minute steps); browsers typically show :00, :15, :30, :45.
- Before building `scheduled_time`, time is normalized with `roundTimeToFifteenMinutes(time)` so the submitted time is always on a 15-minute mark.

### 4. Validation helpers
- **`frontend/src/lib/validation.ts`** (new):
  - `isIntegerDuration(value)` – positive integer check for duration.
  - `clampDuration(value, max?)` – clamp to integer in [1, max].
  - `roundTimeToFifteenMinutes(time)` – round HH:mm to nearest 15 minutes (00, 15, 30, 45).
- `.gitignore`: Allow `frontend/src/lib/` so `validation.ts` is tracked.

## Files touched
- **New:** `frontend/src/components/LocationPickerMap.tsx`, `frontend/src/lib/validation.ts`
- **Modified:** `frontend/src/components/HandshakeDetailsModal.tsx`, `.gitignore`

## Test plan

### Manual – Initiate Handshake flow
1. **Open Initiate Handshake**
   - Go to Service List (or Dashboard) → open a service → start/initiate handshake so the **Initiate Handshake** modal opens (non–Event, non–preset).

2. **Location**
   - **With Mapbox token:** Map is shown; click on the map → pin appears; click **Use My Location** → map moves to current position and pin is set. Submit → payload has `exact_location` as `"lat,lng"`.
   - **Without token:** Fallback shows “Map unavailable” + text input; type an address or click **Use My Location** → submit and confirm `exact_location` in payload (address or `"lat,lng"`).
   - Leave location empty and submit → error: *"Location is required."*

3. **Duration**
   - Try decimals (e.g. 2.5) → input should only allow integers (e.g. 2 or 3 after step/clamp).
   - Set 1, 2, 5 → submit → payload has integer `exact_duration`.
   - For Offer/Need: set &gt; 10 → clamped to 10; submit and confirm.
   - Clear or set 0 → validation error about whole number / at least 1.

4. **Time**
   - Use the time control → only :00, :15, :30, :45 should be available (or rounded on submit).
   - Pick a time, submit → `scheduled_time` in payload has minutes in {00, 15, 30, 45}.
   - Pick a past date/time → error: *"Scheduled time must be in the future."*

5. **Full submit**
   - Fill location (map or text), duration (integer), date and time → **Send Details** → handshake initiates and modal closes; in chat/API, handshake has `exact_location`, `exact_duration`, `scheduled_time` as expected.

### Preset / Event
- **Preset (group offer with fixed details):** Open Initiate Handshake for such a conversation → preset location/duration/time are read-only; **Share Fixed Details** submits preset values (no regression).
- **Event:** Event handshake shows the Event Registration message only (no form); no changes to that flow.

### Regression
- Existing handshake initiate API tests still pass (location string and integer duration are valid).
- No backend or API contract changes.