### PR TITLE
fix(report): add report handling and event participant removal functionality

### DIFF
--- a/backend/api/tests/integration/test_reporting_api.py
+++ b/backend/api/tests/integration/test_reporting_api.py
@@ -134,9 +134,9 @@ class TestReportingAPI:
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        report = response.json()
-        assert report["issue_type"] == "harassment"
-        assert report["description"] == payload["description"]
+        report = Report.objects.get(id=response.data["report_id"])
+        assert report.type == "harassment"
+        assert report.description == payload["description"]
 
     def test_event_handshake_allows_behavior_reports_during_24h_window(self):
         organizer = UserFactory()

--- a/backend/api/tests/integration/test_reporting_api.py
+++ b/backend/api/tests/integration/test_reporting_api.py
@@ -99,7 +99,7 @@ class TestReportingAPI:
         assert handshake_report.status_code == status.HTTP_201_CREATED
         assert "report_id" in handshake_report.data
 
-    def test_non_event_handshake_rejects_behavior_issue_types(self):
+    def test_non_event_handshake_report_keeps_active_status(self):
         provider = UserFactory()
         reporter = UserFactory()
         service = ServiceFactory(user=provider, type="Offer")
@@ -108,12 +108,35 @@ class TestReportingAPI:
         reporter_client = AuthenticatedAPIClient().authenticate_user(reporter)
         response = reporter_client.post(
             f"/api/handshakes/{handshake.id}/report/",
-            {"issue_type": "harassment", "description": "Abusive language in chat."},
+            {"issue_type": "service_issue", "description": "Abusive language during handshake."},
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "invalid issue_type" in (response.data.get("detail", "") or "").lower()
+        assert response.status_code == status.HTTP_201_CREATED
+        handshake.refresh_from_db()
+        assert handshake.status == "accepted"
+
+    def test_non_event_handshake_accepts_behavior_issue_types(self):
+        provider = UserFactory()
+        reporter = UserFactory()
+        service = ServiceFactory(user=provider, type="Offer")
+        handshake = HandshakeFactory(service=service, requester=reporter, status="accepted")
+
+        reporter_client = AuthenticatedAPIClient().authenticate_user(reporter)
+        payload = {
+            "issue_type": "harassment",
+            "description": "Participant used abusive language during the exchange.",
+        }
+        response = reporter_client.post(
+            f"/api/handshakes/{handshake.id}/report/",
+            payload,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        report = response.json()
+        assert report["issue_type"] == "harassment"
+        assert report["description"] == payload["description"]
 
     def test_event_handshake_allows_behavior_reports_during_24h_window(self):
         organizer = UserFactory()
@@ -138,7 +161,27 @@ class TestReportingAPI:
         assert report.type == "harassment"
         assert report.reported_user_id == organizer.id
 
-    def test_event_handshake_rejects_reports_before_event_start(self):
+    def test_event_handshake_allows_behavior_reports_before_event_start(self):
+        organizer = UserFactory()
+        participant = UserFactory()
+        event = ServiceFactory(
+            user=organizer,
+            type="Event",
+            max_participants=10,
+            scheduled_time=timezone.now() + timedelta(hours=1),
+        )
+        handshake = HandshakeFactory(service=event, requester=participant, status="accepted")
+
+        participant_client = AuthenticatedAPIClient().authenticate_user(participant)
+        response = participant_client.post(
+            f"/api/handshakes/{handshake.id}/report/",
+            {"issue_type": "harassment", "description": "Abusive chat behavior before event start."},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_event_handshake_rejects_no_show_reports_before_event_start(self):
         organizer = UserFactory()
         participant = UserFactory()
         event = ServiceFactory(
@@ -157,9 +200,9 @@ class TestReportingAPI:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "up to 24 hours" in (response.data.get("detail", "") or "").lower()
+        assert "no-show reports are allowed" in (response.data.get("detail", "") or "").lower()
 
-    def test_event_handshake_rejects_reports_after_24h_window(self):
+    def test_event_handshake_rejects_no_show_reports_after_24h_window(self):
         organizer = UserFactory()
         participant = UserFactory()
         event = ServiceFactory(
@@ -173,12 +216,32 @@ class TestReportingAPI:
         participant_client = AuthenticatedAPIClient().authenticate_user(participant)
         response = participant_client.post(
             f"/api/handshakes/{handshake.id}/report/",
-            {"issue_type": "service_issue", "description": "Attempt after report window."},
+            {"issue_type": "no_show", "description": "Attempt after report window."},
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "up to 24 hours" in (response.data.get("detail", "") or "").lower()
+        assert "no-show reports are allowed" in (response.data.get("detail", "") or "").lower()
+
+    def test_event_handshake_allows_behavior_reports_after_24h_window(self):
+        organizer = UserFactory()
+        participant = UserFactory()
+        event = ServiceFactory(
+            user=organizer,
+            type="Event",
+            max_participants=10,
+            scheduled_time=timezone.now() - timedelta(hours=26),
+        )
+        handshake = HandshakeFactory(service=event, requester=participant, status="accepted")
+
+        participant_client = AuthenticatedAPIClient().authenticate_user(participant)
+        response = participant_client.post(
+            f"/api/handshakes/{handshake.id}/report/",
+            {"issue_type": "service_issue", "description": "Late behavior report after event."},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
 
     def test_event_participant_can_report_another_participant_with_reported_user_id(self):
         organizer = UserFactory()
@@ -208,6 +271,10 @@ class TestReportingAPI:
         report = Report.objects.get(id=response.data["report_id"])
         assert report.reported_user_id == target_participant.id
         assert report.type == "spam"
+        # Reporter's own handshake must NOT be marked 'reported' when reporting
+        # a fellow participant (non-organizer).
+        reporter_handshake.refresh_from_db()
+        assert reporter_handshake.status == "accepted"
 
     def test_duplicate_open_handshake_report_is_blocked_but_resolved_report_allows_new(self):
         organizer = UserFactory()

--- a/backend/api/tests/integration/test_reputation_api.py
+++ b/backend/api/tests/integration/test_reputation_api.py
@@ -934,3 +934,77 @@ class TestAdminReportResolutionStatusMapping:
         assert response.status_code == status.HTTP_200_OK
         report.refresh_from_db()
         assert report.status == 'resolved'
+
+    def test_remove_from_event_action_cancels_participant_and_resolves_report(self):
+        organizer = UserFactory()
+        reporter = UserFactory()
+        reported_participant = UserFactory()
+        event = ServiceFactory(user=organizer, type='Event', status='Active')
+
+        reporter_handshake = HandshakeFactory(
+            service=event,
+            requester=reporter,
+            status='accepted',
+            provisioned_hours=0,
+        )
+        participant_handshake = HandshakeFactory(
+            service=event,
+            requester=reported_participant,
+            status='accepted',
+            provisioned_hours=0,
+        )
+
+        report = Report.objects.create(
+            reporter=reporter,
+            reported_user=reported_participant,
+            related_handshake=reporter_handshake,
+            reported_service=event,
+            type='harassment',
+            status='pending',
+            description='Participant sent abusive event chat messages.',
+        )
+
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        admin_client = AuthenticatedAPIClient().authenticate_admin(admin)
+        response = admin_client.post(
+            f'/api/admin/reports/{report.id}/resolve/',
+            {'action': 'remove_from_event', 'admin_notes': 'Removed after chat abuse report.'},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        report.refresh_from_db()
+        participant_handshake.refresh_from_db()
+        assert report.status == 'resolved'
+        assert participant_handshake.status == 'cancelled'
+
+    def test_remove_from_event_rejects_when_reported_user_is_event_organizer(self):
+        organizer = UserFactory()
+        reporter = UserFactory()
+        event = ServiceFactory(user=organizer, type='Event', status='Active')
+
+        reporter_handshake = HandshakeFactory(
+            service=event,
+            requester=reporter,
+            status='accepted',
+            provisioned_hours=0,
+        )
+
+        report = Report.objects.create(
+            reporter=reporter,
+            reported_user=organizer,
+            related_handshake=reporter_handshake,
+            reported_service=event,
+            type='harassment',
+            status='pending',
+            description='Organizer chat behavior report.',
+        )
+
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        admin_client = AuthenticatedAPIClient().authenticate_admin(admin)
+        response = admin_client.post(
+            f'/api/admin/reports/{report.id}/resolve/',
+            {'action': 'remove_from_event'},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'organizer cannot be removed' in (response.data.get('detail', '') or '').lower()

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2036,6 +2036,7 @@ class ServiceViewSet(viewsets.ModelViewSet):
                 str(e), code=ErrorCodes.INVALID_STATE,
                 status_code=status.HTTP_400_BAD_REQUEST
             )
+        invalidate_service_lists()
         serializer = self.get_serializer(service)
         return Response(serializer.data)
 
@@ -3551,12 +3552,9 @@ class HandshakeViewSet(viewsets.ModelViewSet):
         description = (request.data.get('description') or '').strip()
         is_event_handshake = handshake.service.type == 'Event'
 
-        # Event handshakes support broader behavior report types; non-event
-        # handshakes only support no-show/service-issue disputes.
-        if is_event_handshake:
-            allowed_types = {'no_show', 'service_issue', 'harassment', 'spam', 'scam', 'other'}
-        else:
-            allowed_types = {'no_show', 'service_issue'}
+        # Both event and non-event handshakes support behavior issue reports.
+        # Non-event handshakes still do not support target overrides.
+        allowed_types = {'no_show', 'service_issue', 'harassment', 'spam', 'scam', 'other'}
 
         if issue_type not in allowed_types:
             return create_error_response(
@@ -3578,7 +3576,7 @@ class HandshakeViewSet(viewsets.ModelViewSet):
                 status_code=status.HTTP_403_FORBIDDEN
             )
 
-        if is_event_handshake:
+        if is_event_handshake and issue_type == 'no_show':
             event_start = handshake.service.scheduled_time or handshake.scheduled_time
             if not event_start:
                 return create_error_response(
@@ -3591,7 +3589,7 @@ class HandshakeViewSet(viewsets.ModelViewSet):
             report_window_ends_at = event_start + timedelta(hours=24)
             if now < event_start or now > report_window_ends_at:
                 return create_error_response(
-                    'Event reports are allowed from event start time up to 24 hours after start.',
+                    'Event no-show reports are allowed from event start time up to 24 hours after start.',
                     code=ErrorCodes.VALIDATION_ERROR,
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
@@ -3672,8 +3670,16 @@ class HandshakeViewSet(viewsets.ModelViewSet):
             description=description,
         )
 
-        handshake.status = 'reported'
-        handshake.save()
+        # Only mark the reporter's handshake as 'reported' when reporting the
+        # event organizer — participant-vs-participant reports should not affect
+        # the reporter's own event participation status.
+        reported_is_organizer = (
+            reported_user is not None
+            and str(reported_user.id) == str(handshake.service.user_id)
+        )
+        if is_event_handshake and reported_is_organizer and handshake.status != 'reported':
+            handshake.status = 'reported'
+            handshake.save(update_fields=['status', 'updated_at'])
 
         admins = User.objects.filter(role='admin')
         for admin in admins:
@@ -4764,7 +4770,111 @@ class AdminReportViewSet(viewsets.ReadOnlyModelViewSet):
         from .utils import get_provider_and_receiver
         from django.utils import timezone
 
-        if action_type == 'confirm_no_show':
+        if action_type == 'remove_from_event':
+            handshake = report.related_handshake
+            if not handshake:
+                return create_error_response(
+                    'This report has no related handshake. Cannot remove participant from event.',
+                    code=ErrorCodes.VALIDATION_ERROR,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if handshake.service.type != 'Event':
+                return create_error_response(
+                    'Remove from event is only available for event reports.',
+                    code=ErrorCodes.VALIDATION_ERROR,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if not report.reported_user_id:
+                return create_error_response(
+                    'This report has no reported participant to remove.',
+                    code=ErrorCodes.VALIDATION_ERROR,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            if str(report.reported_user_id) == str(handshake.service.user_id):
+                return create_error_response(
+                    'Event organizer cannot be removed from their own event.',
+                    code=ErrorCodes.VALIDATION_ERROR,
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            with transaction.atomic():
+                target_handshake = (
+                    Handshake.objects
+                    .select_for_update()
+                    .select_related('service', 'requester')
+                    .filter(service=handshake.service, requester_id=report.reported_user_id)
+                    .order_by('-updated_at')
+                    .first()
+                )
+                if not target_handshake:
+                    return create_error_response(
+                        'Could not find an active event participant handshake for the reported user.',
+                        code=ErrorCodes.NOT_FOUND,
+                        status_code=status.HTTP_404_NOT_FOUND
+                    )
+
+                if target_handshake.status not in ['accepted', 'checked_in', 'reported', 'paused']:
+                    return create_error_response(
+                        f'Cannot remove participant with handshake status "{target_handshake.status}".',
+                        code=ErrorCodes.INVALID_STATE,
+                        status_code=status.HTTP_400_BAD_REQUEST
+                    )
+
+                target_handshake.status = 'cancelled'
+                target_handshake.save(update_fields=['status', 'updated_at'])
+
+                report.status = 'resolved'
+                report.resolved_by = request.user
+                report.resolved_at = timezone.now()
+                report.admin_notes = admin_notes or 'Reported participant removed from event by admin moderation'
+                report.save()
+
+                create_notification(
+                    user=target_handshake.requester,
+                    notification_type='admin_warning',
+                    title='Removed From Event',
+                    message=f'You were removed from the event "{target_handshake.service.title}" after moderator review.',
+                    handshake=target_handshake,
+                    service=target_handshake.service,
+                )
+
+                if report.reporter_id and report.reporter_id != target_handshake.requester_id:
+                    create_notification(
+                        user=report.reporter,
+                        notification_type='dispute_resolved',
+                        title='Report Resolved',
+                        message=f'Your report was upheld and the participant was removed from "{target_handshake.service.title}".',
+                        handshake=target_handshake,
+                        service=target_handshake.service,
+                    )
+
+                if target_handshake.service.user_id not in [target_handshake.requester_id, report.reporter_id]:
+                    create_notification(
+                        user=target_handshake.service.user,
+                        notification_type='admin_warning',
+                        title='Participant Removed',
+                        message=f'A participant was removed from your event "{target_handshake.service.title}" after moderation review.',
+                        handshake=target_handshake,
+                        service=target_handshake.service,
+                    )
+
+            invalidate_conversations(str(target_handshake.requester_id))
+            invalidate_conversations(str(target_handshake.service.user_id))
+            if report.reporter_id:
+                invalidate_conversations(str(report.reporter_id))
+
+            log_admin_action(
+                request.user,
+                'resolve_report',
+                'report',
+                report,
+                admin_notes or action_type,
+            )
+
+        elif action_type == 'confirm_no_show':
             # REQ-ADM-007: Handle no-show with correct financial action
             # REQ-ADM-008: Apply karma penalty to no-show user
             
@@ -4931,7 +5041,7 @@ class AdminReportViewSet(viewsets.ReadOnlyModelViewSet):
         
         else:
             return create_error_response(
-                'Invalid action. Use "confirm_no_show" or "dismiss".',
+                'Invalid action. Use "confirm_no_show", "dismiss", or "remove_from_event".',
                 code=ErrorCodes.VALIDATION_ERROR,
                 status_code=status.HTTP_400_BAD_REQUEST
             )

--- a/frontend/src/components/ReportModal.tsx
+++ b/frontend/src/components/ReportModal.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+import { FiSend } from 'react-icons/fi'
+
+import {
+  RED,
+  RED_LT,
+  GRAY100,
+  GRAY200,
+  GRAY500,
+  GRAY700,
+  GRAY800,
+  WHITE,
+} from '@/theme/tokens'
+
+export type ReportOption = {
+  value: string
+  label: string
+  desc: string
+}
+
+export default function ReportModal({
+  onClose,
+  onSubmit,
+  loading,
+  options,
+  title,
+  subtitle,
+  submitLabel = 'Submit Report',
+  zIndex = 2500,
+}: {
+  onClose: () => void
+  onSubmit: (t: string) => void
+  loading: boolean
+  options: ReportOption[]
+  title: string
+  subtitle: string
+  submitLabel?: string
+  zIndex?: number
+}) {
+  const [selected, setSelected] = useState<string>(options[0]?.value ?? '')
+  const selectedValue = options.some((opt) => opt.value === selected)
+    ? selected
+    : (options[0]?.value ?? '')
+
+  return (
+    <Box
+      position="fixed" inset={0} zIndex={zIndex}
+      bg="rgba(0,0,0,0.55)"
+      display="flex" alignItems="center" justifyContent="center"
+      p={4} onClick={onClose}
+    >
+      <Box
+        bg={WHITE} borderRadius="20px" w="100%" maxW="440px" p={6}
+        boxShadow="0 20px 60px rgba(0,0,0,0.2)"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Text fontWeight={800} fontSize="18px" color={GRAY800} mb="4px">{title}</Text>
+        <Text fontSize="13px" color={GRAY500} mb={5}>{subtitle}</Text>
+        <Stack gap={2} mb={5}>
+          {options.map((opt) => (
+            <Box
+              key={opt.value}
+              as="label"
+              display="flex" alignItems="flex-start" gap={3} p={3}
+              borderRadius="10px" border="1px solid"
+              borderColor={selected === opt.value ? '#FCA5A5' : GRAY200}
+              bg={selected === opt.value ? RED_LT : WHITE}
+              cursor="pointer" transition="all 0.15s"
+            >
+              <input type="radio" name="reportType" value={opt.value}
+                checked={selectedValue === opt.value} onChange={() => setSelected(opt.value)}
+                style={{ marginTop: '3px', accentColor: RED }} />
+              <Box>
+                <Text fontSize="14px" fontWeight={600} color={GRAY800}>{opt.label}</Text>
+                <Text fontSize="12px" color={GRAY500}>{opt.desc}</Text>
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+        <Flex gap={2}>
+          <Box as="button" flex={1} py="10px" borderRadius="10px"
+            bg={RED} color={WHITE} fontSize="14px" fontWeight={700}
+            display="flex" alignItems="center" justifyContent="center" gap="6px"
+            onClick={() => !loading && selectedValue && onSubmit(selectedValue)}
+            style={{ opacity: loading ? 0.7 : 1, cursor: loading ? 'not-allowed' : 'pointer', border: 'none' }}
+          >
+            <FiSend size={14} /> {loading ? 'Submitting…' : submitLabel}
+          </Box>
+          <Box as="button" flex={1} py="10px" borderRadius="10px"
+            bg={GRAY100} color={GRAY700} fontSize="14px" fontWeight={600}
+            onClick={onClose}
+            style={{ border: 'none', cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.65 : 1 }}
+          >
+            Cancel
+          </Box>
+        </Flex>
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -63,6 +63,35 @@ function getReportedObjectLabel(report: AdminReport): string {
     || 'Content unavailable'
 }
 
+function hasPendingLinkedHandshake(report: AdminReport): boolean {
+  return Boolean(report.related_handshake) && report.handshake_status === 'pending'
+}
+
+function isEventNotStartedForNoShow(report: AdminReport): boolean {
+  if (report.reported_service_type !== 'Event') return false
+
+  if (report.handshake_scheduled_time) {
+    const startMs = new Date(report.handshake_scheduled_time).getTime()
+    if (!Number.isNaN(startMs) && startMs > Date.now()) return true
+  }
+
+  return ['pending', 'accepted', 'checked_in'].includes(report.handshake_status ?? '')
+}
+
+function canCloseReportedService(report: AdminReport): boolean {
+  if (!report.reported_service) return false
+  if (!report.reported_user || !report.reported_service_owner) return false
+  return report.reported_user === report.reported_service_owner
+}
+
+function canRemoveReportedUserFromEvent(report: AdminReport): boolean {
+  if (!report.related_handshake) return false
+  if (report.reported_service_type !== 'Event') return false
+  if (!report.reported_user) return false
+  if (report.reported_user === report.reported_service_owner) return false
+  return ['accepted', 'checked_in', 'reported', 'paused'].includes(report.handshake_status ?? '')
+}
+
 // ── Shared modal primitives ────────────────────────────────────────────────────
 const ModalBackdrop = ({ onClick, children }: { onClick: () => void; children: React.ReactNode }) => (
   <Box position="fixed" inset={0} zIndex={3000} display="flex" alignItems="center" justifyContent="center" p={4}
@@ -495,10 +524,23 @@ const AdminDashboard = () => {
       toast.error('This report has no linked handshake. Confirm no-show is disabled.')
       return
     }
+    if (action === 'confirm_no_show' && hasPendingLinkedHandshake(report)) {
+      toast.error('Confirm no-show is disabled while handshake status is pending.')
+      return
+    }
+    if (action === 'confirm_no_show' && isEventNotStartedForNoShow(report)) {
+      toast.error('Confirm no-show is disabled until the event has started.')
+      return
+    }
+    if (action === 'remove_from_event' && !canRemoveReportedUserFromEvent(report)) {
+      toast.error('Remove from event is only available for active reported event participants.')
+      return
+    }
 
     const labelMap: Record<string, { title: string; desc: string; label: string; accent: string; accentLt: string }> = {
       confirm_no_show: { title: 'Confirm No-Show', desc: 'Mark this as a no-show incident and resolve the report. This action cannot be undone.', label: 'Confirm no-show', accent: GREEN, accentLt: GREEN_LT },
       dismiss:         { title: 'Dismiss Report',  desc: 'Dismiss this report as unsubstantiated. The reported content will remain visible.', label: 'Dismiss', accent: BLUE, accentLt: BLUE_LT },
+      remove_from_event: { title: 'Remove From Event', desc: 'Remove the reported participant from this event and resolve the report.', label: 'Remove participant', accent: RED, accentLt: RED_LT },
     }
     const meta = labelMap[action] ?? { title: `Action: ${action}`, desc: 'Confirm this moderation action.', label: 'Confirm', accent: GREEN, accentLt: GREEN_LT }
 
@@ -535,6 +577,10 @@ const AdminDashboard = () => {
   const handlePauseReport = (report: AdminReport) => {
     if (!report.related_handshake) {
       toast.error('This report has no linked handshake. Pause is disabled.')
+      return
+    }
+    if (hasPendingLinkedHandshake(report)) {
+      toast.error('Pause handshake is disabled while handshake status is pending.')
       return
     }
 
@@ -610,9 +656,22 @@ const AdminDashboard = () => {
       toast.error('This report has no linked handshake. Confirm no-show is disabled.')
       return
     }
+    if (action === 'confirm_no_show' && hasPendingLinkedHandshake(openReport)) {
+      toast.error('Confirm no-show is disabled while handshake status is pending.')
+      return
+    }
+    if (action === 'confirm_no_show' && isEventNotStartedForNoShow(openReport)) {
+      toast.error('Confirm no-show is disabled until the event has started.')
+      return
+    }
+    if (action === 'remove_from_event' && !canRemoveReportedUserFromEvent(openReport)) {
+      toast.error('Remove from event is only available for active reported event participants.')
+      return
+    }
     const labelMap: Record<string, { title: string; desc: string; label: string; accent: string; accentLt: string }> = {
       confirm_no_show: { title: 'Confirm No-Show', desc: 'Mark this as a no-show incident and resolve the report.', label: 'Confirm no-show', accent: GREEN, accentLt: GREEN_LT },
       dismiss:         { title: 'Dismiss Report',  desc: 'Dismiss this report. The reported content will remain visible.', label: 'Dismiss', accent: BLUE, accentLt: BLUE_LT },
+      remove_from_event: { title: 'Remove From Event', desc: 'Remove the reported participant from this event and resolve the report.', label: 'Remove participant', accent: RED, accentLt: RED_LT },
     }
     const meta = labelMap[action] ?? { title: `Action: ${action}`, desc: 'Confirm this moderation action.', label: 'Confirm', accent: GREEN, accentLt: GREEN_LT }
     setConfirmModal({
@@ -635,6 +694,10 @@ const AdminDashboard = () => {
     if (!openReport) return
     if (!openReport.related_handshake) {
       toast.error('This report has no linked handshake. Pause is disabled.')
+      return
+    }
+    if (hasPendingLinkedHandshake(openReport)) {
+      toast.error('Pause handshake is disabled while handshake status is pending.')
       return
     }
     setConfirmModal({
@@ -1412,12 +1475,13 @@ const AdminDashboard = () => {
                         </Box>
 
                         {/* Actions — icon-only, label shown as native tooltip on hover */}
-                        <Flex w="108px" flexShrink={0} justify="flex-end" gap="4px" pl={2}
+                        <Flex w="136px" flexShrink={0} justify="flex-end" gap="4px" pl={2}
                           onClick={(e) => e.stopPropagation()}>
                           {mkBtn('Detail', <FiArrowUpRight size={11} />, GRAY700, GRAY100, GRAY200, () => requestOpenReport(report.id))}
-                          {mkBtn('No-show', <FiCheck size={11} />, GREEN, GREEN_LT, GREEN + '40', () => handleResolveReport(report, 'confirm_no_show'), !report.related_handshake)}
+                          {mkBtn('No-show', <FiCheck size={11} />, GREEN, GREEN_LT, GREEN + '40', () => handleResolveReport(report, 'confirm_no_show'), !report.related_handshake || hasPendingLinkedHandshake(report) || isEventNotStartedForNoShow(report))}
                           {mkBtn('Dismiss', <FiX size={11} />, BLUE, BLUE_LT, BLUE + '40', () => handleResolveReport(report, 'dismiss'))}
-                          {mkBtn('Pause', <FiPauseCircle size={11} />, AMBER, AMBER_LT, AMBER + '40', () => handlePauseReport(report), !report.related_handshake)}
+                          {mkBtn('Remove', <FiUserX size={11} />, RED, RED_LT, RED + '40', () => handleResolveReport(report, 'remove_from_event'), !canRemoveReportedUserFromEvent(report))}
+                          {mkBtn('Pause', <FiPauseCircle size={11} />, AMBER, AMBER_LT, AMBER + '40', () => handlePauseReport(report), !report.related_handshake || hasPendingLinkedHandshake(report))}
                         </Flex>
                       </Flex>
                     )
@@ -1893,6 +1957,7 @@ const AdminDashboard = () => {
                   )
                   const isForumReport = !!(openReport.reported_forum_topic || openReport.reported_forum_post)
                   const isServiceReport = !!openReport.reported_service
+                  const canCloseServiceFromReport = canCloseReportedService(openReport)
                   const isServiceAlreadyClosed = openReport.reported_service_status === 'Cancelled' || openReportService?.status === 'Cancelled'
                   const forumTopicPath = openReport.reported_forum_topic ? `/forum/topic/${openReport.reported_forum_topic}` : null
                   const hasHandshakeInfo = !!(openReport.related_handshake || openReport.handshake_status || openReport.handshake_scheduled_time || openReport.handshake_hours != null)
@@ -2142,11 +2207,14 @@ const AdminDashboard = () => {
                               {!isForumReport && (
                                 <PanelActionBtn label="Confirm no-show" icon={<FiCheck size={11} />} accent={GREEN} accentLt={GREEN_LT}
                                   onClick={() => resolveOpenReport('confirm_no_show')}
-                                  disabled={openReportActionLoading || !openReport.related_handshake} />
+                                  disabled={openReportActionLoading || !openReport.related_handshake || hasPendingLinkedHandshake(openReport) || isEventNotStartedForNoShow(openReport)} />
                               )}
                               <PanelActionBtn label="Dismiss" icon={<FiX size={11} />} accent={BLUE} accentLt={BLUE_LT}
                                 onClick={() => resolveOpenReport('dismiss')} disabled={openReportActionLoading} />
-                              {isServiceReport && (
+                              <PanelActionBtn label="Remove from event" icon={<FiUserX size={11} />} accent={RED} accentLt={RED_LT}
+                                onClick={() => resolveOpenReport('remove_from_event')}
+                                disabled={openReportActionLoading || !canRemoveReportedUserFromEvent(openReport)} />
+                              {isServiceReport && canCloseServiceFromReport && (
                                 <PanelActionBtn
                                   label={isServiceAlreadyClosed ? 'Already closed' : 'Close service'}
                                   icon={isServiceAlreadyClosed ? <FiSlash size={11} /> : <FiLock size={11} />}
@@ -2164,11 +2232,20 @@ const AdminDashboard = () => {
                               {!isForumReport && (
                                 <PanelActionBtn label="Pause handshake" icon={<FiPauseCircle size={11} />} accent={AMBER} accentLt={AMBER_LT}
                                   onClick={pauseOpenReport}
-                                  disabled={openReportActionLoading || !openReport.related_handshake} />
+                                  disabled={openReportActionLoading || !openReport.related_handshake || hasPendingLinkedHandshake(openReport)} />
                               )}
                             </Flex>
                             {!isForumReport && !openReport.related_handshake && (
                               <Text fontSize="11px" color={GRAY400} mt={2}>No linked handshake — no-show &amp; pause disabled.</Text>
+                            )}
+                            {!isForumReport && openReport.reported_service_type === 'Event' && !canRemoveReportedUserFromEvent(openReport) && (
+                              <Text fontSize="11px" color={GRAY400} mt={2}>Remove from event is available only for active reported event participants.</Text>
+                            )}
+                            {!isForumReport && hasPendingLinkedHandshake(openReport) && (
+                              <Text fontSize="11px" color={GRAY400} mt={2}>Pending handshake — no-show &amp; pause disabled.</Text>
+                            )}
+                            {!isForumReport && isEventNotStartedForNoShow(openReport) && (
+                              <Text fontSize="11px" color={GRAY400} mt={2}>Event not started — no-show confirm disabled.</Text>
                             )}
                           </Box>
                         </Box>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Flex, Text, Stack, Spinner, Link } from '@chakra-ui/react'
 import {
   FiSend,
   FiArrowLeft,
+  FiFlag,
   FiMessageSquare,
   FiWifiOff,
   FiCheck,
@@ -30,11 +31,12 @@ import {
   type GroupChatParticipant,
   type GroupChatMessage,
 } from '@/services/conversationAPI'
-import { handshakeAPI, type InitiatePayload } from '@/services/handshakeAPI'
+import { handshakeAPI, type InitiatePayload, type HandshakeIssueType } from '@/services/handshakeAPI'
 import { HandshakeDetailsModal } from '@/components/HandshakeDetailsModal'
 import { ProviderDetailsModal } from '@/components/ProviderDetailsModal'
 import { ServiceConfirmationModal } from '@/components/ServiceConfirmationModal'
 import ServiceEvaluationModal from '@/components/ServiceEvaluationModal'
+import ReportModal, { type ReportOption } from '@/components/ReportModal'
 
 import {
   GREEN, GREEN_LT, GREEN_MD,
@@ -52,6 +54,14 @@ const POLL_IN_DEV  = false // In dev, rely on WebSocket only to avoid hammering 
 
 const ACTIVE_STATUSES = new Set(['pending', 'accepted'])
 const CLOSED_STATUSES = new Set(['completed', 'cancelled', 'denied', 'reported', 'paused'])
+type ChatReportIssueType = Exclude<HandshakeIssueType, 'no_show'>
+const CHAT_REPORT_OPTIONS: ReportOption[] = [
+  { value: 'service_issue', label: 'Service issue', desc: 'Problem with quality, communication, or delivery' },
+  { value: 'harassment', label: 'Harassment', desc: 'Abusive, threatening, or unsafe behavior' },
+  { value: 'spam', label: 'Spam', desc: 'Repeated unwanted or disruptive messages' },
+  { value: 'scam', label: 'Scam or fraud', desc: 'Attempt to deceive or exploit' },
+  { value: 'other', label: 'Other', desc: 'Something else not listed above' },
+]
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -742,7 +752,9 @@ function ActionCard({
   isRejectingCancellation,
   onOpenEvaluation,
   onReportNoShow,
+  onOpenReportIssue,
   isReportingNoShow,
+  isReportingIssue,
 }: {
   conv: ChatConversation
   onInitiate: () => void
@@ -758,7 +770,9 @@ function ActionCard({
   isRejectingCancellation: boolean
   onOpenEvaluation: () => void
   onReportNoShow: () => Promise<void>
+  onOpenReportIssue: () => void
   isReportingNoShow: boolean
+  isReportingIssue: boolean
 }) {
   const {
     status, is_provider, provider_initiated,
@@ -788,6 +802,37 @@ function ActionCard({
 
   const myConfirmed    = is_provider ? provider_confirmed_complete : receiver_confirmed_complete
   const otherConfirmed = is_provider ? receiver_confirmed_complete : provider_confirmed_complete
+
+  const reportFlagButton = (
+    <Box
+      as="button"
+      w="34px"
+      h="34px"
+      borderRadius="9px"
+      color={GRAY400}
+      bg="transparent"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      title="Report participant"
+      aria-label="Report participant"
+      onClick={() => {
+        if (!isReportingIssue) onOpenReportIssue()
+      }}
+      _hover={
+        isReportingIssue
+          ? undefined
+          : { color: RED, bg: RED_LT }
+      }
+      transition="all 0.15s"
+      style={{
+        cursor: isReportingIssue ? 'not-allowed' : 'pointer',
+        opacity: isReportingIssue ? 0.7 : 1,
+      }}
+    >
+      <FiFlag size={14} />
+    </Box>
+  )
 
   if (!['pending', 'accepted', 'completed'].includes(status)) return null
 
@@ -1011,11 +1056,11 @@ function ActionCard({
                 h="34px"
                 borderRadius="9px"
                 border={`1px solid ${RED}`}
-                color={RED}
-                bg={RED_LT}
+                color={WHITE}
+                bg={RED}
                 fontSize="12px"
                 fontWeight={700}
-                disabled={isRequestingCancellation || isReportingNoShow}
+                disabled={isRequestingCancellation || isReportingNoShow || isReportingIssue}
                 onClick={() => { void onRequestCancellation() }}
               >
                 {isRequestingCancellation ? 'Requesting...' : 'Request Cancellation'}
@@ -1030,12 +1075,13 @@ function ActionCard({
                   bg={RED_LT}
                   fontSize="12px"
                   fontWeight={700}
-                  disabled={isReportingNoShow || isRequestingCancellation}
+                  disabled={isReportingNoShow || isRequestingCancellation || isReportingIssue}
                   onClick={() => { void onReportNoShow() }}
                 >
                   {isReportingNoShow ? 'Reporting...' : 'Report No-Show'}
                 </Button>
               )}
+              {reportFlagButton}
             </Flex>
           </Flex>
         )}
@@ -1108,6 +1154,7 @@ function ActionCard({
             <Flex align="center" gap={2}>
               <CTA label={fixedGroupOffer ? 'Share Offer Details' : 'Initiate Handshake'} bg={GREEN} onClick={onInitiate} />
               <CancelBtn onClick={onCancel} loading={isCancelling} />
+              {reportFlagButton}
             </Flex>
           </Flex>
         )
@@ -1156,6 +1203,7 @@ function ActionCard({
             <Flex align="center" gap={2}>
               <CTA label="Review & Approve" bg={GREEN} onClick={onShowApprove} />
               <CancelBtn onClick={onCancel} loading={isCancelling} />
+              {reportFlagButton}
             </Flex>
           </Flex>
         ) : (
@@ -1172,6 +1220,7 @@ function ActionCard({
               </Text>
             </Box>
             <CancelBtn onClick={onCancel} loading={isCancelling} />
+            {reportFlagButton}
           </Flex>
         )
       )}
@@ -1600,6 +1649,7 @@ export default function ChatPage() {
   const [isApprovingCancellation, setIsApprovingCancellation] = useState(false)
   const [isRejectingCancellation, setIsRejectingCancellation] = useState(false)
   const [isReportingNoShow,    setIsReportingNoShow]    = useState(false)
+  const [isReportingIssue,     setIsReportingIssue]     = useState(false)
   const [isApproving,          setIsApproving]          = useState(false)
   const [isDeclining,          setIsDeclining]          = useState(false)
   const [mobileShowThread,     setMobileShowThread]     = useState(!!paramId)
@@ -1609,6 +1659,7 @@ export default function ChatPage() {
   const [showApproveModal,  setShowApproveModal]  = useState(false)
   const [showConfirmModal,  setShowConfirmModal]  = useState(false)
   const [showEvaluationModal, setShowEvaluationModal] = useState(false)
+  const [showReportIssueModal, setShowReportIssueModal] = useState(false)
 
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef  = useRef<HTMLTextAreaElement>(null)
@@ -2004,6 +2055,27 @@ export default function ChatPage() {
     }
   }, [isReportingNoShow, refreshConversations, selectedId])
 
+  const handleSubmitReportIssue = useCallback(async (issueType: string) => {
+    if (!selectedId || isReportingIssue) return
+    setIsReportingIssue(true)
+    try {
+      const selectedIssue = CHAT_REPORT_OPTIONS.find((option) => option.value === issueType)
+      const selectedIssueType = (selectedIssue?.value ?? 'service_issue') as ChatReportIssueType
+      const autoDescription = selectedIssue
+        ? `${selectedIssue.label}. ${selectedIssue.desc}`
+        : 'Service issue reported by participant'
+      await handshakeAPI.report(selectedId, selectedIssueType, autoDescription)
+      toast.success('Issue report submitted for admin review.')
+      setShowReportIssueModal(false)
+      refreshConversations()
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { detail?: string } }; message?: string }
+      toast.error(err?.response?.data?.detail ?? err?.message ?? 'Failed to submit issue report.')
+    } finally {
+      setIsReportingIssue(false)
+    }
+  }, [isReportingIssue, refreshConversations, selectedId])
+
   const showConvList = !mobileShowThread
   const showThread   = mobileShowThread || !!selectedId
 
@@ -2160,7 +2232,9 @@ export default function ChatPage() {
                 isRejectingCancellation={isRejectingCancellation}
                 onOpenEvaluation={() => setShowEvaluationModal(true)}
                 onReportNoShow={handleReportNoShow}
+                onOpenReportIssue={() => setShowReportIssueModal(true)}
                 isReportingNoShow={isReportingNoShow}
+                isReportingIssue={isReportingIssue}
               />
 
               {/* Messages */}
@@ -2307,6 +2381,16 @@ export default function ChatPage() {
           onSubmitted={async () => {
             refreshConversations()
           }}
+        />
+      )}
+      {showReportIssueModal && selectedConv && (
+        <ReportModal
+          onClose={() => !isReportingIssue && setShowReportIssueModal(false)}
+          onSubmit={handleSubmitReportIssue}
+          loading={isReportingIssue}
+          options={CHAT_REPORT_OPTIONS}
+          title={`Report ${selectedConv.other_user.name}`}
+          subtitle="Select a reason. Moderators will review your report."
         />
       )}
     </Box>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -397,7 +397,7 @@ const DashboardPage = () => {
     } else {
       raw = await serviceAPI.list(undefined, signal)
     }
-    const active = raw.filter((s) => s.status === 'Active')
+    const active = raw.filter((s) => s.status === 'Active' && s.is_visible)
     const unique = Array.from(new Map(active.map((s) => [s.id, s])).values())
     setAllActiveServices(unique)
     let filtered = unique
@@ -478,6 +478,16 @@ const DashboardPage = () => {
   // ── Derived ───────────────────────────────────────────────────────────────
   const ownServiceHandshakes = Array.from(incomingMap.values()).flat()
   const myServices         = allActiveServices.filter((s) => { const o = s.user ?? s.provider; return !!user && o?.id === user.id })
+
+  // Hide events from the browse feed where the logged-in user was removed
+  // (i.e. their handshake was cancelled by an admin after a report).
+  const displayServices = isAuthenticated
+    ? services.filter((s) => {
+        if (s.type !== 'Event') return true
+        const hs = handshakeMap.get(s.id)
+        return hs?.status !== 'cancelled'
+      })
+    : services
   const pendingHs          = myServices.filter((service) => {
     const incoming = incomingMap.get(service.id) ?? []
     return incoming.some((h) => h.status === 'pending')
@@ -653,7 +663,7 @@ const DashboardPage = () => {
                 )}
               </Flex>
               <MapView
-                services={services}
+                services={displayServices}
                 height="280px"
                 onServiceClick={(id) => navigate(`/service-detail/${id}`)}
                 userLocation={userLocation}
@@ -664,20 +674,20 @@ const DashboardPage = () => {
           {/* Results count */}
           <Box px={{ base: 4, md: 6 }} pt={4} pb={2} flexShrink={0} bgColor={TRANSPARENT}>
             <Text fontSize="12px" color={GRAY400}>
-              {isLoading && services.length === 0 ? 'Loading…' : `${services.length} service${services.length !== 1 ? 's' : ''}`}
+              {isLoading && displayServices.length === 0 ? 'Loading…' : `${displayServices.length} service${displayServices.length !== 1 ? 's' : ''}`}
             </Text>
           </Box>
 
           {/* Grid */}
           <Box flex={1} overflowY="auto" px={{ base: 3, md: 6 }} pt={2} pb={8}>
-            {isLoading && services.length === 0 ? (
+            {isLoading && displayServices.length === 0 ? (
               <Flex justify="center" py={16}><Spinner size="lg" color="green.600" /></Flex>
-            ) : fetchError && services.length === 0 ? (
+            ) : fetchError && displayServices.length === 0 ? (
               <Flex direction="column" align="center" py={16} gap={3}>
                 <Text fontSize="2xl">⚡</Text>
                 <Text color="red.500" fontSize="13px">{fetchError}</Text>
               </Flex>
-            ) : services.length === 0 ? (
+            ) : displayServices.length === 0 ? (
               <Flex direction="column" align="center" py={16} gap={3}>
                 <Text fontSize="3xl">🔍</Text>
                 <Text color={GRAY500} fontSize="13px">No services found. Be the first to post one!</Text>
@@ -696,7 +706,7 @@ const DashboardPage = () => {
                 gap={4}
                 alignItems="stretch"
               >
-                {services.map((service) => {
+                {displayServices.map((service) => {
                   const owner    = service.user ?? service.provider
                   const isOwn    = !!user && owner?.id === user.id
                   const hs       = handshakeMap.get(service.id)

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { Box, Flex, Grid, Stack, Text } from '@chakra-ui/react'
 import {
   FiArrowLeft, FiClock, FiCalendar, FiMapPin, FiMonitor,
-  FiUsers, FiStar, FiFlag, FiMessageSquare, FiSend,
+  FiUsers, FiStar, FiFlag, FiMessageSquare,
   FiAlertTriangle, FiRefreshCw, FiCheckCircle, FiExternalLink,
   FiChevronLeft, FiChevronRight, FiImage, FiX,
 } from 'react-icons/fi'
@@ -15,6 +15,7 @@ import { handshakeAPI } from '@/services/handshakeAPI'
 import { MapView } from '@/components/MapView'
 import EventDetailModal, { type EventDetailModalTab } from '@/components/EventDetailModal'
 import ServiceEvaluationModal from '@/components/ServiceEvaluationModal'
+import ReportModal, { type ReportOption } from '@/components/ReportModal'
 import {
   isWithinLockdownWindow, isFutureEvent, isEventFull, isNearlyFull,
   spotsLeft, formatEventDateTime, timeUntilEvent, isEventBanned, formatBanExpiry,
@@ -51,8 +52,6 @@ const HS_BADGE: Record<Handshake['status'], { label: string; bg: string; color: 
 
 type ReportType = 'inappropriate_content' | 'spam' | 'service_issue' | 'scam' | 'harassment' | 'other'
 type EventBehaviorIssueType = 'service_issue' | 'harassment' | 'spam' | 'scam' | 'other'
-type ReportOption = { value: string; label: string; desc: string }
-
 const REPORT_OPTIONS: ReportOption[] = [
   { value: 'inappropriate_content', label: 'Inappropriate content', desc: 'Offensive or violates guidelines' },
   { value: 'spam',                  label: 'Spam',                  desc: 'Misleading or fake content' },
@@ -241,87 +240,6 @@ function LoadingSkeleton() {
             <Box bg={WHITE} borderRadius="16px" border={`1px solid ${GRAY200}`} p={5} h="180px"><Skel w="60%" /></Box>
           </Stack>
         </Grid>
-      </Box>
-    </Box>
-  )
-}
-
-// ─── Report Modal ─────────────────────────────────────────────────────────────
-
-function ReportModal({
-  onClose,
-  onSubmit,
-  loading,
-  options,
-  title,
-  subtitle,
-  submitLabel = 'Submit Report',
-}: {
-  onClose: () => void
-  onSubmit: (t: string) => void
-  loading: boolean
-  options: ReportOption[]
-  title: string
-  subtitle: string
-  submitLabel?: string
-}) {
-  const [selected, setSelected] = useState<string>(options[0]?.value ?? '')
-  const selectedValue = options.some((opt) => opt.value === selected)
-    ? selected
-    : (options[0]?.value ?? '')
-
-  return (
-    <Box
-      position="fixed" inset={0} zIndex={200}
-      bg="rgba(0,0,0,0.55)"
-      display="flex" alignItems="center" justifyContent="center"
-      p={4} onClick={onClose}
-    >
-      <Box
-        bg={WHITE} borderRadius="20px" w="100%" maxW="440px" p={6}
-        boxShadow="0 20px 60px rgba(0,0,0,0.2)"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Text fontWeight={800} fontSize="18px" color={GRAY800} mb="4px">{title}</Text>
-        <Text fontSize="13px" color={GRAY500} mb={5}>{subtitle}</Text>
-        <Stack gap={2} mb={5}>
-          {options.map((opt) => (
-            <Box
-              key={opt.value}
-              as="label"
-              display="flex" alignItems="flex-start" gap={3} p={3}
-              borderRadius="10px" border="1px solid"
-              borderColor={selected === opt.value ? '#FCA5A5' : GRAY200}
-              bg={selected === opt.value ? RED_LT : WHITE}
-              cursor="pointer" transition="all 0.15s"
-            >
-              <input type="radio" name="reportType" value={opt.value}
-                checked={selectedValue === opt.value} onChange={() => setSelected(opt.value)}
-                style={{ marginTop: '3px', accentColor: RED }} />
-              <Box>
-                <Text fontSize="14px" fontWeight={600} color={GRAY800}>{opt.label}</Text>
-                <Text fontSize="12px" color={GRAY500}>{opt.desc}</Text>
-              </Box>
-            </Box>
-          ))}
-        </Stack>
-        <Flex gap={2}>
-          <Box as="button" flex={1} py="10px" borderRadius="10px"
-            bg={RED} color={WHITE} fontSize="14px" fontWeight={700}
-            display="flex" alignItems="center" justifyContent="center" gap="6px"
-            onClick={() => !loading && selectedValue && onSubmit(selectedValue)}
-            style={{ opacity: loading ? 0.7 : 1, cursor: loading ? 'not-allowed' : 'pointer', border: 'none' }}
-          >
-            <FiSend size={14} /> {loading ? 'Submitting…' : submitLabel}
-          </Box>
-          <Box as="button" flex={1} py="10px" borderRadius="10px"
-            bg={GRAY100} color={GRAY700} fontSize="14px" fontWeight={600}
-            onClick={onClose}
-            style={{ border: 'none', cursor: loading ? 'not-allowed' : 'pointer', opacity: loading ? 0.65 : 1 }}
-          >
-            Cancel
-          </Box>
-        </Flex>
       </Box>
     </Box>
   )
@@ -620,7 +538,7 @@ export default function ServiceDetailPage() {
     ? handshakes.find((h) =>
         exId(h.service) === service?.id &&
         exId(h.requester) === user?.id &&
-        ['accepted', 'checked_in', 'attended', 'no_show'].includes(h.status)
+        ['accepted', 'checked_in', 'attended', 'no_show', 'reported', 'paused', 'completed', 'cancelled'].includes(h.status)
       )
     : undefined
 
@@ -678,6 +596,10 @@ export default function ServiceDetailPage() {
 
   const handleJoinEvent = async () => {
     if (!service || !isAuthenticated) { navigate('/login'); return }
+    if (service.status !== 'Active') {
+      toast.error('This event is no longer open for joining.')
+      return
+    }
     setJoinLoading(true)
     try {
       await handshakeAPI.joinEvent(service.id)
@@ -1396,7 +1318,7 @@ export default function ServiceDetailPage() {
                                 }}
                               >
                                 <FiFlag size={11} />
-                                {alreadyReportedParticipant ? 'Reported' : 'Report user'}
+                                {alreadyReportedParticipant ? 'Reported' : ''}
                               </Box>
                               <Box px="7px" py="2px" borderRadius="full" fontSize="10px" fontWeight={700}
                                 style={{ background: cfg.bg, color: cfg.color, flexShrink: 0 }}
@@ -1455,6 +1377,38 @@ export default function ServiceDetailPage() {
                         <Text fontSize="12px" color="#991B1B" mt="3px">
                           You have 3 no-shows. You can join events again after{' '}
                           <strong>{formatBanExpiry(user?.is_event_banned_until)}</strong>.
+                        </Text>
+                      </Box>
+                    </Stack>
+                  ) : service.status === 'Cancelled' ? (
+                    /* Cancelled event */
+                    <Stack gap={2}>
+                      <Box w="full" py="12px" borderRadius="11px"
+                        bg={GRAY100} color={GRAY400} fontSize="14px" fontWeight={700} textAlign="center"
+                      >
+                        Event Cancelled
+                      </Box>
+                      <Text fontSize="12px" color={GRAY400} textAlign="center">
+                        This event is no longer accepting participation.
+                      </Text>
+                    </Stack>
+                  ) : myEventHandshake?.status === 'reported' ? (
+                    /* Participant has been reported — under review */
+                    <Stack gap={2}>
+                      <Box bg={AMBER_LT} borderRadius="12px" p={4} border={`1px solid ${AMBER}40`}>
+                        <Text fontSize="13px" fontWeight={700} color={AMBER}>Participation Under Review</Text>
+                        <Text fontSize="12px" color="#92400E" mt="3px">
+                          Your participation is being reviewed by a moderator. You cannot check in or join while the review is pending.
+                        </Text>
+                      </Box>
+                    </Stack>
+                  ) : myEventHandshake?.status === 'cancelled' ? (
+                    /* Participant was removed from event */
+                    <Stack gap={2}>
+                      <Box bg={RED_LT} borderRadius="12px" p={4} border={`1px solid ${RED}30`}>
+                        <Text fontSize="13px" fontWeight={700} color={RED}>Removed From Event</Text>
+                        <Text fontSize="12px" color="#991B1B" mt="3px">
+                          You have been removed from this event after a moderation review.
                         </Text>
                       </Box>
                     </Stack>

--- a/frontend/src/services/adminAPI.ts
+++ b/frontend/src/services/adminAPI.ts
@@ -7,6 +7,7 @@ export type AuditTargetFilter = 'user' | 'report' | 'handshake' | 'comment' | 'f
 export type ReportResolveAction =
   | 'confirm_no_show'
   | 'dismiss'
+  | 'remove_from_event'
   | 'uphold_no_show'
   | 'overturn_no_show'
 


### PR DESCRIPTION
## Summary
Implements participant-facing event reporting on both Chat and Service Detail pages, and clarifies/enforces reporting rules for event vs chat-related violations.

This PR addresses the issue where users could not report participants from all required contexts, and aligns backend validation with the expected distinction between general event reports and chat behavior reports.

Closes #184  
Closes #185

## Changes
- Added participant reporting entry points in Chat UI for active conversation contexts.
- Added/expanded participant reporting flows in Service Detail for event participation scenarios.
- Introduced shared report modal usage for consistent reporting UX across pages.
- Added broader behavior-related report options for chat/event moderation cases:
  - service_issue
  - harassment
  - spam
  - scam
  - other
- Enforced timing distinction in backend report validation:
  - no_show reports: allowed only from event start until 24h after start
  - chat/behavior reports: allowed immediately (not blocked by event-start window)
- Updated moderation behavior so participant-to-participant reports do not incorrectly force unrelated event status transitions.
- Added admin resolution capability for event moderation via remove_from_event and related safeguards.
- Improved visibility/eligibility handling for reported or removed participants in event action areas.
- Added cache invalidation on event cancellation to prevent stale browse results.
- Ensured users with cancelled event participation (handshake status cancelled) do not see those events in browse listings.

## How to Test
1. Start backend and frontend.
2. Create an event with organizer user A.
3. Join event as participant user B and user C.
4. Open event chat as user B and report user C using a behavior reason (for example harassment) before event start.
5. Verify report submission succeeds immediately.
6. Attempt no_show report before event start and verify it is rejected with the timing message.
7. Move event time into valid no_show window (or use a fixture) and verify no_show report is accepted only within start to +24h.
8. Open Service Detail page for joined participant and verify reporting options are available where applicable.
9. As admin, open reports and resolve with remove_from_event for a reported participant.
10. Verify removed participant handshake becomes cancelled and participant cannot rejoin from Service Detail.
11. Verify removed participant does not see that event in browse list.
12. Cancel an event and verify cancelled service is removed from browse without stale cache delay.


