### PR TITLE
Feat/setup demo hotfix

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -335,6 +335,22 @@ class PublicChatConsumer(AsyncWebsocketConsumer):
 class GroupChatConsumer(AsyncWebsocketConsumer):
     """WebSocket consumer for private group chats (accepted participants only). Optional session_id for recurrent."""
 
+    CLOSE_MISSING_TOKEN = 4401
+    CLOSE_FORBIDDEN = 4403
+    CLOSE_NOT_FOUND = 4404
+    CLOSE_BAD_REQUEST = 4400
+    CLOSE_INTERNAL_ERROR = 4500
+
+    async def _reject(self, reason, code):
+        logger.warning(
+            "GroupChat WS rejected: reason=%s service_id=%s session_id=%s code=%s",
+            reason,
+            getattr(self, 'service_id', None),
+            getattr(self, 'session_id', None),
+            code,
+        )
+        await self.close(code=code)
+
     async def connect(self):
         self.service_id = self.scope['url_route']['kwargs']['service_id']
         self.session_id = None
@@ -349,19 +365,22 @@ class GroupChatConsumer(AsyncWebsocketConsumer):
 
         token = _get_token_from_scope(self.scope)
         if not token:
-            await self.close(code=4001)
+            await self._reject('missing access token', self.CLOSE_MISSING_TOKEN)
             return
 
         try:
             user = await self._authenticate(token)
             if not user:
-                await self.close(code=4003)
+                await self._reject('invalid access token', self.CLOSE_FORBIDDEN)
                 return
 
             requires_session = await self._service_requires_session(self.service_id)
             if requires_session and not self.session_id:
                 # Recurrent group chat must always be session-scoped.
-                await self.close(code=4003)
+                await self._reject(
+                    'session_id is required for recurrent group chat',
+                    self.CLOSE_BAD_REQUEST,
+                )
                 return
             if self.session_id and not requires_session:
                 # Keep backward compatibility for one-time/event clients that may
@@ -373,7 +392,14 @@ class GroupChatConsumer(AsyncWebsocketConsumer):
             else:
                 has_access = await self._check_access(user, self.service_id)
             if not has_access:
-                await self.close(code=4003)
+                if self.session_id:
+                    session_exists = await self._session_exists_for_service(self.service_id, self.session_id)
+                    if not session_exists:
+                        await self._reject('session not found for service', self.CLOSE_NOT_FOUND)
+                    else:
+                        await self._reject('user is not allowed for session', self.CLOSE_FORBIDDEN)
+                else:
+                    await self._reject('user is not allowed for service group chat', self.CLOSE_FORBIDDEN)
                 return
 
             self.user = user
@@ -382,7 +408,12 @@ class GroupChatConsumer(AsyncWebsocketConsumer):
                 else f'group_chat_{self.service_id}'
             )
         except Exception:
-            await self.close(code=4003)
+            logger.exception(
+                "GroupChat WS connect failure: service_id=%s session_id=%s",
+                self.service_id,
+                self.session_id,
+            )
+            await self.close(code=self.CLOSE_INTERNAL_ERROR)
             return
 
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
@@ -473,6 +504,14 @@ class GroupChatConsumer(AsyncWebsocketConsumer):
                 and service.type != 'Event'
             )
         except (Service.DoesNotExist, ValidationError, ValueError):
+            return False
+
+    @database_sync_to_async
+    def _session_exists_for_service(self, service_id, session_id):
+        try:
+            from .models import GroupChatSession
+            return GroupChatSession.objects.filter(id=session_id, service_id=service_id).exists()
+        except (ValidationError, ValueError):
             return False
 
     @database_sync_to_async

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -402,7 +402,7 @@ yasemin = create_or_update_user(
 murat = create_or_update_user(
     'murat@demo.com', 'Murat', 'Sezer',
     'Recently moved to Istanbul for remote work and is using The Hive to find low-pressure ways to meet people through board games, study sessions, and neighborhood routines.',
-    Decimal('9.00'), 11, date_joined_offset_days=45,
+    Decimal('7.00'), 11, date_joined_offset_days=45,
     avatar_url=dicebear_avatar('murat'),
     banner_url=semantic_banner_image('board games study session city'),
     location='Kadıköy, Istanbul',
@@ -611,8 +611,8 @@ cem_chess_offer = Service.objects.create(
     location_lat=Decimal('40.9819'),
     location_lng=Decimal('29.0244'),
     max_participants=1,
-    schedule_type='Recurrent',
-    schedule_details='Every Sunday at 15:00',
+    schedule_type='One-Time',
+    schedule_details='Next Sunday at 15:00',
     status='Active',
     created_at=timezone.now() - timedelta(days=18),
 )
@@ -720,8 +720,8 @@ zeynep_language = Service.objects.create(
     duration=Decimal('1.00'),
     location_type='Online',
     max_participants=1,
-    schedule_type='Recurrent',
-    schedule_details='Every Wednesday at 20:00',
+    schedule_type='One-Time',
+    schedule_details='Next Wednesday at 20:00',
     status='Active',
     created_at=timezone.now() - timedelta(days=22),
 )
@@ -812,7 +812,7 @@ print(f"  Created: {deniz_tech.title}")
 
 burak_chess = Service.objects.create(
     user=burak,
-    title='Looking for a Weekly Chess Practice Partner',
+    title='Looking for a Chess Practice Partner',
     description='I am looking for steady, friendly practice games where we can talk through moves and keep each other improving over time. Casual and community-minded is ideal.',
     type='Need',
     duration=Decimal('1.00'),
@@ -821,8 +821,8 @@ burak_chess = Service.objects.create(
     location_lat=Decimal('40.9819'),
     location_lng=Decimal('29.0244'),
     max_participants=1,
-    schedule_type='Recurrent',
-    schedule_details='Every Friday evening',
+    schedule_type='One-Time',
+    schedule_details='This Friday evening',
     status='Active',
     created_at=timezone.now() - timedelta(days=9),
 )
@@ -862,8 +862,8 @@ deniz_jogging = Service.objects.create(
     location_lat=Decimal('40.9819'),
     location_lng=Decimal('29.0244'),
     max_participants=1,
-    schedule_type='Recurrent',
-    schedule_details='Weekdays at 07:00',
+    schedule_type='One-Time',
+    schedule_details='Tomorrow at 07:00',
     status='Active',
     created_at=timezone.now() - timedelta(days=4),
 )
@@ -903,8 +903,8 @@ selin_reading_circle = create_demo_service(
     location_lat=Decimal('41.0320'),
     location_lng=Decimal('28.9740'),
     max_participants=6,
-    schedule_type='Recurrent',
-    schedule_details='Every other Thursday at 19:00 in Cihangir',
+    schedule_type='One-Time',
+    schedule_details='Next Thursday at 19:00 in Cihangir',
     tags=[language_tag, education_tag],
     created_days_ago=30,
 )
@@ -954,9 +954,9 @@ emre_boardgames_need = create_demo_service(
     location_area='Üsküdar',
     location_lat=Decimal('41.0257'),
     location_lng=Decimal('29.0154'),
-    max_participants=3,
-    schedule_type='Recurrent',
-    schedule_details='Saturday evenings, twice a month',
+    max_participants=1,
+    schedule_type='One-Time',
+    schedule_details='This Saturday evening',
     tags=[chess_tag, education_tag],
     created_days_ago=11,
 )
@@ -995,14 +995,14 @@ yasemin_recipe_need = create_demo_service(
 
 murat_study_need = create_demo_service(
     user=murat,
-    title='Looking for a Weekly Accountability Study Session',
+    title='Looking for an Accountability Study Session',
     description='Remote work has made my weeks blur together. I am looking for one or two people to meet regularly, set a realistic goal, work quietly, and check in at the end.',
     service_type='Need',
     duration='1.00',
     location_type='Online',
-    max_participants=2,
-    schedule_type='Recurrent',
-    schedule_details='Tuesday evenings online',
+    max_participants=1,
+    schedule_type='One-Time',
+    schedule_details='This Tuesday evening online',
     tags=[education_tag, technology_tag],
     created_days_ago=5,
 )
@@ -1036,8 +1036,8 @@ levent_singalong = create_demo_service(
     location_lat=Decimal('41.0320'),
     location_lng=Decimal('28.9740'),
     max_participants=5,
-    schedule_type='Recurrent',
-    schedule_details='Every Sunday at 16:00',
+    schedule_type='One-Time',
+    schedule_details='This Sunday at 16:00',
     tags=[music_tag, education_tag],
     created_days_ago=40,
 )
@@ -1139,7 +1139,7 @@ for service in services:
     media_urls = [semantic_service_image(service)]
     if service.type == 'Event':
         media_urls.extend(semantic_gallery_images(service.title, 2, start_offset=5))
-    elif service.max_participants > 1 or service.schedule_type == 'Recurrent':
+    elif service.max_participants > 1:
         media_urls.extend(semantic_gallery_images(service.title, 1, start_offset=3))
 
     for display_order, media_url in enumerate(media_urls):
@@ -1193,7 +1193,7 @@ def simulate_handshake_workflow(service, requester, provider_initiated_days_ago=
 
     # Mirror accept_handshake view logic:
     # Only when all slots are filled do we deny remaining pending handshakes
-    # and transition the service to Agreed. Recurrent stays Active.
+    # and transition the service to Agreed.
     if service.schedule_type == 'One-Time':
         accepted_count = Handshake.objects.filter(
             service=service,
@@ -1243,36 +1243,7 @@ def simulate_handshake_workflow(service, requester, provider_initiated_days_ago=
         )
     
     if completed_days_ago is not None:
-        completion_time = timezone.now() - timedelta(days=completed_days_ago)
-        with transaction.atomic():
-            handshake.provider_confirmed_complete = True
-            handshake.receiver_confirmed_complete = True
-            handshake.updated_at = completion_time
-            # Don't set status='completed' before complete_timebank_transfer —
-            # the function exits early (idempotency guard) if status is already
-            # 'completed', skipping the service-status update logic.
-            handshake.save()
-            complete_timebank_transfer(handshake)
-
-            # After transfer, manually back-date the timestamps
-            Handshake.objects.filter(pk=handshake.pk).update(updated_at=completion_time)
-
-            # Sync service status: One-Time services should become 'Completed'
-            # when no active handshakes remain (mirrors utils.py logic).
-            svc = Service.objects.get(pk=service.pk)
-            if svc.schedule_type == 'One-Time':
-                active_count = Handshake.objects.filter(
-                    service=svc,
-                    status__in=['pending', 'accepted', 'reported', 'paused'],
-                ).count()
-                if active_count == 0 and svc.status != 'Completed':
-                    svc.status = 'Completed'
-                    svc.save(update_fields=['status'])
-
-        handshake.refresh_from_db()
-        check_and_assign_badges(provider)
-        check_and_assign_badges(receiver)
-
+        handshake = complete_seeded_handshake(handshake, completed_days_ago=completed_days_ago)
         return handshake, True
     
     return handshake, False
@@ -1290,6 +1261,41 @@ def sync_fixed_group_offer_time(service, scheduled_time):
         exact_duration=service.duration,
     )
     service.refresh_from_db(fields=['scheduled_time'])
+
+
+def complete_seeded_handshake(handshake, *, completed_days_ago):
+    """Mark an already-accepted handshake as completed with realistic backdated timestamps."""
+    completion_time = timezone.now() - timedelta(days=completed_days_ago)
+    with transaction.atomic():
+        handshake.provider_confirmed_complete = True
+        handshake.receiver_confirmed_complete = True
+        handshake.updated_at = completion_time
+        # Don't set status='completed' before complete_timebank_transfer —
+        # the function exits early (idempotency guard) if status is already
+        # 'completed', skipping the service-status update logic.
+        handshake.save()
+        complete_timebank_transfer(handshake)
+
+        # After transfer, manually back-date the timestamps.
+        Handshake.objects.filter(pk=handshake.pk).update(updated_at=completion_time)
+
+        # Sync service status: One-Time services should become 'Completed'
+        # when no active handshakes remain (mirrors utils.py logic).
+        svc = Service.objects.get(pk=handshake.service.pk)
+        if svc.schedule_type == 'One-Time':
+            active_count = Handshake.objects.filter(
+                service=svc,
+                status__in=['pending', 'accepted', 'reported', 'paused'],
+            ).count()
+            if active_count == 0 and svc.status != 'Completed':
+                svc.status = 'Completed'
+                svc.save(update_fields=['status'])
+
+    handshake.refresh_from_db()
+    provider, receiver = get_provider_and_receiver(handshake)
+    check_and_assign_badges(provider)
+    check_and_assign_badges(receiver)
+    return handshake
 
 
 def add_public_chat_messages(service, messages, base_time):
@@ -1531,7 +1537,7 @@ print(f"  Accepted (pending completion): {ayse_plant_advice.title} (Ayşe -> Zey
 handshake14, completed = simulate_handshake_workflow(
     burak_chess, cem, provider_initiated_days_ago=0
 )
-handshake14 = expect_handshake_state(handshake14, completed, expected_completed=False, label='Looking for a Weekly Chess Practice Partner (Burak -> Cem)')
+handshake14 = expect_handshake_state(handshake14, completed, expected_completed=False, label='Looking for a Chess Practice Partner (Burak -> Cem)')
 accepted_handshakes.append(handshake14)
 print(f"  Accepted (pending completion): {burak_chess.title} (Burak -> Cem)")
 
@@ -1539,11 +1545,10 @@ pending1 = create_pending_interest(elif_tech, deniz, age_delta=timedelta(days=1)
 pending2 = create_pending_interest(burak_guitar, deniz, age_delta=timedelta(hours=12), label='Burak -> Deniz')
 
 handshake16, completed = simulate_handshake_workflow(
-    selin_reading_circle, murat, provider_initiated_days_ago=18, completed_days_ago=13
+    selin_reading_circle, murat, provider_initiated_days_ago=18
 )
-handshake16 = expect_handshake_state(handshake16, completed, expected_completed=True, label='Slow Reading Circle for Curious Neighbors (Selin -> Murat)')
-completed_handshakes.append(handshake16)
-print(f"  Completed: {selin_reading_circle.title} (Selin -> Murat)")
+handshake16 = expect_handshake_state(handshake16, completed, expected_completed=False, label='Slow Reading Circle for Curious Neighbors (Selin -> Murat)')
+print(f"  Accepted (pending completion): {selin_reading_circle.title} (Selin -> Murat)")
 
 handshake17, completed = simulate_handshake_workflow(
     selin_reading_circle, can, provider_initiated_days_ago=12, completed_days_ago=7
@@ -1551,6 +1556,9 @@ handshake17, completed = simulate_handshake_workflow(
 handshake17 = expect_handshake_state(handshake17, completed, expected_completed=True, label='Slow Reading Circle for Curious Neighbors (Selin -> Can)')
 completed_handshakes.append(handshake17)
 print(f"  Completed: {selin_reading_circle.title} (Selin -> Can)")
+handshake16 = complete_seeded_handshake(handshake16, completed_days_ago=6)
+completed_handshakes.append(handshake16)
+print(f"  Completed: {selin_reading_circle.title} (Selin -> Murat)")
 
 handshake18, completed = simulate_handshake_workflow(
     yasemin_coffee_offer, zeynep, provider_initiated_days_ago=9, completed_days_ago=6
@@ -1591,7 +1599,7 @@ print(f"  Accepted (pending completion): {murat_boardgames_offer.title} (Murat -
 handshake23, completed = simulate_handshake_workflow(
     murat_study_need, zeynep, provider_initiated_days_ago=1
 )
-handshake23 = expect_handshake_state(handshake23, completed, expected_completed=False, label='Looking for a Weekly Accountability Study Session (Murat -> Zeynep)')
+handshake23 = expect_handshake_state(handshake23, completed, expected_completed=False, label='Looking for an Accountability Study Session (Murat -> Zeynep)')
 accepted_handshakes.append(handshake23)
 print(f"  Accepted (pending completion): {murat_study_need.title} (Murat -> Zeynep)")
 
@@ -1604,7 +1612,7 @@ print(f"  Cancelled with refund: {selin_potluck_need.title} (Selin -> Yasemin)")
 
 pending3 = create_pending_interest(emre_boardgames_need, burak, age_delta=timedelta(days=2), label='Emre -> Burak')
 pending4 = create_pending_interest(yasemin_recipe_need, elif_user, age_delta=timedelta(hours=30), label='Yasemin -> Elif')
-pending5 = create_pending_interest(selin_reading_circle, emre, age_delta=timedelta(hours=18), label='Selin -> Emre')
+pending5 = create_pending_interest(murat_boardgames_offer, emre, age_delta=timedelta(hours=18), label='Murat -> Emre')
 
 print("  Creating event participation...")
 selin_event_1 = event_rsvp(selin_reading_event, elif_user, joined_days_ago=4)
@@ -1953,8 +1961,8 @@ topics = [
     {
         'category': forum_feedback,
         'author': murat,
-        'title': 'Could the platform surface smaller recurring meetups more clearly?',
-        'body': 'As a newcomer, I find one-time events easily, but I almost missed recurring circles that might be even better for building routine. Curious if others feel the same.',
+        'title': 'Could the platform surface smaller meetups more clearly?',
+        'body': 'As a newcomer, I can find big events quickly, but I nearly missed small circles that might be better for building trust. Curious if others feel the same.',
         'created_at': timezone.now() - timedelta(days=3),
         'view_count': 33,
     },
@@ -1998,7 +2006,7 @@ posts_data = [
     (forum_topics[5], emre, "That is a great idea. I want the route to be social, not just scenic.", timezone.now() - timedelta(days=3, hours=12)),
     (forum_topics[6], mehmet, "I write down who told the story, where we were sitting, and what season it was. Those details matter later.", timezone.now() - timedelta(days=8, hours=16)),
     (forum_topics[6], yasemin, "That is beautiful. It is exactly the kind of context I am trying not to lose.", timezone.now() - timedelta(days=8, hours=10)),
-    (forum_topics[7], selin, "Yes. Small recurring gatherings are often where trust actually forms.", timezone.now() - timedelta(days=2, hours=22)),
+    (forum_topics[7], selin, "Yes. Smaller gatherings are often where trust actually forms.", timezone.now() - timedelta(days=2, hours=22)),
     (forum_topics[7], ayse, "A filter for 'easy to join' or 'good for newcomers' could help too.", timezone.now() - timedelta(days=2, hours=12)),
     (forum_topics[8], elif_user, "For me it was when the conversation continued after the practical part was over.", timezone.now() - timedelta(days=10, hours=16)),
     (forum_topics[8], levent, "That is such a good way to put it. The exchange becomes memorable when no one is performing usefulness.", timezone.now() - timedelta(days=10, hours=8)),

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -402,7 +402,7 @@ yasemin = create_or_update_user(
 murat = create_or_update_user(
     'murat@demo.com', 'Murat', 'Sezer',
     'Recently moved to Istanbul for remote work and is using The Hive to find low-pressure ways to meet people through board games, study sessions, and neighborhood routines.',
-    Decimal('7.00'), 11, date_joined_offset_days=45,
+    Decimal('9.00'), 11, date_joined_offset_days=45,
     avatar_url=dicebear_avatar('murat'),
     banner_url=semantic_banner_image('board games study session city'),
     location='Kadıköy, Istanbul',

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1192,13 +1192,35 @@ function isUrlSegment(segment: string): boolean {
   return segment.startsWith('http://') || segment.startsWith('https://')
 }
 
+function splitLinkAndTrailingPunctuation(segment: string): { href: string; trailing: string } {
+  let href = segment
+  let trailing = ''
+
+  // Strip sentence punctuation first (excluding parentheses).
+  const punctuation = href.match(/[.,;:!?]+$/)?.[0] ?? ''
+  if (punctuation) {
+    href = href.slice(0, -punctuation.length)
+    trailing = punctuation + trailing
+  }
+
+  // Strip only unmatched trailing ')' so valid URLs ending with ')' still work.
+  while (href.endsWith(')')) {
+    const openParenCount = (href.match(/\(/g) ?? []).length
+    const closeParenCount = (href.match(/\)/g) ?? []).length
+    if (closeParenCount <= openParenCount) break
+    href = href.slice(0, -1)
+    trailing = `)${trailing}`
+  }
+
+  return { href, trailing }
+}
+
 /** Splits message body into segments and returns React nodes; URLs become clickable links. */
 function linkifyMessageBody(body: string, linkColor: string): ReactNode[] {
   const segments = body.split(URL_IN_MESSAGE)
   return segments.map((segment, i) => {
     if (isUrlSegment(segment)) {
-      const trailingPunctuation = segment.match(/[.,;:)!?]+$/)?.[0] ?? ''
-      const href = trailingPunctuation ? segment.slice(0, -trailingPunctuation.length) : segment
+      const { href, trailing } = splitLinkAndTrailingPunctuation(segment)
       return (
         <span key={i}>
           <Link
@@ -1213,7 +1235,7 @@ function linkifyMessageBody(body: string, linkColor: string): ReactNode[] {
           >
             {href}
           </Link>
-          {trailingPunctuation}
+          {trailing}
         </span>
       )
     }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1560,6 +1560,18 @@ export default function ChatPage() {
   paramIdRef.current    = paramId
 
   const selectedConv     = conversations.find((c) => c.handshake_id === selectedId) ?? null
+  const selectedGroupConversation = useMemo(
+    () => conversations.find((c) => c.service_id === groupServiceId) ?? null,
+    [conversations, groupServiceId],
+  )
+  const groupRequiresSession = useMemo(
+    () => (
+      selectedGroupConversation?.schedule_type === 'Recurrent'
+      && selectedGroupConversation?.service_type !== 'Event'
+      && (selectedGroupConversation?.max_participants ?? 0) > 1
+    ),
+    [selectedGroupConversation],
+  )
   const refreshConversations = useCallback(() => setConvRefreshTick((n) => n + 1), [])
 
   useEffect(() => {
@@ -1613,7 +1625,23 @@ export default function ChatPage() {
   const fetchGroupMessages = useCallback(async (signal: AbortSignal) => {
     if (!groupServiceId) return
     try {
-      const fetched = await groupChatAPI.getMessages(groupServiceId, signal, groupSessionId)
+      let resolvedSessionId = groupSessionId
+      if (!resolvedSessionId) {
+        // Resolve session first for recurrent group chats to avoid an expected 400 round-trip.
+        const sessions = await groupChatAPI.getSessions(groupServiceId, signal)
+        const firstSession = sessions[0]
+        if (firstSession) {
+          resolvedSessionId = firstSession.id
+          setGroupSessionId((prev) => prev ?? firstSession.id)
+        } else if (groupRequiresSession) {
+          setGroupMessages([])
+          setGroupParticipants([])
+          setGroupLoadError("Group chat isn't available for this post yet. It will appear once this post has active participants.")
+          return
+        }
+      }
+
+      const fetched = await groupChatAPI.getMessages(groupServiceId, signal, resolvedSessionId)
       setGroupLoadError(null)
       setGroupMessages(fetched.messages)
       setGroupParticipants(fetched.participants)
@@ -1638,7 +1666,7 @@ export default function ChatPage() {
         throw err
       }
     }
-  }, [groupServiceId, groupSessionId])
+  }, [groupServiceId, groupSessionId, groupRequiresSession])
 
   // Initial load from DB when conversation is selected (so old messages show even when polling is off in dev)
   useEffect(() => {
@@ -1713,7 +1741,7 @@ export default function ChatPage() {
     url: groupWsUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onMessage: handleGroupWsMessage as any,
-    enabled: !!groupServiceId && isAuthenticated,
+    enabled: !!groupServiceId && isAuthenticated && (!groupRequiresSession || !!groupSessionId),
   })
 
   const selectConversation = useCallback((id: string) => {


### PR DESCRIPTION
## Summary
This PR improves group chat stability and aligns demo seeding with product rules.
- Prevents initial recurrent group chat requests without `session_id` on the frontend.
- Adds clearer WS rejection handling/logging in `GroupChatConsumer` with explicit close codes.
- Updates demo setup to remove recurrent service seeds and enforce single-provider `Need` services (`max_participants=1`).
- Fixes one-time demo handshake sequencing so `make setup-demo` runs end-to-end without `Service is not active`.

## Test Plan
- `npm run lint -- src/pages/ChatPage.tsx`
- `python3 -m py_compile backend/setup_demo.py`
- `make setup-demo`