### PR TITLE
Filter created events from joined upcoming events in user profile

### DIFF
--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -406,10 +406,12 @@ const UserProfile = () => {
   const offersTab  = services.filter(s => s.type === 'Offer' && s.status === 'Active')
   const needsTab   = services.filter(s => s.type === 'Need'  && s.status === 'Active')
   const eventServices = services.filter(s => s.type === 'Event' && s.status === 'Active')
+  const createdEventIds = new Set(eventServices.map((event) => String(event.id)))
   const nowTs = Date.now()
   const createdUpcoming = eventServices.filter((event) => event.status === 'Active' && ((eventTs(event.scheduled_time) ?? nowTs + 1) >= nowTs))
   const joinedUpcoming = eventHandshakes.filter((handshake) => {
     if (!['accepted', 'checked_in', 'attended'].includes(handshake.status)) return false
+    if (createdEventIds.has(getHandshakeServiceId(handshake))) return false
     const joinedService = joinedEventServicesById[getHandshakeServiceId(handshake)]
     return joinedService ? joinedService.status === 'Active' : true
   })


### PR DESCRIPTION
closes #148

This pull request improves the logic for displaying upcoming events on the user profile page by ensuring that events the user has created are not also shown in their list of joined events. The main change is the introduction of a check to filter out events created by the user from their joined events list.

Event filtering improvements:

* Added a `createdEventIds` set to track IDs of events created by the user, and updated the `joinedUpcoming` computation to exclude any events the user created from their joined events list.