### PR TITLE
Feature/113 mutual cancellation

### DIFF
--- a/backend/api/migrations/0045_handshake_cancellation_request.py
+++ b/backend/api/migrations/0045_handshake_cancellation_request.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0044_merge_20260307_1309'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='handshake',
+            name='cancellation_reason',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='handshake',
+            name='cancellation_requested_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='handshake',
+            name='cancellation_requested_by',
+            field=models.ForeignKey(
+                blank=True,
+                help_text='Which participant requested cancellation of an accepted handshake.',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='requested_handshake_cancellations',
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='notification',
+            name='type',
+            field=models.CharField(
+                choices=[
+                    ('handshake_request', 'Handshake Request'),
+                    ('handshake_accepted', 'Handshake Accepted'),
+                    ('handshake_denied', 'Handshake Denied'),
+                    ('handshake_cancellation_requested', 'Handshake Cancellation Requested'),
+                    ('handshake_cancellation_rejected', 'Handshake Cancellation Rejected'),
+                    ('handshake_cancelled', 'Handshake Cancelled'),
+                    ('service_updated', 'Service Updated'),
+                    ('chat_message', 'Chat Message'),
+                    ('service_reminder', 'Service Reminder'),
+                    ('service_confirmation', 'Service Confirmation'),
+                    ('positive_rep', 'Positive Reputation'),
+                    ('admin_warning', 'Admin Warning'),
+                    ('dispute_resolved', 'Dispute Resolved'),
+                ],
+                max_length=50,
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -377,6 +377,16 @@ class Handshake(models.Model):  # noqa: E302
     scheduled_time = models.DateTimeField(null=True, blank=True, help_text='Scheduled time for the service')
     provider_initiated = models.BooleanField(default=False, help_text='Whether provider has initiated the handshake')
     requester_initiated = models.BooleanField(default=False, help_text='Whether requester has initiated the handshake')
+    cancellation_requested_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='requested_handshake_cancellations',
+        help_text='Which participant requested cancellation of an accepted handshake.',
+    )
+    cancellation_requested_at = models.DateTimeField(null=True, blank=True)
+    cancellation_reason = models.TextField(blank=True, default='')
     evaluation_window_starts_at = models.DateTimeField(null=True, blank=True)
     evaluation_window_ends_at = models.DateTimeField(null=True, blank=True, db_index=True)
     evaluation_window_closed_at = models.DateTimeField(null=True, blank=True, db_index=True)
@@ -439,6 +449,8 @@ class Notification(models.Model):
         ('handshake_request', 'Handshake Request'),
         ('handshake_accepted', 'Handshake Accepted'),
         ('handshake_denied', 'Handshake Denied'),
+        ('handshake_cancellation_requested', 'Handshake Cancellation Requested'),
+        ('handshake_cancellation_rejected', 'Handshake Cancellation Rejected'),
         ('handshake_cancelled', 'Handshake Cancelled'),
         ('service_updated', 'Service Updated'),
         ('chat_message', 'Chat Message'),

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1288,6 +1288,10 @@ class HandshakeSerializer(serializers.ModelSerializer):
     counterpart = serializers.SerializerMethodField()
     is_current_user_provider = serializers.SerializerMethodField()
     user_has_reviewed = serializers.SerializerMethodField()
+    cancellation_requested_by_id = serializers.UUIDField(source='cancellation_requested_by.id', read_only=True, allow_null=True)
+    cancellation_requested_by_name = serializers.SerializerMethodField()
+    can_request_cancellation = serializers.SerializerMethodField()
+    can_respond_to_cancellation = serializers.SerializerMethodField()
 
     class Meta:
         model = Handshake
@@ -1299,6 +1303,9 @@ class HandshakeSerializer(serializers.ModelSerializer):
             'provider_confirmed_complete', 'receiver_confirmed_complete',
             'exact_location', 'exact_duration', 'scheduled_time',
             'provider_initiated', 'requester_initiated',
+            'cancellation_requested_by_id', 'cancellation_requested_by_name',
+            'cancellation_requested_at', 'cancellation_reason',
+            'can_request_cancellation', 'can_respond_to_cancellation',
             'evaluation_window_starts_at', 'evaluation_window_ends_at', 'evaluation_window_closed_at',
             'user_has_reviewed',
             'created_at', 'updated_at'
@@ -1351,6 +1358,35 @@ class HandshakeSerializer(serializers.ModelSerializer):
         if hasattr(obj, 'user_reps'):
             return len(obj.user_reps) > 0
         return ReputationRep.objects.filter(handshake=obj, giver=request.user).exists()
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_cancellation_requested_by_name(self, obj):
+        requester = obj.cancellation_requested_by
+        if requester is None:
+            return None
+        return f"{requester.first_name} {requester.last_name}".strip() or requester.email
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_can_request_cancellation(self, obj):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return False
+        if obj.service.type == 'Event':
+            return False
+        if obj.status != 'accepted':
+            return False
+        if request.user.id not in {obj.requester_id, obj.service.user_id}:
+            return False
+        return obj.cancellation_requested_by_id is None
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_can_respond_to_cancellation(self, obj):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return False
+        if obj.status != 'accepted' or obj.cancellation_requested_by_id is None:
+            return False
+        return request.user.id in {obj.requester_id, obj.service.user_id} and request.user.id != obj.cancellation_requested_by_id
 
 # Chat Message Serializers
 @extend_schema_serializer(

--- a/backend/api/tests/integration/test_handshake_api.py
+++ b/backend/api/tests/integration/test_handshake_api.py
@@ -245,8 +245,8 @@ class TestHandshakeViewSet:
         provider.refresh_from_db()
         assert provider.timebank_balance > Decimal('5.00')
     
-    def test_cancel_handshake(self):
-        """Test canceling a handshake"""
+    def test_request_and_approve_cancellation(self):
+        """Accepted Offer/Need handshakes require a mutual cancellation approval."""
         provider = UserFactory()
         requester = UserFactory(timebank_balance=Decimal('1.00'))
         service = ServiceFactory(user=provider, type='Offer', duration=Decimal('2.00'))
@@ -259,8 +259,19 @@ class TestHandshakeViewSet:
         
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
-        
-        response = client.post(f'/api/handshakes/{handshake.id}/cancel/')
+
+        request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/', {
+            'reason': 'Unexpected conflict',
+        })
+        assert request_response.status_code == status.HTTP_200_OK
+
+        handshake.refresh_from_db()
+        assert handshake.status == 'accepted'
+        assert handshake.cancellation_requested_by == provider
+        assert handshake.cancellation_reason == 'Unexpected conflict'
+
+        client.authenticate_user(requester)
+        response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/approve/')
         assert response.status_code == status.HTTP_200_OK
         
         handshake.refresh_from_db()
@@ -268,6 +279,71 @@ class TestHandshakeViewSet:
         
         requester.refresh_from_db()
         assert requester.timebank_balance == Decimal('3.00')
+
+    def test_reject_cancellation_request_keeps_handshake_active(self):
+        provider = UserFactory()
+        requester = UserFactory(timebank_balance=Decimal('4.00'))
+        service = ServiceFactory(user=provider, type='Offer', duration=Decimal('2.00'))
+        handshake = HandshakeFactory(
+            service=service,
+            requester=requester,
+            status='accepted',
+            provisioned_hours=Decimal('2.00'),
+        )
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(provider)
+        request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/', {
+            'reason': 'Need to reschedule instead',
+        })
+        assert request_response.status_code == status.HTTP_200_OK
+
+        client.authenticate_user(requester)
+        reject_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/reject/')
+        assert reject_response.status_code == status.HTTP_200_OK
+
+        handshake.refresh_from_db()
+        requester.refresh_from_db()
+        assert handshake.status == 'accepted'
+        assert handshake.cancellation_requested_by is None
+        assert handshake.cancellation_requested_at is None
+        assert handshake.cancellation_reason == ''
+        assert requester.timebank_balance == Decimal('4.00')
+
+    def test_requester_cannot_approve_own_cancellation_request(self):
+        provider = UserFactory()
+        requester = UserFactory(timebank_balance=Decimal('4.00'))
+        service = ServiceFactory(user=provider, type='Offer', duration=Decimal('2.00'))
+        handshake = HandshakeFactory(
+            service=service,
+            requester=requester,
+            status='accepted',
+            provisioned_hours=Decimal('2.00'),
+        )
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(requester)
+        request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/')
+        assert request_response.status_code == status.HTTP_200_OK
+
+        approve_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/approve/')
+        assert approve_response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_event_handshake_cannot_use_cancellation_request(self):
+        organizer = UserFactory()
+        attendee = UserFactory()
+        service = ServiceFactory(user=organizer, type='Event')
+        handshake = HandshakeFactory(
+            service=service,
+            requester=attendee,
+            status='accepted',
+            provisioned_hours=Decimal('0.00'),
+        )
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(organizer)
+        response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 # ── Tests: initiate/approve permission changes (service-owner-first model) ────
@@ -651,7 +727,10 @@ class TestAgreedStatusIntegration:
 
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
-        resp = client.post(f'/api/handshakes/{h.id}/cancel/')
+        request_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/')
+        assert request_resp.status_code == status.HTTP_200_OK
+        client.authenticate_user(requester)
+        resp = client.post(f'/api/handshakes/{h.id}/cancel-request/approve/')
         assert resp.status_code == status.HTTP_200_OK
 
         svc.refresh_from_db()
@@ -670,7 +749,11 @@ class TestAgreedStatusIntegration:
 
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
-        client.post(f'/api/handshakes/{h.id}/cancel/')
+        request_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/')
+        assert request_resp.status_code == status.HTTP_200_OK
+        client.authenticate_user(requester)
+        approve_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/approve/')
+        assert approve_resp.status_code == status.HTTP_200_OK
 
         viewer = UserFactory()
         client.authenticate_user(viewer)

--- a/backend/api/tests/unit/test_capacity_and_agreed.py
+++ b/backend/api/tests/unit/test_capacity_and_agreed.py
@@ -385,12 +385,16 @@ class TestAgreedStatusTransitions:
 
         client = APIClient()
         client.force_authenticate(user=provider)
-        resp = client.post(f'/api/handshakes/{h.id}/cancel/')
+        request_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/')
+        assert request_resp.status_code == 200, request_resp.data
+
+        client.force_authenticate(user=requester)
+        resp = client.post(f'/api/handshakes/{h.id}/cancel-request/approve/')
         assert resp.status_code == 200, resp.data
 
         svc.refresh_from_db()
         assert svc.status == 'Active', (
-            f"Cancelling accepted handshake should revert Agreed → Active, got {svc.status}"
+            f"Approving cancellation for accepted handshake should revert Agreed → Active, got {svc.status}"
         )
 
     def test_agreed_service_hidden_from_public_list(self):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2359,7 +2359,7 @@ class HandshakeViewSet(viewsets.ModelViewSet):
         user = self.request.user
         return Handshake.objects.filter(
             Q(requester=user) | Q(service__user=user)
-        ).select_related('service', 'requester', 'service__user').prefetch_related(
+        ).select_related('service', 'requester', 'service__user', 'cancellation_requested_by').prefetch_related(
             Prefetch('reps', queryset=ReputationRep.objects.filter(giver=user), to_attr='user_reps')
         ).order_by('-created_at')
 
@@ -2956,7 +2956,6 @@ class HandshakeViewSet(viewsets.ModelViewSet):
     def cancel_handshake(self, request, pk=None):
         handshake = self.get_object()
         user = request.user
-        # Offer: service owner = provider; Need: service owner = receiver. Allow both parties to cancel.
         if handshake.service.user != user and handshake.requester != user:
             return create_error_response(
                 'Only the service owner or the requester can cancel this handshake',
@@ -2964,23 +2963,262 @@ class HandshakeViewSet(viewsets.ModelViewSet):
                 status_code=status.HTTP_403_FORBIDDEN
             )
 
-        if handshake.status != 'accepted':
-            return create_error_response(
-                'Can only cancel accepted handshakes',
-                code=ErrorCodes.INVALID_STATE,
-                status_code=status.HTTP_400_BAD_REQUEST
+        with transaction.atomic():
+            locked_handshake = (
+                Handshake.objects
+                .select_for_update()
+                .select_related('service', 'requester', 'service__user')
+                .get(pk=handshake.pk)
             )
 
-        svc = handshake.service
-        with transaction.atomic():
-            cancel_timebank_transfer(handshake)
+            if locked_handshake.status == 'accepted' and locked_handshake.service.type != 'Event':
+                return create_error_response(
+                    'Accepted handshakes require a cancellation request and approval',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
 
-            # If the service was Agreed, reopen it now that the accepted slot is freed.
+            if locked_handshake.status != 'pending':
+                return create_error_response(
+                    'Can only directly cancel pending handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            locked_handshake.status = 'cancelled'
+            locked_handshake.save(update_fields=['status', 'updated_at'])
+
+            if user == locked_handshake.requester:
+                create_notification(
+                    user=locked_handshake.service.user,
+                    notification_type='handshake_cancelled',
+                    title='Handshake Cancelled',
+                    message=f"{user.first_name} {user.last_name} cancelled their request for '{locked_handshake.service.title}'.",
+                    handshake=locked_handshake,
+                    service=locked_handshake.service,
+                )
+
+            serializer = self.get_serializer(locked_handshake)
+            return Response(serializer.data)
+
+    @action(detail=True, methods=['post'], url_path='cancel-request')
+    def request_cancellation(self, request, pk=None):
+        handshake = self.get_object()
+        user = request.user
+        if handshake.service.user != user and handshake.requester != user:
+            return create_error_response(
+                'Only the service owner or the requester can request cancellation',
+                code=ErrorCodes.PERMISSION_DENIED,
+                status_code=status.HTTP_403_FORBIDDEN
+            )
+
+        reason = str(request.data.get('reason') or '').strip()
+
+        with transaction.atomic():
+            locked_handshake = (
+                Handshake.objects
+                .select_for_update()
+                .select_related('service', 'requester', 'service__user')
+                .get(pk=handshake.pk)
+            )
+
+            if locked_handshake.service.type == 'Event':
+                return create_error_response(
+                    'Cancellation requests are only available for Offer and Need handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.status != 'accepted':
+                return create_error_response(
+                    'Can only request cancellation for accepted handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.cancellation_requested_by_id is not None:
+                return create_error_response(
+                    'A cancellation request is already pending for this handshake',
+                    code=ErrorCodes.ALREADY_EXISTS,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            locked_handshake.cancellation_requested_by = user
+            locked_handshake.cancellation_requested_at = timezone.now()
+            locked_handshake.cancellation_reason = reason
+            locked_handshake.save(update_fields=[
+                'cancellation_requested_by',
+                'cancellation_requested_at',
+                'cancellation_reason',
+                'updated_at',
+            ])
+
+            other_user = (
+                locked_handshake.requester
+                if locked_handshake.service.user == user
+                else locked_handshake.service.user
+            )
+            display_name = f"{user.first_name} {user.last_name}".strip() or user.email
+            message = f"{display_name} requested to cancel '{locked_handshake.service.title}'."
+            if reason:
+                message = f"{message} Reason: {reason}"
+
+            create_notification(
+                user=other_user,
+                notification_type='handshake_cancellation_requested',
+                title='Cancellation Requested',
+                message=message,
+                handshake=locked_handshake,
+                service=locked_handshake.service,
+            )
+            invalidate_conversations(str(locked_handshake.requester_id))
+            invalidate_conversations(str(locked_handshake.service.user_id))
+
+            serializer = self.get_serializer(locked_handshake)
+            return Response(serializer.data)
+
+    @action(detail=True, methods=['post'], url_path='cancel-request/approve')
+    def approve_cancellation_request(self, request, pk=None):
+        handshake = self.get_object()
+        user = request.user
+        if handshake.service.user != user and handshake.requester != user:
+            return create_error_response(
+                'Only the service owner or the requester can approve cancellation',
+                code=ErrorCodes.PERMISSION_DENIED,
+                status_code=status.HTTP_403_FORBIDDEN
+            )
+
+        with transaction.atomic():
+            locked_handshake = (
+                Handshake.objects
+                .select_for_update()
+                .select_related('service', 'requester', 'service__user')
+                .get(pk=handshake.pk)
+            )
+
+            if locked_handshake.service.type == 'Event':
+                return create_error_response(
+                    'Cancellation requests are only available for Offer and Need handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.status != 'accepted':
+                return create_error_response(
+                    'Can only approve cancellation for accepted handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.cancellation_requested_by_id is None:
+                return create_error_response(
+                    'There is no pending cancellation request for this handshake',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.cancellation_requested_by_id == user.id:
+                return create_error_response(
+                    'The user who requested cancellation cannot approve it',
+                    code=ErrorCodes.PERMISSION_DENIED,
+                    status_code=status.HTTP_403_FORBIDDEN
+                )
+
+            svc = locked_handshake.service
+            requester_name = (
+                f"{locked_handshake.cancellation_requested_by.first_name} "
+                f"{locked_handshake.cancellation_requested_by.last_name}"
+            ).strip() or locked_handshake.cancellation_requested_by.email
+
+            cancel_timebank_transfer(locked_handshake)
+
             if svc.status == 'Agreed':
                 Service.objects.filter(pk=svc.pk).update(status='Active')
 
-        serializer = self.get_serializer(handshake)
-        return Response(serializer.data)
+            create_notification(
+                user=svc.user,
+                notification_type='handshake_cancelled',
+                title='Cancellation Approved',
+                message=f"The cancellation request for '{svc.title}' was approved by mutual agreement. Requested by {requester_name}.",
+                handshake=locked_handshake,
+                service=svc,
+            )
+
+            serializer = self.get_serializer(locked_handshake)
+            return Response(serializer.data)
+
+    @action(detail=True, methods=['post'], url_path='cancel-request/reject')
+    def reject_cancellation_request(self, request, pk=None):
+        handshake = self.get_object()
+        user = request.user
+        if handshake.service.user != user and handshake.requester != user:
+            return create_error_response(
+                'Only the service owner or the requester can reject cancellation',
+                code=ErrorCodes.PERMISSION_DENIED,
+                status_code=status.HTTP_403_FORBIDDEN
+            )
+
+        with transaction.atomic():
+            locked_handshake = (
+                Handshake.objects
+                .select_for_update()
+                .select_related('service', 'requester', 'service__user')
+                .get(pk=handshake.pk)
+            )
+
+            if locked_handshake.service.type == 'Event':
+                return create_error_response(
+                    'Cancellation requests are only available for Offer and Need handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.status != 'accepted':
+                return create_error_response(
+                    'Can only reject cancellation for accepted handshakes',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.cancellation_requested_by_id is None:
+                return create_error_response(
+                    'There is no pending cancellation request for this handshake',
+                    code=ErrorCodes.INVALID_STATE,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if locked_handshake.cancellation_requested_by_id == user.id:
+                return create_error_response(
+                    'The user who requested cancellation cannot reject it',
+                    code=ErrorCodes.PERMISSION_DENIED,
+                    status_code=status.HTTP_403_FORBIDDEN
+                )
+
+            request_user = locked_handshake.cancellation_requested_by
+            locked_handshake.cancellation_requested_by = None
+            locked_handshake.cancellation_requested_at = None
+            locked_handshake.cancellation_reason = ''
+            locked_handshake.save(update_fields=[
+                'cancellation_requested_by',
+                'cancellation_requested_at',
+                'cancellation_reason',
+                'updated_at',
+            ])
+
+            responder_name = f"{user.first_name} {user.last_name}".strip() or user.email
+            create_notification(
+                user=request_user,
+                notification_type='handshake_cancellation_rejected',
+                title='Cancellation Request Declined',
+                message=f"{responder_name} declined your cancellation request for '{locked_handshake.service.title}'.",
+                handshake=locked_handshake,
+                service=locked_handshake.service,
+            )
+            invalidate_conversations(str(locked_handshake.requester_id))
+            invalidate_conversations(str(locked_handshake.service.user_id))
+
+            serializer = self.get_serializer(locked_handshake)
+            return Response(serializer.data)
 
     @action(detail=True, methods=['post'], url_path='confirm', throttle_classes=[ConfirmationThrottle])
     @track_performance
@@ -3564,7 +3802,8 @@ class ChatViewSet(viewsets.ViewSet):
         ).select_related(
             'service', 
             'requester', 
-            'service__user'
+            'service__user',
+            'cancellation_requested_by',
         ).prefetch_related(
             last_message_prefetch,
             reputation_prefetch
@@ -3618,6 +3857,7 @@ class ChatViewSet(viewsets.ViewSet):
             
             # Check if user has already left reputation for this handshake (using prefetched data)
             user_has_reviewed = len(handshake.user_reps) > 0
+            cancellation_request_user = handshake.cancellation_requested_by
             
             conversations.append({
                 'handshake_id': str(handshake.id),
@@ -3650,6 +3890,22 @@ class ChatViewSet(viewsets.ViewSet):
                 'max_participants': handshake.service.max_participants,
                 'schedule_type': handshake.service.schedule_type,
                 'service_member_count': 1 + active_member_counts_by_service.get(handshake.service_id, 0),
+                'cancellation_requested_by_id': str(cancellation_request_user.id) if cancellation_request_user else None,
+                'cancellation_requested_by_name': (
+                    f"{cancellation_request_user.first_name} {cancellation_request_user.last_name}".strip() or cancellation_request_user.email
+                ) if cancellation_request_user else None,
+                'cancellation_requested_at': handshake.cancellation_requested_at.isoformat() if handshake.cancellation_requested_at else None,
+                'cancellation_reason': handshake.cancellation_reason or '',
+                'can_request_cancellation': (
+                    handshake.service.type != 'Event'
+                    and handshake.status == 'accepted'
+                    and handshake.cancellation_requested_by_id is None
+                ),
+                'can_respond_to_cancellation': (
+                    handshake.status == 'accepted'
+                    and handshake.cancellation_requested_by_id is not None
+                    and handshake.cancellation_requested_by_id != user.id
+                ),
             })
 
         page = paginator.paginate_queryset(conversations, request)

--- a/frontend/src/components/NotificationItem.tsx
+++ b/frontend/src/components/NotificationItem.tsx
@@ -16,6 +16,8 @@ const ICON_MAP: Record<NotificationType, React.ElementType> = {
   handshake_request: FiRefreshCw,
   handshake_accepted: FiCheckCircle,
   handshake_denied: FiRefreshCw,
+  handshake_cancellation_requested: FiClock,
+  handshake_cancellation_rejected: FiAlertTriangle,
   handshake_cancelled: FiRefreshCw,
   service_updated: FiRefreshCw,
   chat_message: FiMessageSquare,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -727,7 +727,21 @@ function HsStepBar({ conv }: { conv: ChatConversation }) {
 // ─── Action Card ──────────────────────────────────────────────────────────────
 
 function ActionCard({
-  conv, onInitiate, onShowApprove, onConfirm, onCancel, isCancelling, onOpenEvaluation, onReportNoShow, isReportingNoShow,
+  conv,
+  onInitiate,
+  onShowApprove,
+  onConfirm,
+  onCancel,
+  isCancelling,
+  onRequestCancellation,
+  onApproveCancellation,
+  onRejectCancellation,
+  isRequestingCancellation,
+  isApprovingCancellation,
+  isRejectingCancellation,
+  onOpenEvaluation,
+  onReportNoShow,
+  isReportingNoShow,
 }: {
   conv: ChatConversation
   onInitiate: () => void
@@ -735,6 +749,12 @@ function ActionCard({
   onConfirm: () => void
   onCancel: () => Promise<void>
   isCancelling: boolean
+  onRequestCancellation: () => Promise<void>
+  onApproveCancellation: () => Promise<void>
+  onRejectCancellation: () => Promise<void>
+  isRequestingCancellation: boolean
+  isApprovingCancellation: boolean
+  isRejectingCancellation: boolean
   onOpenEvaluation: () => void
   onReportNoShow: () => Promise<void>
   isReportingNoShow: boolean
@@ -795,6 +815,10 @@ function ActionCard({
 
   if (status === 'accepted') {
     const hasDetails = provisioned_hours != null || scheduled_time || exact_location || exact_duration
+    const hasCancellationRequest = Boolean(conv.cancellation_requested_by_id)
+    const canRespondToCancellation = conv.can_respond_to_cancellation === true
+    const cancellationReason = conv.cancellation_reason?.trim()
+    const cancellationRequesterName = conv.cancellation_requested_by_name ?? conv.other_user.name
 
     return (
       <Box mx={4} my="10px" borderRadius="14px" overflow="hidden"
@@ -861,33 +885,91 @@ function ActionCard({
           </Box>
         )}
 
-        {/* Confirm strip */}
-        <Flex
-          align="center" justify="space-between" gap={3}
-          px={4} py="12px"
-          bg={myConfirmed ? GREEN_LT : AMBER_LT}
-          flexWrap="wrap"
-        >
-          <Box>
-            {myConfirmed ? (
-              <Text fontSize="13px" fontWeight={700} color={GREEN}>✓ You confirmed completion</Text>
+        {hasCancellationRequest ? (
+          <Flex
+            align="center" justify="space-between" gap={3}
+            px={4} py="12px"
+            bg={RED_LT}
+            borderTop={`1px solid ${GRAY100}`}
+            flexWrap="wrap"
+          >
+            <Box>
+              <Text fontSize="13px" fontWeight={700} color={RED}>
+                {canRespondToCancellation ? 'Cancellation approval needed' : 'Cancellation request pending'}
+              </Text>
+              <Text fontSize="12px" color={GRAY500} mt="1px">
+                {canRespondToCancellation
+                  ? `${cancellationRequesterName} wants to cancel this handshake.`
+                  : `Waiting for ${conv.other_user.name} to respond to the cancellation request.`}
+              </Text>
+              {cancellationReason && (
+                <Text fontSize="11px" color={GRAY600} mt="4px">
+                  Reason: {cancellationReason}
+                </Text>
+              )}
+            </Box>
+            {canRespondToCancellation ? (
+              <Flex align="center" gap={2}>
+                <Button
+                  px="12px"
+                  h="34px"
+                  borderRadius="9px"
+                  bg={RED}
+                  color={WHITE}
+                  fontSize="12px"
+                  fontWeight={700}
+                  disabled={isApprovingCancellation || isRejectingCancellation}
+                  onClick={() => { void onApproveCancellation() }}
+                >
+                  {isApprovingCancellation ? 'Approving...' : 'Approve Cancellation'}
+                </Button>
+                <Button
+                  px="12px"
+                  h="34px"
+                  borderRadius="9px"
+                  border={`1px solid ${GRAY300}`}
+                  bg={WHITE}
+                  color={GRAY700}
+                  fontSize="12px"
+                  fontWeight={700}
+                  disabled={isApprovingCancellation || isRejectingCancellation}
+                  onClick={() => { void onRejectCancellation() }}
+                >
+                  {isRejectingCancellation ? 'Keeping...' : 'Keep Handshake'}
+                </Button>
+              </Flex>
             ) : (
-              <Text fontSize="13px" fontWeight={700} color={AMBER}>Confirm the service is done</Text>
+              <Text fontSize="12px" fontWeight={700} color={RED}>
+                Awaiting response
+              </Text>
             )}
-            <Text fontSize="12px" color={GRAY500} mt="1px">
-              {myConfirmed
-                ? otherConfirmed
-                  ? 'Both confirmed — completing transfer…'
-                  : `Waiting for ${conv.other_user.name} to confirm`
-                : otherConfirmed
-                  ? `${conv.other_user.name} already confirmed — your turn!`
-                  : 'Both sides must confirm to release TimeBank hours'
-              }
-            </Text>
-          </Box>
-          <Flex align="center" gap={2}>
-            {!myConfirmed && <CTA label="Confirm Completion" bg={AMBER} onClick={onConfirm} />}
-            {!myConfirmed && (
+          </Flex>
+        ) : (
+          <Flex
+            align="center" justify="space-between" gap={3}
+            px={4} py="12px"
+            bg={myConfirmed ? GREEN_LT : AMBER_LT}
+            flexWrap="wrap"
+          >
+            <Box>
+              {myConfirmed ? (
+                <Text fontSize="13px" fontWeight={700} color={GREEN}>✓ You confirmed completion</Text>
+              ) : (
+                <Text fontSize="13px" fontWeight={700} color={AMBER}>Confirm the service is done</Text>
+              )}
+              <Text fontSize="12px" color={GRAY500} mt="1px">
+                {myConfirmed
+                  ? otherConfirmed
+                    ? 'Both confirmed — completing transfer…'
+                    : `Waiting for ${conv.other_user.name} to confirm`
+                  : otherConfirmed
+                    ? `${conv.other_user.name} already confirmed — your turn!`
+                    : 'Both sides must confirm to release TimeBank hours'
+                }
+              </Text>
+            </Box>
+            <Flex align="center" gap={2} flexWrap="wrap">
+              {!myConfirmed && <CTA label="Confirm Completion" bg={AMBER} onClick={onConfirm} />}
               <Button
                 px="12px"
                 h="34px"
@@ -897,14 +979,30 @@ function ActionCard({
                 bg={RED_LT}
                 fontSize="12px"
                 fontWeight={700}
-                disabled={isReportingNoShow}
-                onClick={() => { void onReportNoShow() }}
+                disabled={isRequestingCancellation || isReportingNoShow}
+                onClick={() => { void onRequestCancellation() }}
               >
-                {isReportingNoShow ? 'Reporting...' : 'Report No-Show'}
+                {isRequestingCancellation ? 'Requesting...' : 'Request Cancellation'}
               </Button>
-            )}
+              {!myConfirmed && (
+                <Button
+                  px="12px"
+                  h="34px"
+                  borderRadius="9px"
+                  border={`1px solid ${RED}`}
+                  color={RED}
+                  bg={RED_LT}
+                  fontSize="12px"
+                  fontWeight={700}
+                  disabled={isReportingNoShow || isRequestingCancellation}
+                  onClick={() => { void onReportNoShow() }}
+                >
+                  {isReportingNoShow ? 'Reporting...' : 'Report No-Show'}
+                </Button>
+              )}
+            </Flex>
           </Flex>
-        </Flex>
+        )}
       </Box>
     )
   }
@@ -1348,6 +1446,9 @@ export default function ChatPage() {
   const [isSending,            setIsSending]            = useState(false)
   const [sendError,            setSendError]            = useState<string | null>(null)
   const [isCancelling,         setIsCancelling]         = useState(false)
+  const [isRequestingCancellation, setIsRequestingCancellation] = useState(false)
+  const [isApprovingCancellation, setIsApprovingCancellation] = useState(false)
+  const [isRejectingCancellation, setIsRejectingCancellation] = useState(false)
   const [isReportingNoShow,    setIsReportingNoShow]    = useState(false)
   const [isApproving,          setIsApproving]          = useState(false)
   const [isDeclining,          setIsDeclining]          = useState(false)
@@ -1611,6 +1712,8 @@ export default function ChatPage() {
       const detail = err?.response?.data?.detail ?? ''
       if (detail.toLowerCase().includes('only the service provider')) {
         toast.error('Only the service provider can cancel this handshake.')
+      } else if (detail.toLowerCase().includes('cancellation request')) {
+        toast.error('Accepted handshakes now require a cancellation request.')
       } else if (detail.toLowerCase().includes('only cancel accepted') || detail.toLowerCase().includes('can only cancel')) {
         toast.error('Only accepted handshakes can be cancelled.')
       } else {
@@ -1620,6 +1723,58 @@ export default function ChatPage() {
       setIsCancelling(false)
     }
   }, [selectedId, isCancelling, refreshConversations])
+
+  const handleRequestCancellation = useCallback(async () => {
+    if (!selectedId || isRequestingCancellation) return
+
+    const reason = window.prompt(
+      'Optional: why do you want to cancel this handshake?',
+      'Something changed and I would like to cancel this handshake.',
+    )
+    if (reason === null) return
+
+    setIsRequestingCancellation(true)
+    try {
+      await handshakeAPI.requestCancellation(selectedId, reason.trim() || undefined)
+      toast.success('Cancellation request sent.')
+      refreshConversations()
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { detail?: string } }; message?: string }
+      toast.error(err?.response?.data?.detail ?? err?.message ?? 'Failed to request cancellation.')
+    } finally {
+      setIsRequestingCancellation(false)
+    }
+  }, [isRequestingCancellation, refreshConversations, selectedId])
+
+  const handleApproveCancellation = useCallback(async () => {
+    if (!selectedId || isApprovingCancellation) return
+    setIsApprovingCancellation(true)
+    try {
+      await handshakeAPI.approveCancellation(selectedId)
+      toast.success('Handshake cancelled and reserved hours refunded.')
+      refreshConversations()
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { detail?: string } }; message?: string }
+      toast.error(err?.response?.data?.detail ?? err?.message ?? 'Failed to approve cancellation.')
+    } finally {
+      setIsApprovingCancellation(false)
+    }
+  }, [isApprovingCancellation, refreshConversations, selectedId])
+
+  const handleRejectCancellation = useCallback(async () => {
+    if (!selectedId || isRejectingCancellation) return
+    setIsRejectingCancellation(true)
+    try {
+      await handshakeAPI.rejectCancellation(selectedId)
+      toast.success('Cancellation request declined. The handshake remains active.')
+      refreshConversations()
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { detail?: string } }; message?: string }
+      toast.error(err?.response?.data?.detail ?? err?.message ?? 'Failed to keep handshake active.')
+    } finally {
+      setIsRejectingCancellation(false)
+    }
+  }, [isRejectingCancellation, refreshConversations, selectedId])
 
   const handleReportNoShow = useCallback(async () => {
     if (!selectedId || isReportingNoShow) return
@@ -1790,6 +1945,12 @@ export default function ChatPage() {
                 onConfirm={() => setShowConfirmModal(true)}
                 onCancel={handleCancel}
                 isCancelling={isCancelling}
+                onRequestCancellation={handleRequestCancellation}
+                onApproveCancellation={handleApproveCancellation}
+                onRejectCancellation={handleRejectCancellation}
+                isRequestingCancellation={isRequestingCancellation}
+                isApprovingCancellation={isApprovingCancellation}
+                isRejectingCancellation={isRejectingCancellation}
                 onOpenEvaluation={() => setShowEvaluationModal(true)}
                 onReportNoShow={handleReportNoShow}
                 isReportingNoShow={isReportingNoShow}

--- a/frontend/src/services/conversationAPI.ts
+++ b/frontend/src/services/conversationAPI.ts
@@ -63,6 +63,12 @@ export interface ChatConversation {
   max_participants: number
   schedule_type: string  // 'One-Time' | 'Recurrent'
   service_member_count?: number
+  cancellation_requested_by_id?: string | null
+  cancellation_requested_by_name?: string | null
+  cancellation_requested_at?: string | null
+  cancellation_reason?: string | null
+  can_request_cancellation?: boolean
+  can_respond_to_cancellation?: boolean
 }
 
 export interface GroupChatMessage {

--- a/frontend/src/services/handshakeAPI.ts
+++ b/frontend/src/services/handshakeAPI.ts
@@ -35,6 +35,12 @@ export interface Handshake {
   exact_location?: string | null
   exact_duration?: number | null
   scheduled_time?: string | null
+  cancellation_requested_by_id?: string | null
+  cancellation_requested_by_name?: string | null
+  cancellation_requested_at?: string | null
+  cancellation_reason?: string | null
+  can_request_cancellation?: boolean
+  can_respond_to_cancellation?: boolean
   created_at: string
   updated_at: string
 }
@@ -70,6 +76,23 @@ export const handshakeAPI = {
 
   cancel: async (id: string): Promise<Handshake> => {
     const res = await apiClient.post<Handshake>(`/handshakes/${id}/cancel/`, {})
+    return res.data
+  },
+
+  requestCancellation: async (id: string, reason?: string): Promise<Handshake> => {
+    const res = await apiClient.post<Handshake>(`/handshakes/${id}/cancel-request/`, {
+      ...(reason ? { reason } : {}),
+    })
+    return res.data
+  },
+
+  approveCancellation: async (id: string): Promise<Handshake> => {
+    const res = await apiClient.post<Handshake>(`/handshakes/${id}/cancel-request/approve/`, {})
+    return res.data
+  },
+
+  rejectCancellation: async (id: string): Promise<Handshake> => {
+    const res = await apiClient.post<Handshake>(`/handshakes/${id}/cancel-request/reject/`, {})
     return res.data
   },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -228,6 +228,8 @@ export type NotificationType =
   | 'handshake_request'
   | 'handshake_accepted'
   | 'handshake_denied'
+  | 'handshake_cancellation_requested'
+  | 'handshake_cancellation_rejected'
   | 'handshake_cancelled'
   | 'service_updated'
   | 'chat_message'


### PR DESCRIPTION
## Summary

This PR adds a mutual cancellation flow for active Offer/Need handshakes, replacing the previous one-sided cancel behavior after a handshake has already been accepted.

- Adds a new cancellation request workflow for accepted non-Event handshakes: one party requests cancellation, the other party approves or rejects it.
- Updates the chat experience so active handshakes can show `Request Cancellation`, pending approval state, and approve/keep-active actions inline.
- Preserves backend refund and service reopening behavior by cancelling the handshake, refunding blocked credits, and moving the related service from `Agreed` back to `Active` when cancellation is approved.

## Backend Changes

- Added handshake-level cancellation request state:
  - `cancellation_requested_by`
  - `cancellation_requested_at`
  - `cancellation_reason`
- Added new notification types for:
  - cancellation requested
  - cancellation rejected
- Added new handshake actions:
  - `POST /api/handshakes/:id/cancel-request/`
  - `POST /api/handshakes/:id/cancel-request/approve/`
  - `POST /api/handshakes/:id/cancel-request/reject/`
- Restricted direct `/cancel/` behavior for accepted non-Event handshakes so they must go through the mutual approval flow.
- Kept the existing refund logic and `Agreed -> Active` service reopening on approved cancellation.
- Fixed the PostgreSQL locking issue caused by `FOR UPDATE` on a nullable joined relation in cancellation approve/reject flows.

## Frontend Changes

- Extended handshake and conversation types with cancellation request metadata and capability flags.
- Added cancellation request API methods to the handshake client.
- Updated `ChatPage` active handshake cards to:
  - show `Request Cancellation`
  - show waiting-for-approval state to the requester
  - show approve / keep-active actions to the other participant
- Added notification type support for cancellation request and rejection states.

## Test Plan

- Backend: verify a participant can request cancellation on an accepted Offer/Need handshake.
- Backend: verify the other participant can approve and the handshake becomes `cancelled`.
- Backend: verify blocked credits are refunded on approval.
- Backend: verify the related service reopens from `Agreed` to `Active` after approval.
- Backend: verify the other participant can reject and the handshake stays `accepted`.
- Backend: verify the requesting user cannot approve or reject their own request.
- Backend: verify Event handshakes cannot use the mutual cancellation flow.
- Frontend: verify active handshake chat cards show the correct CTA/state for requester vs responder.
- Frontend: verify notification clicks still route users back into the relevant chat thread.

Closes #113