### PR TITLE
Test/feature 2 profile coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,9 @@ logs/
 backend/tests/reports/
 frontend/tests/reports/
 
+# Test reports when pytest/coverage is run from repo root (outputs under ./tests/reports/)
+tests/reports/
+
 # Allow frontend src lib (validation helpers)
 !frontend/src/lib/
 !frontend/src/lib/**

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -82,14 +82,27 @@ class TestUserProfileView:
         
         response = client.patch('/api/users/me/', {
             'bio': 'Updated bio',
-            'first_name': 'Updated'
+            'first_name': 'Updated',
+            'last_name': 'Profile',
+            'avatar_url': 'https://example.com/avatars/updated.jpg',
+            'show_history': False,
+            'email': 'should-not-change@example.com',
         })
         assert response.status_code == status.HTTP_200_OK
         assert response.data['bio'] == 'Updated bio'
         assert response.data['first_name'] == 'Updated'
+        assert response.data['last_name'] == 'Profile'
+        assert response.data['avatar_url'] == 'https://example.com/avatars/updated.jpg'
+        assert response.data['show_history'] is False
+        assert response.data['email'] == user.email
         
         user.refresh_from_db()
         assert user.bio == 'Updated bio'
+        assert user.first_name == 'Updated'
+        assert user.last_name == 'Profile'
+        assert user.avatar_url == 'https://example.com/avatars/updated.jpg'
+        assert user.show_history is False
+        assert user.email != 'should-not-change@example.com'
     
     def test_update_user_profile_validation(self):
         """Test profile update validation"""

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -106,7 +106,7 @@ class TestUserProfileView:
     
     def test_update_user_profile_validation(self):
         """Test profile update validation"""
-        user = UserFactory()
+        user = UserFactory(bio='Initial bio')
         client = AuthenticatedAPIClient()
         client.authenticate_user(user)
         
@@ -114,6 +114,10 @@ class TestUserProfileView:
             'bio': 'x' * 1001  # Exceeds limit
         })
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'field_errors' in response.data
+        assert 'bio' in response.data['field_errors']
+        user.refresh_from_db()
+        assert user.bio == 'Initial bio'
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -518,7 +518,10 @@ class TestPublicUserProfile:
         response = client.get(f'/api/users/{other_user.id}/')
         assert response.status_code == status.HTTP_200_OK
         assert 'email' not in response.data
+        assert 'role' not in response.data
         assert 'timebank_balance' not in response.data
+        assert 'is_verified' not in response.data
+        assert 'is_onboarded' not in response.data
 
     def test_public_profile_includes_created_and_joined_events(self):
         viewer = UserFactory()

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -19,7 +19,12 @@ class TestUserProfileView:
     
     def test_get_current_user_profile(self):
         """Test retrieving current user profile"""
-        user = UserFactory()
+        user = UserFactory(
+            first_name='Elif',
+            last_name='Yilmaz',
+            bio='I like helping people with design feedback.',
+            avatar_url='https://example.com/avatars/elif.jpg',
+        )
         client = AuthenticatedAPIClient()
         client.authenticate_user(user)
         
@@ -27,6 +32,10 @@ class TestUserProfileView:
         assert response.status_code == status.HTTP_200_OK
         assert response.data['email'] == user.email
         assert response.data['first_name'] == user.first_name
+        assert response.data['last_name'] == user.last_name
+        assert response.data['bio'] == user.bio
+        assert response.data['avatar_url'] == user.avatar_url
+        assert response.data['date_joined'].startswith(user.date_joined.date().isoformat())
         assert 'achievements' in response.data
 
     def test_get_current_user_profile_includes_event_sections(self):

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -388,6 +388,26 @@ class TestUserProfileSerializer:
         assert user.show_history is False
         assert user.email != 'should-not-change@example.com'
 
+    @pytest.mark.parametrize(
+        'payload,expected_field',
+        [
+            ({'first_name': 'x' * 151}, 'first_name'),
+            ({'last_name': 'x' * 151}, 'last_name'),
+            ({'avatar_url': 'javascript:alert(1)'}, 'avatar_url'),
+        ],
+    )
+    def test_user_profile_rejects_invalid_profile_inputs(self, payload, expected_field):
+        """Invalid profile inputs should fail validation before update/save."""
+        user = UserFactory(
+            first_name='Elif',
+            last_name='Yilmaz',
+            avatar_url='https://example.com/avatars/original.jpg',
+        )
+        serializer = UserProfileSerializer(user, data=payload, partial=True)
+
+        assert serializer.is_valid() is False
+        assert expected_field in serializer.errors
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -313,11 +313,20 @@ class TestUserProfileSerializer:
     
     def test_user_profile_serialization(self):
         """Test user profile serialization"""
-        user = UserFactory()
+        user = UserFactory(
+            first_name='Elif',
+            last_name='Yilmaz',
+            bio='Community-focused learner',
+            avatar_url='https://example.com/avatars/elif.jpg',
+        )
         serializer = UserProfileSerializer(user)
         data = serializer.data
         assert data['email'] == user.email
         assert data['first_name'] == user.first_name
+        assert data['last_name'] == user.last_name
+        assert data['bio'] == user.bio
+        assert data['avatar_url'] == user.avatar_url
+        assert data['date_joined'].startswith(user.date_joined.date().isoformat())
         assert float(data['timebank_balance']) == float(user.timebank_balance)
     
     def test_user_profile_bio_validation(self):

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -411,6 +411,25 @@ class TestUserProfileSerializer:
 
 @pytest.mark.django_db
 @pytest.mark.unit
+class TestPublicUserProfileSerializer:
+    """Test PublicUserProfileSerializer"""
+
+    def test_public_profile_serializer_hides_sensitive_fields(self):
+        """Public serializer should not expose email, role internals, or security metadata."""
+        user = UserFactory()
+        serializer = PublicUserProfileSerializer(user)
+        data = serializer.data
+
+        assert data['id'] == str(user.id)
+        assert 'email' not in data
+        assert 'role' not in data
+        assert 'timebank_balance' not in data
+        assert 'is_verified' not in data
+        assert 'is_onboarded' not in data
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
 class TestCommentSerializer:
     """Test CommentSerializer"""
     

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -360,6 +360,34 @@ class TestUserProfileSerializer:
         assert 'achievements' in data
         assert 'test-achievement' in data['achievements']
 
+    def test_user_profile_partial_update_fields_and_read_only_email(self):
+        """Editable fields update; email remains read-only."""
+        user = UserFactory(
+            first_name='Before',
+            last_name='User',
+            bio='Before bio',
+            avatar_url='https://example.com/avatars/before.jpg',
+            show_history=True,
+        )
+        serializer = UserProfileSerializer(user, data={
+            'first_name': 'After',
+            'last_name': 'Profile',
+            'bio': 'After bio',
+            'avatar_url': 'https://example.com/avatars/after.jpg',
+            'show_history': False,
+            'email': 'should-not-change@example.com',
+        }, partial=True)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        user.refresh_from_db()
+        assert user.first_name == 'After'
+        assert user.last_name == 'Profile'
+        assert user.bio == 'After bio'
+        assert user.avatar_url == 'https://example.com/avatars/after.jpg'
+        assert user.show_history is False
+        assert user.email != 'should-not-change@example.com'
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2301,7 +2301,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3512,7 +3514,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3696,7 +3700,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "peer": true,
       "engines": {
@@ -4362,7 +4368,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5303,7 +5311,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6159,7 +6169,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/frontend/tests/e2e/feature-2/profile-fr02a.spec.ts
+++ b/frontend/tests/e2e/feature-2/profile-fr02a.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * E2E — Feature 2 / FR-02a: Self-profile view displays core fields
+ *
+ * Covers implemented UI only (no forum statistics).
+ * Requires seeded demo data (setup_demo.py) so Elif has bio + avatar_url.
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+test.describe('Self-profile (FR-02a)', () => {
+  test('shows display name, avatar, join year, and bio for seeded demo user', async ({
+    page,
+  }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    // Wait until profile chrome is ready (not spinner-only)
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    // Resolve current user profile dynamically so test is resilient to prior edits.
+    const meRes = await page.context().request.get('/api/users/me/')
+    expect(meRes.ok()).toBeTruthy()
+    const me = await meRes.json()
+    const displayName = `${me.first_name || ''} ${me.last_name || ''}`.trim() || String(me.email || '')
+
+    await expect(page.getByText(displayName)).toBeVisible()
+
+    // Avatar: if avatar_url exists, profile header should render image with alt=displayName.
+    if (me.avatar_url) {
+      await expect(page.getByRole('img', { name: displayName }).first()).toBeVisible()
+    }
+
+    // Join date in header: "Joined {year}" (year depends on seed date_joined vs today)
+    await expect(page.getByText(/^Joined \d{4}$/)).toBeVisible()
+
+    // Bio (read mode): section is shown when profile has bio.
+    await expect(page.getByText('About')).toBeVisible()
+    if (me.bio) {
+      await expect(page.getByText(String(me.bio))).toBeVisible()
+    }
+  })
+})

--- a/frontend/tests/e2e/feature-2/profile-fr02b.spec.ts
+++ b/frontend/tests/e2e/feature-2/profile-fr02b.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E — Feature 2 / FR-02b: Self-profile edit flow
+ *
+ * Covers implemented behavior only:
+ * - display name edit (first_name + last_name)
+ * - bio edit
+ * - avatar edit via crop modal
+ * - supported contact preference: show_history toggle
+ *
+ * Does NOT cover email change (not implemented) or forum stats.
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+function tinyPngFile() {
+  // 1x1 transparent PNG
+  const base64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn8x7YAAAAASUVORK5CYII='
+  const NodeBuffer = (globalThis as unknown as { Buffer: { from: (input: string, encoding: string) => unknown } }).Buffer
+  return {
+    name: 'avatar.png',
+    mimeType: 'image/png',
+    buffer: NodeBuffer.from(base64, 'base64') as Uint8Array,
+  }
+}
+
+test.describe('Self-profile (FR-02b)', () => {
+  test('user can edit display name, bio, avatar and show_history preference', async ({ page }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    const meBeforeRes = await page.context().request.get('/api/users/me/')
+    expect(meBeforeRes.ok()).toBeTruthy()
+    const meBefore = await meBeforeRes.json()
+    const displayNameBefore =
+      `${meBefore.first_name || ''} ${meBefore.last_name || ''}`.trim() || String(meBefore.email || '')
+    const targetShowHistory = !(meBefore.show_history ?? false)
+
+    const stamp = Date.now().toString().slice(-6)
+    const firstName = `Elif${stamp}`
+    const lastName = `FR02b${stamp}`
+    const updatedBio = `FR-02b bio update ${stamp}`
+
+    const avatarImg = page.getByRole('img', { name: displayNameBefore }).first()
+    await expect(avatarImg).toBeVisible()
+    const oldAvatarSrc = await avatarImg.getAttribute('src')
+
+    await page.getByRole('button', { name: 'Edit Profile' }).click()
+
+    const firstNameInput = page.locator('text=First name').locator('xpath=following::input[1]')
+    const lastNameInput = page.locator('text=Last name').locator('xpath=following::input[1]')
+    const bioInput = page.getByPlaceholder('Tell others about yourself…')
+
+    await firstNameInput.fill(firstName)
+    await lastNameInput.fill(lastName)
+    await bioInput.fill(updatedBio)
+
+    // Toggle supported contact preference (show_history)
+    await page.getByText('Show my exchange history on public profile').click()
+
+    // Trigger avatar edit and apply crop
+    await page.locator('input[type="file"]').first().setInputFiles(tinyPngFile())
+    await expect(page.getByText('Crop Profile Photo')).toBeVisible()
+    await page.getByRole('button', { name: /Apply Crop/i }).click()
+
+    // Avatar preview should now be a local cropped data URL
+    // In edit mode, profile header still renders displayName from current user state
+    // until Save updates the backend/user store.
+    const previewAvatar = page.getByRole('img', { name: displayNameBefore }).first()
+    await expect(previewAvatar).toBeVisible()
+    await expect(previewAvatar).toHaveAttribute('src', /data:image\/jpeg/)
+
+    await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.getByText('Profile updated')).toBeVisible({ timeout: 20_000 })
+
+    // Updated read-mode UI checks
+    await expect(page.getByText(`${firstName} ${lastName}`)).toBeVisible()
+    await expect(page.getByText('About')).toBeVisible()
+    await expect(page.getByText(updatedBio)).toBeVisible()
+
+    // API confirms persisted profile fields + supported contact preference
+    const meAfterRes = await page.context().request.get('/api/users/me/')
+    expect(meAfterRes.ok()).toBeTruthy()
+    const meAfter = await meAfterRes.json()
+    expect(meAfter.first_name).toBe(firstName)
+    expect(meAfter.last_name).toBe(lastName)
+    expect(meAfter.bio).toBe(updatedBio)
+    expect(meAfter.show_history).toBe(targetShowHistory)
+    expect(String(meAfter.avatar_url || '')).not.toBe(String(oldAvatarSrc || ''))
+  })
+})

--- a/frontend/tests/e2e/feature-2/profile-fr02c.spec.ts
+++ b/frontend/tests/e2e/feature-2/profile-fr02c.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * E2E — Feature 2 / FR-02c: Profile inputs are validated before persist
+ *
+ * Covers implemented UI/backend behavior only:
+ * - invalid profile payload (bio > 1000) returns validation error
+ * - invalid update is not persisted
+ */
+
+import { test, expect } from '@playwright/test'
+import { expectToast, loginAs, USERS } from './helpers/auth'
+
+test.describe('Self-profile (FR-02c)', () => {
+  test('rejects overlong bio and keeps stored profile unchanged', async ({ page }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    const meBeforeRes = await page.context().request.get('/api/users/me/')
+    expect(meBeforeRes.ok()).toBeTruthy()
+    const meBefore = await meBeforeRes.json()
+    const bioBefore = String(meBefore.bio || '')
+
+    await page.getByRole('button', { name: 'Edit Profile' }).click()
+
+    const bioInput = page.getByPlaceholder('Tell others about yourself…')
+    await bioInput.fill('x'.repeat(1001))
+
+    await page.getByRole('button', { name: 'Save' }).click()
+
+    await expectToast(page, /Validation failed|1000 characters/i)
+    await expect(page.getByText('Profile updated')).toHaveCount(0)
+
+    const meAfterRes = await page.context().request.get('/api/users/me/')
+    expect(meAfterRes.ok()).toBeTruthy()
+    const meAfter = await meAfterRes.json()
+    expect(String(meAfter.bio || '')).toBe(bioBefore)
+  })
+})

--- a/frontend/tests/e2e/feature-2/profile-fr02d.spec.ts
+++ b/frontend/tests/e2e/feature-2/profile-fr02d.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * E2E — Feature 2 / FR-02d: Public profile hides sensitive fields
+ *
+ * Covers implemented behavior only:
+ * - public profile view should not expose account/security sections
+ * - public profile API payload should not include sensitive fields
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+test.describe('Public profile privacy (FR-02d)', () => {
+  test('viewer cannot see sensitive fields on another user profile', async ({ page, request }) => {
+    // Resolve target user id from seeded demo account (Cem)
+    const loginRes = await request.post('/api/auth/login/', {
+      data: { email: USERS.cem.email, password: USERS.cem.password },
+    })
+    expect(loginRes.ok()).toBeTruthy()
+
+    const meRes = await request.get('/api/users/me/')
+    expect(meRes.ok()).toBeTruthy()
+    const cem = await meRes.json()
+    const cemId = String(cem.id)
+
+    // Login as a different user and open Cem's public profile
+    await loginAs(page, USERS.elif)
+    await page.goto(`/public-profile/${cemId}`)
+
+    await expect(page.getByText(USERS.cem.name)).toBeVisible({ timeout: 25_000 })
+
+    // Sensitive account/security sections from own-profile UI must not appear
+    await expect(page.getByText('Account Information')).toHaveCount(0)
+    await expect(page.getByText('Change Password')).toHaveCount(0)
+    await expect(page.getByText('Settings')).toHaveCount(0)
+    await expect(page.getByText(USERS.cem.email)).toHaveCount(0)
+
+    // API contract check for sensitive fields hidden in public profile payload
+    const publicRes = await page.context().request.get(`/api/users/${cemId}/`)
+    expect(publicRes.ok()).toBeTruthy()
+    const publicData = await publicRes.json()
+    expect(publicData.email).toBeUndefined()
+    expect(publicData.role).toBeUndefined()
+    expect(publicData.timebank_balance).toBeUndefined()
+    expect(publicData.is_verified).toBeUndefined()
+    expect(publicData.is_onboarded).toBeUndefined()
+  })
+})

--- a/frontend/tests/e2e/profile-fr02a.spec.ts
+++ b/frontend/tests/e2e/profile-fr02a.spec.ts
@@ -20,21 +20,26 @@ test.describe('Self-profile (FR-02a)', () => {
       timeout: 25_000,
     })
 
-    // Display name: first_name + last_name (seeded Elif Yılmaz)
-    await expect(page.getByText('Elif Yılmaz')).toBeVisible()
+    // Resolve current user profile dynamically so test is resilient to prior edits.
+    const meRes = await page.context().request.get('/api/users/me/')
+    expect(meRes.ok()).toBeTruthy()
+    const me = await meRes.json()
+    const displayName = `${me.first_name || ''} ${me.last_name || ''}`.trim() || String(me.email || '')
 
-    // Avatar: seeded user has avatar_url → <img alt={displayName}>
-    await expect(page.getByRole('img', { name: 'Elif Yılmaz' })).toBeVisible()
+    await expect(page.getByText(displayName)).toBeVisible()
+
+    // Avatar: if avatar_url exists, profile header should render image with alt=displayName.
+    if (me.avatar_url) {
+      await expect(page.getByRole('img', { name: displayName }).first()).toBeVisible()
+    }
 
     // Join date in header: "Joined {year}" (year depends on seed date_joined vs today)
     await expect(page.getByText(/^Joined \d{4}$/)).toBeVisible()
 
-    // Bio (read mode): About section + seeded copy from setup_demo.py
+    // Bio (read mode): section is shown when profile has bio.
     await expect(page.getByText('About')).toBeVisible()
-    await expect(
-      page.getByText(
-        /Freelance designer and cooking enthusiast living in Beşiktaş/i,
-      ),
-    ).toBeVisible()
+    if (me.bio) {
+      await expect(page.getByText(String(me.bio))).toBeVisible()
+    }
   })
 })

--- a/frontend/tests/e2e/profile-fr02a.spec.ts
+++ b/frontend/tests/e2e/profile-fr02a.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * E2E — Feature 2 / FR-02a: Self-profile view displays core fields
+ *
+ * Covers implemented UI only (no forum statistics).
+ * Requires seeded demo data (setup_demo.py) so Elif has bio + avatar_url.
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+test.describe('Self-profile (FR-02a)', () => {
+  test('shows display name, avatar, join year, and bio for seeded demo user', async ({
+    page,
+  }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    // Wait until profile chrome is ready (not spinner-only)
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    // Display name: first_name + last_name (seeded Elif Yılmaz)
+    await expect(page.getByText('Elif Yılmaz')).toBeVisible()
+
+    // Avatar: seeded user has avatar_url → <img alt={displayName}>
+    await expect(page.getByRole('img', { name: 'Elif Yılmaz' })).toBeVisible()
+
+    // Join date in header: "Joined {year}" (year depends on seed date_joined vs today)
+    await expect(page.getByText(/^Joined \d{4}$/)).toBeVisible()
+
+    // Bio (read mode): About section + seeded copy from setup_demo.py
+    await expect(page.getByText('About')).toBeVisible()
+    await expect(
+      page.getByText(
+        /Freelance designer and cooking enthusiast living in Beşiktaş/i,
+      ),
+    ).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/profile-fr02b.spec.ts
+++ b/frontend/tests/e2e/profile-fr02b.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E — Feature 2 / FR-02b: Self-profile edit flow
+ *
+ * Covers implemented behavior only:
+ * - display name edit (first_name + last_name)
+ * - bio edit
+ * - avatar edit via crop modal
+ * - supported contact preference: show_history toggle
+ *
+ * Does NOT cover email change (not implemented) or forum stats.
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+function tinyPngFile() {
+  // 1x1 transparent PNG
+  const base64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn8x7YAAAAASUVORK5CYII='
+  const NodeBuffer = (globalThis as unknown as { Buffer: { from: (input: string, encoding: string) => unknown } }).Buffer
+  return {
+    name: 'avatar.png',
+    mimeType: 'image/png',
+    buffer: NodeBuffer.from(base64, 'base64') as any,
+  }
+}
+
+test.describe('Self-profile (FR-02b)', () => {
+  test('user can edit display name, bio, avatar and show_history preference', async ({ page }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    const meBeforeRes = await page.context().request.get('/api/users/me/')
+    expect(meBeforeRes.ok()).toBeTruthy()
+    const meBefore = await meBeforeRes.json()
+    const targetShowHistory = !(meBefore.show_history ?? false)
+
+    const stamp = Date.now().toString().slice(-6)
+    const firstName = `Elif${stamp}`
+    const lastName = `FR02b${stamp}`
+    const updatedBio = `FR-02b bio update ${stamp}`
+
+    const avatarImg = page.getByRole('img', { name: /Elif/i }).first()
+    await expect(avatarImg).toBeVisible()
+    const oldAvatarSrc = await avatarImg.getAttribute('src')
+
+    await page.getByRole('button', { name: 'Edit Profile' }).click()
+
+    const firstNameInput = page.locator('text=First name').locator('xpath=following::input[1]')
+    const lastNameInput = page.locator('text=Last name').locator('xpath=following::input[1]')
+    const bioInput = page.getByPlaceholder('Tell others about yourself…')
+
+    await firstNameInput.fill(firstName)
+    await lastNameInput.fill(lastName)
+    await bioInput.fill(updatedBio)
+
+    // Toggle supported contact preference (show_history)
+    await page.getByText('Show my exchange history on public profile').click()
+
+    // Trigger avatar edit and apply crop
+    await page.locator('input[type="file"]').first().setInputFiles(tinyPngFile())
+    await expect(page.getByText('Crop Profile Photo')).toBeVisible()
+    await page.getByRole('button', { name: /Apply Crop/i }).click()
+
+    // Avatar preview should now be a local cropped data URL
+    // In edit mode, profile header still renders displayName from current user state
+    // until Save updates the backend/user store.
+    const previewAvatar = page.getByRole('img', { name: /Elif Yılmaz/i }).first()
+    await expect(previewAvatar).toBeVisible()
+    await expect(previewAvatar).toHaveAttribute('src', /data:image\/jpeg/)
+
+    await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.getByText('Profile updated')).toBeVisible({ timeout: 20_000 })
+
+    // Updated read-mode UI checks
+    await expect(page.getByText(`${firstName} ${lastName}`)).toBeVisible()
+    await expect(page.getByText('About')).toBeVisible()
+    await expect(page.getByText(updatedBio)).toBeVisible()
+
+    // API confirms persisted profile fields + supported contact preference
+    const meAfterRes = await page.context().request.get('/api/users/me/')
+    expect(meAfterRes.ok()).toBeTruthy()
+    const meAfter = await meAfterRes.json()
+    expect(meAfter.first_name).toBe(firstName)
+    expect(meAfter.last_name).toBe(lastName)
+    expect(meAfter.bio).toBe(updatedBio)
+    expect(meAfter.show_history).toBe(targetShowHistory)
+    expect(String(meAfter.avatar_url || '')).not.toBe(String(oldAvatarSrc || ''))
+  })
+})

--- a/frontend/tests/e2e/profile-fr02b.spec.ts
+++ b/frontend/tests/e2e/profile-fr02b.spec.ts
@@ -21,7 +21,7 @@ function tinyPngFile() {
   return {
     name: 'avatar.png',
     mimeType: 'image/png',
-    buffer: NodeBuffer.from(base64, 'base64') as any,
+    buffer: NodeBuffer.from(base64, 'base64') as Uint8Array,
   }
 }
 

--- a/frontend/tests/e2e/profile-fr02b.spec.ts
+++ b/frontend/tests/e2e/profile-fr02b.spec.ts
@@ -37,6 +37,8 @@ test.describe('Self-profile (FR-02b)', () => {
     const meBeforeRes = await page.context().request.get('/api/users/me/')
     expect(meBeforeRes.ok()).toBeTruthy()
     const meBefore = await meBeforeRes.json()
+    const displayNameBefore =
+      `${meBefore.first_name || ''} ${meBefore.last_name || ''}`.trim() || String(meBefore.email || '')
     const targetShowHistory = !(meBefore.show_history ?? false)
 
     const stamp = Date.now().toString().slice(-6)
@@ -44,7 +46,7 @@ test.describe('Self-profile (FR-02b)', () => {
     const lastName = `FR02b${stamp}`
     const updatedBio = `FR-02b bio update ${stamp}`
 
-    const avatarImg = page.getByRole('img', { name: /Elif/i }).first()
+    const avatarImg = page.getByRole('img', { name: displayNameBefore }).first()
     await expect(avatarImg).toBeVisible()
     const oldAvatarSrc = await avatarImg.getAttribute('src')
 
@@ -69,7 +71,7 @@ test.describe('Self-profile (FR-02b)', () => {
     // Avatar preview should now be a local cropped data URL
     // In edit mode, profile header still renders displayName from current user state
     // until Save updates the backend/user store.
-    const previewAvatar = page.getByRole('img', { name: /Elif Yılmaz/i }).first()
+    const previewAvatar = page.getByRole('img', { name: displayNameBefore }).first()
     await expect(previewAvatar).toBeVisible()
     await expect(previewAvatar).toHaveAttribute('src', /data:image\/jpeg/)
 

--- a/frontend/tests/e2e/profile-fr02c.spec.ts
+++ b/frontend/tests/e2e/profile-fr02c.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * E2E — Feature 2 / FR-02c: Profile inputs are validated before persist
+ *
+ * Covers implemented UI/backend behavior only:
+ * - invalid profile payload (bio > 1000) returns validation error
+ * - invalid update is not persisted
+ */
+
+import { test, expect } from '@playwright/test'
+import { expectToast, loginAs, USERS } from './helpers/auth'
+
+test.describe('Self-profile (FR-02c)', () => {
+  test('rejects overlong bio and keeps stored profile unchanged', async ({ page }) => {
+    await loginAs(page, USERS.elif)
+    await page.goto('/profile')
+
+    await expect(page.getByRole('button', { name: /Edit Profile/i })).toBeVisible({
+      timeout: 25_000,
+    })
+
+    const meBeforeRes = await page.context().request.get('/api/users/me/')
+    expect(meBeforeRes.ok()).toBeTruthy()
+    const meBefore = await meBeforeRes.json()
+    const bioBefore = String(meBefore.bio || '')
+
+    await page.getByRole('button', { name: 'Edit Profile' }).click()
+
+    const bioInput = page.getByPlaceholder('Tell others about yourself…')
+    await bioInput.fill('x'.repeat(1001))
+
+    await page.getByRole('button', { name: 'Save' }).click()
+
+    await expectToast(page, /Validation failed|1000 characters/i)
+    await expect(page.getByText('Profile updated')).toHaveCount(0)
+
+    const meAfterRes = await page.context().request.get('/api/users/me/')
+    expect(meAfterRes.ok()).toBeTruthy()
+    const meAfter = await meAfterRes.json()
+    expect(String(meAfter.bio || '')).toBe(bioBefore)
+  })
+})

--- a/frontend/tests/e2e/profile-fr02d.spec.ts
+++ b/frontend/tests/e2e/profile-fr02d.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * E2E — Feature 2 / FR-02d: Public profile hides sensitive fields
+ *
+ * Covers implemented behavior only:
+ * - public profile view should not expose account/security sections
+ * - public profile API payload should not include sensitive fields
+ */
+
+import { test, expect } from '@playwright/test'
+import { loginAs, USERS } from './helpers/auth'
+
+test.describe('Public profile privacy (FR-02d)', () => {
+  test('viewer cannot see sensitive fields on another user profile', async ({ page, request }) => {
+    // Resolve target user id from seeded demo account (Cem)
+    const loginRes = await request.post('/api/auth/login/', {
+      data: { email: USERS.cem.email, password: USERS.cem.password },
+    })
+    expect(loginRes.ok()).toBeTruthy()
+
+    const meRes = await request.get('/api/users/me/')
+    expect(meRes.ok()).toBeTruthy()
+    const cem = await meRes.json()
+    const cemId = String(cem.id)
+
+    // Login as a different user and open Cem's public profile
+    await loginAs(page, USERS.elif)
+    await page.goto(`/public-profile/${cemId}`)
+
+    await expect(page.getByText(USERS.cem.name)).toBeVisible({ timeout: 25_000 })
+
+    // Sensitive account/security sections from own-profile UI must not appear
+    await expect(page.getByText('Account Information')).toHaveCount(0)
+    await expect(page.getByText('Change Password')).toHaveCount(0)
+    await expect(page.getByText('Settings')).toHaveCount(0)
+    await expect(page.getByText(USERS.cem.email)).toHaveCount(0)
+
+    // API contract check for sensitive fields hidden in public profile payload
+    const publicRes = await page.context().request.get(`/api/users/${cemId}/`)
+    expect(publicRes.ok()).toBeTruthy()
+    const publicData = await publicRes.json()
+    expect(publicData.email).toBeUndefined()
+    expect(publicData.role).toBeUndefined()
+    expect(publicData.timebank_balance).toBeUndefined()
+    expect(publicData.is_verified).toBeUndefined()
+    expect(publicData.is_onboarded).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #242
## Summary
- Add requirement-mapped test coverage for Feature 2 profile requirements FR-02a through FR-02d.
- Extend backend unit/integration tests for profile input validation and public-profile privacy boundaries.
- Add Playwright E2E specs for self-profile view/edit/validation and public-profile sensitive-field hiding.
- Stabilize FR-02a/FR-02b E2E by replacing hardcoded seeded-name assertions with `/api/users/me/`-driven dynamic assertions.

## Scope

### Backend tests
- Updated `backend/api/tests/unit/test_serializers.py`
- Updated `backend/api/tests/integration/test_user_api.py`

### E2E tests
- Added `frontend/tests/e2e/profile-fr02a.spec.ts`
- Added `frontend/tests/e2e/profile-fr02b.spec.ts`
- Added `frontend/tests/e2e/profile-fr02c.spec.ts`
- Added `frontend/tests/e2e/profile-fr02d.spec.ts`

## Requirement coverage

### FR-02a — Self-profile displays core fields (name, avatar, join date, bio)
- **Backend Unit**
  - `backend/api/tests/unit/test_serializers.py`
  - `TestUserProfileSerializer::test_user_profile_serialization`
  - Validates serializer output includes `first_name`, `last_name`, `bio`, `avatar_url`, `date_joined`, `timebank_balance`.
- **Backend Integration**
  - `backend/api/tests/integration/test_user_api.py`
  - `TestUserProfileView::test_get_current_user_profile`
  - Validates `GET /api/users/me/` returns core profile fields.
- **E2E**
  - `frontend/tests/e2e/profile-fr02a.spec.ts`
  - `Self-profile (FR-02a) › shows display name, avatar, join year, and bio for seeded demo user`
  - Validates visible profile UI fields; now uses dynamic `/api/users/me/` values for resilience.

### FR-02b — Self-profile edit flow persists supported fields
- **Backend Unit**
  - `backend/api/tests/unit/test_serializers.py`
  - `TestUserProfileSerializer::test_user_profile_partial_update_fields_and_read_only_email`
  - Validates editable fields persist and `email` remains read-only.
- **Backend Integration**
  - `backend/api/tests/integration/test_user_api.py`
  - `TestUserProfileView::test_update_user_profile`
  - Validates `PATCH /api/users/me/` updates persisted fields and preserves read-only `email`.
- **E2E**
  - `frontend/tests/e2e/profile-fr02b.spec.ts`
  - `Self-profile (FR-02b) › user can edit display name, bio, avatar and show_history preference`
  - Validates end-to-end edit/save flow and persisted API values.

### FR-02c — Validate profile inputs before persisting
- **Backend Unit**
  - `backend/api/tests/unit/test_serializers.py`
  - `TestUserProfileSerializer::test_user_profile_bio_validation`
  - `TestUserProfileSerializer::test_user_profile_rejects_invalid_profile_inputs` (parametrized)
  - Validates invalid profile payloads are rejected at serializer level.
- **Backend Integration**
  - `backend/api/tests/integration/test_user_api.py`
  - `TestUserProfileView::test_update_user_profile_validation`
  - Validates invalid `bio` update returns `400` with `field_errors.bio` and does not mutate DB state.
- **E2E**
  - `frontend/tests/e2e/profile-fr02c.spec.ts`
  - `Self-profile (FR-02c) › rejects overlong bio and keeps stored profile unchanged`
  - Validates UI error behavior and non-persistence via API re-check.

### FR-02d — Public profile hides sensitive fields (email, role internals, security metadata)
- **Backend Unit**
  - `backend/api/tests/unit/test_serializers.py`
  - `TestPublicUserProfileSerializer::test_public_profile_serializer_hides_sensitive_fields`
  - Validates public serializer excludes `email`, `role`, `timebank_balance`, `is_verified`, `is_onboarded`.
- **Backend Integration**
  - `backend/api/tests/integration/test_user_api.py`
  - `TestPublicUserProfile::test_public_profile_excludes_sensitive_data`
  - Validates `GET /api/users/{id}/` excludes sensitive fields.
- **E2E**
  - `frontend/tests/e2e/profile-fr02d.spec.ts`
  - `Public profile privacy (FR-02d) › viewer cannot see sensitive fields on another user profile`
  - Validates sensitive surfaces are hidden in UI and absent in public-profile payload.

## Notes
- No application behavior changes; scope is test-focused.
- Optional forum statistics remain out of scope (not implemented).
- Email-change flow remains out of scope (not implemented).

## Test plan

### Backend unit (targeted)
- `api/tests/unit/test_serializers.py -k "user_profile_rejects_invalid_profile_inputs or PublicUserProfileSerializer"`

### Backend integration (targeted)
- `api/tests/integration/test_user_api.py -k "test_update_user_profile_validation or public_profile_excludes_sensitive_data"`

### E2E (targeted)
- `tests/e2e/profile-fr02a.spec.ts`
- `tests/e2e/profile-fr02b.spec.ts`
- `tests/e2e/profile-fr02c.spec.ts`
- `tests/e2e/profile-fr02d.spec.ts`