### PR TITLE
feat: implement xfail tests for QR and GPS check-in validation

### DIFF
--- a/backend/api/tests/integration/test_discovery_api.py
+++ b/backend/api/tests/integration/test_discovery_api.py
@@ -1,0 +1,334 @@
+"""
+Integration tests for Discovery API — FR-19c, FR-19e, FR-19h (blur), NFR-19a.
+
+Test classes and their status:
+  TestAdminPinEvent             — green  (pin endpoint is implemented)
+  TestAdminShowcaseFeatured     — xfail  (FR-19c: no showcase/featured concept)
+  TestFollowSystem              — xfail  (FR-19e: no follow model or endpoints)
+  TestDiscoveryFeedPerformance  — xfail  (NFR-19a: no SLA test enforced)
+  TestLocationBlurInFeed        — xfail  (FR-19h: feed distance values are not blurred)
+"""
+import time
+import pytest
+from decimal import Decimal
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.tests.helpers.factories import (
+    UserFactory,
+    ServiceFactory,
+    HandshakeFactory,
+)
+
+
+# ---------------------------------------------------------------------------
+# FR-19c — Admin pin event (green — already implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestAdminPinEvent:
+    """
+    Pinning an event via POST /api/services/{id}/pin-event/ is fully implemented.
+    These tests document and protect the existing behaviour.
+    """
+
+    def _admin_client(self):
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        return client, admin
+
+    def test_admin_can_pin_event(self):
+        """Admin can toggle is_pinned=True on an event."""
+        client, _ = self._admin_client()
+        event = ServiceFactory(type='Event', status='Active', is_pinned=False)
+
+        resp = client.post(f'/api/services/{event.id}/pin-event/')
+
+        assert resp.status_code == 200
+        event.refresh_from_db()
+        assert event.is_pinned is True
+
+    def test_admin_can_unpin_event(self):
+        """Calling pin-event on an already-pinned event toggles it back to False."""
+        client, _ = self._admin_client()
+        event = ServiceFactory(type='Event', status='Active', is_pinned=True)
+
+        resp = client.post(f'/api/services/{event.id}/pin-event/')
+
+        assert resp.status_code == 200
+        event.refresh_from_db()
+        assert event.is_pinned is False
+
+    def test_non_admin_cannot_pin_event(self):
+        """Regular member must receive 403 when attempting to pin an event."""
+        member = UserFactory(role='member')
+        client = APIClient()
+        client.force_authenticate(user=member)
+        event = ServiceFactory(type='Event', status='Active')
+
+        resp = client.post(f'/api/services/{event.id}/pin-event/')
+
+        assert resp.status_code == 403
+
+    def test_pin_endpoint_rejects_non_event_service(self):
+        """Offer and Need services cannot be pinned via the event pin endpoint."""
+        client, _ = self._admin_client()
+        offer = ServiceFactory(type='Offer', status='Active')
+
+        resp = client.post(f'/api/services/{offer.id}/pin-event/')
+
+        assert resp.status_code in (400, 403, 422)
+
+    def test_pinned_events_appear_before_unpinned_in_feed(self):
+        """Pinned events must sort ahead of unpinned events in the discovery feed."""
+        ServiceFactory(type='Event', status='Active', is_pinned=False, hot_score=100.0)
+        ServiceFactory(type='Event', status='Active', is_pinned=True, hot_score=1.0)
+
+        client = APIClient()
+        resp = client.get('/api/services/?type=Event')
+        assert resp.status_code == 200
+
+        results = resp.data.get('results', [])
+        pinned_idx = next(
+            (i for i, s in enumerate(results) if s.get('is_pinned') is True), None
+        )
+        unpinned_idx = next(
+            (i for i, s in enumerate(results) if s.get('is_pinned') is False), None
+        )
+        assert pinned_idx is not None
+        assert unpinned_idx is not None
+        assert pinned_idx < unpinned_idx, "Pinned event should appear before unpinned event."
+
+
+# ---------------------------------------------------------------------------
+# FR-19c — Admin showcase / featured section (xfail — not implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.integration
+@pytest.mark.xfail(
+    reason="FR-19c: no 'showcase' or 'featured section' concept exists; only is_pinned is implemented",
+    strict=False,
+)
+class TestAdminShowcaseFeatured:
+    """
+    The spec requires admins to be able to showcase events in 'featured sections' —
+    a distinct placement separate from sort-order pinning.
+
+    These tests are xfail because:
+    - Service has no is_featured field.
+    - There is no /api/services/{id}/feature/ or /api/featured/ endpoint.
+    - There is no homepage featured section feed.
+    """
+
+    def test_admin_can_feature_an_event(self):
+        """Admin should be able to mark an event as featured."""
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        event = ServiceFactory(type='Event', status='Active')
+
+        resp = client.post(f'/api/services/{event.id}/feature/')
+
+        assert resp.status_code == 200
+        event.refresh_from_db()
+        assert getattr(event, 'is_featured', False) is True
+
+    def test_featured_events_appear_in_dedicated_featured_feed(self):
+        """A dedicated feed endpoint must return only featured events."""
+        ServiceFactory(type='Event', status='Active')  # not featured
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        featured_event = ServiceFactory(type='Event', status='Active')
+        # Mark it as featured via API
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        client.post(f'/api/services/{featured_event.id}/feature/')
+
+        # Fetch the featured feed
+        resp = client.get('/api/services/featured/')
+        assert resp.status_code == 200
+        result_ids = [s['id'] for s in resp.data.get('results', [])]
+        assert str(featured_event.id) in result_ids
+
+    def test_featured_placement_has_optional_expiry(self):
+        """Featured placements should accept an expiry datetime after which they are removed."""
+        admin = UserFactory(role='admin', is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        event = ServiceFactory(type='Event', status='Active')
+        expiry = (timezone.now() + timedelta(days=7)).isoformat()
+
+        resp = client.post(
+            f'/api/services/{event.id}/feature/',
+            data={'expires_at': expiry},
+            format='json',
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# FR-19e — Follow system (xfail — not implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.integration
+@pytest.mark.xfail(
+    reason="FR-19e: no Follow model, no follow endpoints, no feed boost implemented",
+    strict=False,
+)
+class TestFollowSystem:
+    """
+    FR-19e requires users to follow each other and for followed-user content to
+    receive a boost in the discovery feed.
+
+    These tests are xfail because no follow infrastructure exists in the codebase.
+    """
+
+    def test_user_can_follow_another_user(self):
+        """POST /api/users/{id}/follow/ should create a follow relationship."""
+        follower = UserFactory()
+        followed = UserFactory()
+        client = APIClient()
+        client.force_authenticate(user=follower)
+
+        resp = client.post(f'/api/users/{followed.id}/follow/')
+
+        assert resp.status_code in (200, 201)
+
+    def test_user_can_unfollow(self):
+        """DELETE /api/users/{id}/follow/ should remove the follow relationship."""
+        follower = UserFactory()
+        followed = UserFactory()
+        client = APIClient()
+        client.force_authenticate(user=follower)
+        client.post(f'/api/users/{followed.id}/follow/')
+
+        resp = client.delete(f'/api/users/{followed.id}/follow/')
+
+        assert resp.status_code in (200, 204)
+
+    def test_follow_is_idempotent(self):
+        """Following the same user twice should not create a duplicate entry."""
+        follower = UserFactory()
+        followed = UserFactory()
+        client = APIClient()
+        client.force_authenticate(user=follower)
+        client.post(f'/api/users/{followed.id}/follow/')
+
+        resp = client.post(f'/api/users/{followed.id}/follow/')
+
+        assert resp.status_code in (200, 201, 400)  # 400 for duplicate is acceptable
+
+    def test_cannot_follow_self(self):
+        """A user should not be able to follow themselves."""
+        user = UserFactory()
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        resp = client.post(f'/api/users/{user.id}/follow/')
+
+        assert resp.status_code in (400, 403)
+
+    def test_followed_user_listings_rank_higher_in_feed(self):
+        """
+        Services from a followed user should rank above equivalent-score services
+        from non-followed users in the discovery feed.
+        """
+        viewer = UserFactory()
+        followed_provider = UserFactory()
+        other_provider = UserFactory()
+
+        followed_svc = ServiceFactory(
+            user=followed_provider, type='Offer', status='Active', hot_score=5.0
+        )
+        other_svc = ServiceFactory(
+            user=other_provider, type='Offer', status='Active', hot_score=5.0
+        )
+
+        # Follow the first provider
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        client.post(f'/api/users/{followed_provider.id}/follow/')
+
+        resp = client.get('/api/services/?type=Offer')
+        assert resp.status_code == 200
+        results = resp.data.get('results', [])
+        ids = [str(s['id']) for s in results]
+
+        assert str(followed_svc.id) in ids
+        assert str(other_svc.id) in ids
+        assert ids.index(str(followed_svc.id)) < ids.index(str(other_svc.id)), (
+            "Followed-user service should appear before same-score non-followed service."
+        )
+
+    def test_anonymous_user_follow_endpoint_requires_auth(self):
+        """Anonymous users should receive 401 when hitting the follow endpoint."""
+        followed = UserFactory()
+        client = APIClient()
+
+        resp = client.post(f'/api/users/{followed.id}/follow/')
+
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# NFR-19a — Discovery feed 2-second SLA (xfail — no benchmark enforced)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.integration
+@pytest.mark.xfail(
+    reason="NFR-19a: no performance SLA test exists; 2s threshold not enforced",
+    strict=False,
+)
+class TestDiscoveryFeedPerformance:
+    """
+    The discovery feed (including serialization and pagination) must return
+    the first page within 2 seconds for a catalogue of ~1 000 active services.
+
+    Xfail because no benchmark guard exists and the threshold has not been
+    validated under load.
+    """
+
+    FEED_SLA_SECONDS = 2.0
+
+    def test_feed_loads_within_2_seconds_with_1000_services(self, db):
+        """Anonymous feed request for 1 000 services should arrive in < 2s."""
+        user = UserFactory()
+        ServiceFactory.create_batch(1000, status='Active', user=user)
+
+        client = APIClient()
+        start = time.monotonic()
+        resp = client.get('/api/services/')
+        elapsed = time.monotonic() - start
+
+        assert resp.status_code == 200
+        assert elapsed < self.FEED_SLA_SECONDS, (
+            f"Discovery feed took {elapsed:.3f}s — exceeds the {self.FEED_SLA_SECONDS}s NFR-19a SLA."
+        )
+
+    def test_authenticated_feed_with_location_filter_within_2_seconds(self, db):
+        """Authenticated feed with a 10km radius filter should also meet the SLA."""
+        user = UserFactory()
+        ServiceFactory.create_batch(
+            500, status='Active', user=user,
+            location_type='In-Person',
+            location_lat=Decimal('41.012345'),
+            location_lng=Decimal('28.974321'),
+        )
+        ServiceFactory.create_batch(500, status='Active', user=user, location_type='Online')
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        start = time.monotonic()
+        resp = client.get('/api/services/?lat=41.012345&lng=28.974321&distance=10')
+        elapsed = time.monotonic() - start
+
+        assert resp.status_code == 200
+        assert elapsed < self.FEED_SLA_SECONDS, (
+            f"Location-filtered feed took {elapsed:.3f}s — exceeds the NFR-19a SLA."
+        )

--- a/backend/api/tests/unit/test_event_service.py
+++ b/backend/api/tests/unit/test_event_service.py
@@ -373,3 +373,178 @@ class TestCancelEvent:
         service = ServiceFactory(type='Offer', status='Active')
         with pytest.raises(ValueError, match='not an event'):
             EventHandshakeService.cancel_event(service, service.user)
+
+
+# ─── FR-19i: QR + GPS dual-factor check-in (xfail — not yet implemented) ──────
+
+try:
+    from api.services import EventHandshakeService as _EHS_qr
+    _qr_checkin = getattr(_EHS_qr, 'checkin_with_qr', None)
+    _gps_checkin = getattr(_EHS_qr, 'checkin_with_proximity', None)
+except ImportError:
+    _qr_checkin = None
+    _gps_checkin = None
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason="FR-19i: QR token validation not yet implemented in EventHandshakeService",
+    strict=False,
+)
+class TestCheckinQRValidation:
+    """
+    FR-19i requires a valid QR token as the first factor of attendance verification.
+
+    These tests are xfail because:
+    - No QR token is generated when a handshake is accepted.
+    - EventHandshakeService has no checkin_with_qr() method.
+    - The check-in endpoint does not validate any token.
+    """
+
+    def setUp(self):
+        if _qr_checkin is None:
+            pytest.xfail("checkin_with_qr not yet implemented — FR-19i")
+
+    def test_checkin_with_valid_qr_token_succeeds(self):
+        """Valid QR token issued for the handshake should allow check-in."""
+        organizer = UserFactory()
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        # The token should have been generated when the handshake was accepted
+        assert hasattr(hs, 'qr_token') and hs.qr_token, "No QR token generated on accepted handshake."
+        result = _qr_checkin(hs, participant, qr_token=hs.qr_token)
+        assert result.status == 'checked_in'
+
+    def test_checkin_with_invalid_qr_token_raises(self):
+        """An incorrect QR token must be rejected."""
+        organizer = UserFactory()
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        with pytest.raises((ValueError, PermissionError), match='[Ii]nvalid.*[Tt]oken|[Qq][Rr]'):
+            _qr_checkin(hs, participant, qr_token='bad-token-value')
+
+    def test_qr_token_is_single_use(self):
+        """Using the same QR token twice must fail on the second attempt."""
+        organizer = UserFactory()
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        p1 = UserFactory()
+        p2 = UserFactory()
+        hs1 = EventHandshakeService.join_event(service, p1)
+        hs2 = EventHandshakeService.join_event(service, p2)
+
+        _qr_checkin(hs1, p1, qr_token=hs1.qr_token)
+
+        # Reusing hs1's token for a different handshake must fail
+        with pytest.raises((ValueError, PermissionError)):
+            _qr_checkin(hs2, p2, qr_token=hs1.qr_token)
+
+    def test_qr_token_belongs_to_correct_handshake(self):
+        """A token generated for one handshake cannot be used for a different participant."""
+        organizer = UserFactory()
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        p1 = UserFactory()
+        p2 = UserFactory()
+        hs1 = EventHandshakeService.join_event(service, p1)
+        hs2 = EventHandshakeService.join_event(service, p2)
+
+        with pytest.raises((ValueError, PermissionError)):
+            _qr_checkin(hs2, p2, qr_token=hs1.qr_token)
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason="FR-19i: GPS proximity check not yet implemented in EventHandshakeService",
+    strict=False,
+)
+class TestCheckinGPSProximity:
+    """
+    FR-19i requires the check-in request to include GPS coordinates that are within
+    100m of the event's real location. Online events skip the GPS check.
+
+    These tests are xfail because no proximity validation exists in the codebase.
+    """
+
+    def setUp(self):
+        if _gps_checkin is None:
+            pytest.xfail("checkin_with_proximity not yet implemented — FR-19i")
+
+    def test_checkin_within_100m_succeeds(self):
+        """GPS coordinates within 100m of the event location should pass the proximity check."""
+        organizer = UserFactory()
+        service = ServiceFactory(
+            user=organizer, type='Event', status='Active',
+            max_participants=10, schedule_type='One-Time',
+            scheduled_time=timezone.now() + timedelta(hours=12),
+            duration=Decimal('1.00'),
+            location_type='In-Person',
+            location_lat=Decimal('41.012345'),
+            location_lng=Decimal('28.974321'),
+        )
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        # Coordinates ~50m away (well within 100m)
+        result = _gps_checkin(hs, participant, lat=41.012345, lng=28.974800)
+        assert result.status == 'checked_in'
+
+    def test_checkin_beyond_100m_raises(self):
+        """GPS coordinates more than 100m from the event location must be rejected."""
+        organizer = UserFactory()
+        service = ServiceFactory(
+            user=organizer, type='Event', status='Active',
+            max_participants=10, schedule_type='One-Time',
+            scheduled_time=timezone.now() + timedelta(hours=12),
+            duration=Decimal('1.00'),
+            location_type='In-Person',
+            location_lat=Decimal('41.012345'),
+            location_lng=Decimal('28.974321'),
+        )
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        # Coordinates ~2km away
+        with pytest.raises((ValueError, PermissionError), match='[Pp]roximity|[Dd]istance|[Ll]ocation'):
+            _gps_checkin(hs, participant, lat=41.030000, lng=28.974321)
+
+    def test_online_event_skips_proximity_check(self):
+        """Online events should not require GPS coordinates for check-in."""
+        organizer = UserFactory()
+        service = ServiceFactory(
+            user=organizer, type='Event', status='Active',
+            max_participants=10, schedule_type='One-Time',
+            scheduled_time=timezone.now() + timedelta(hours=12),
+            duration=Decimal('1.00'),
+            location_type='Online',
+            location_lat=None,
+            location_lng=None,
+        )
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        # No GPS required for online events
+        result = _gps_checkin(hs, participant, lat=None, lng=None)
+        assert result.status == 'checked_in'
+
+    def test_missing_gps_coordinates_for_inperson_event_raises(self):
+        """Submitting no GPS for an in-person event must be rejected."""
+        organizer = UserFactory()
+        service = ServiceFactory(
+            user=organizer, type='Event', status='Active',
+            max_participants=10, schedule_type='One-Time',
+            scheduled_time=timezone.now() + timedelta(hours=12),
+            duration=Decimal('1.00'),
+            location_type='In-Person',
+            location_lat=Decimal('41.012345'),
+            location_lng=Decimal('28.974321'),
+        )
+        participant = UserFactory()
+        hs = EventHandshakeService.join_event(service, participant)
+
+        with pytest.raises((ValueError, TypeError)):
+            _gps_checkin(hs, participant, lat=None, lng=None)

--- a/backend/api/tests/unit/test_location_privacy.py
+++ b/backend/api/tests/unit/test_location_privacy.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for location privacy / coordinate blur behaviour — FR-19h, FR-17l.
+
+FR-19h requires:
+  - In-person listing coordinates are blurred (~500m) until the requesting user has
+    an ACCEPTED handshake with the service provider.
+  - Once a handshake is accepted, exact coordinates are visible to both participants.
+  - The blur offset must be deterministic (same service → same fuzz) to prevent
+    triangulation via repeated queries.
+
+Current codebase status:
+  - _fuzzy_coords() in serializers.py applies a deterministic FNV-1a ~500m offset.
+  - The blur is applied to ALL non-owner users regardless of handshake status.
+  - Conditional reveal on handshake ACCEPTED is NOT yet implemented.
+
+Test classes:
+  TestLocationBlurDeterminism   — green (current behaviour, already works)
+  TestLocationBlurConditional   — xfail (FR-19h conditional reveal not implemented)
+"""
+import math
+import pytest
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from api.tests.helpers.factories import (
+    UserFactory,
+    ServiceFactory,
+    HandshakeFactory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Green tests — document the current deterministic blur behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestLocationBlurDeterminism:
+    """
+    The existing _fuzzy_coords() offset must be deterministic:
+    the same service ID always produces the same offset, so a single user
+    cannot triangulate the real location by querying repeatedly.
+    """
+
+    def _fetch_coords(self, service, user):
+        client = APIClient()
+        client.force_authenticate(user=user)
+        resp = client.get(f'/api/services/{service.id}/')
+        assert resp.status_code == 200
+        return resp.data.get('location_lat'), resp.data.get('location_lng')
+
+    def test_non_owner_sees_fuzzed_coordinates(self):
+        """Non-owner should not receive exact service coordinates."""
+        provider = UserFactory()
+        viewer = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider,
+            type='Offer',
+            location_type='In-Person',
+            location_lat=real_lat,
+            location_lng=real_lng,
+            status='Active',
+        )
+
+        lat, lng = self._fetch_coords(service, viewer)
+
+        assert lat is not None
+        assert lng is not None
+        assert float(lat) != pytest.approx(float(real_lat), abs=1e-4), (
+            "Non-owner received exact latitude — blur not applied."
+        )
+
+    def test_blur_is_consistent_across_requests(self):
+        """Same non-owner querying the same service twice must get identical fuzzed coords."""
+        provider = UserFactory()
+        viewer = UserFactory()
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=Decimal('41.012345'), location_lng=Decimal('28.974321'),
+            status='Active',
+        )
+
+        lat1, lng1 = self._fetch_coords(service, viewer)
+        lat2, lng2 = self._fetch_coords(service, viewer)
+
+        assert lat1 == lat2, "Fuzzed latitude changed between identical requests — not deterministic."
+        assert lng1 == lng2, "Fuzzed longitude changed between identical requests — not deterministic."
+
+    def test_different_services_get_different_offsets(self):
+        """Two distinct services at the same real coordinates should fuzz to different locations."""
+        provider = UserFactory()
+        viewer = UserFactory()
+        kwargs = dict(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=Decimal('41.012345'), location_lng=Decimal('28.974321'),
+            status='Active',
+        )
+        s1 = ServiceFactory(**kwargs)
+        s2 = ServiceFactory(**kwargs)
+
+        lat1, lng1 = self._fetch_coords(s1, viewer)
+        lat2, lng2 = self._fetch_coords(s2, viewer)
+
+        # Different services → different hash seeds → different offsets
+        assert (lat1, lng1) != (lat2, lng2), (
+            "Two different services produced identical fuzz — hash is not service-specific."
+        )
+
+    def test_owner_sees_exact_coordinates(self):
+        """Service owner must receive the real unblurred coordinates."""
+        provider = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=real_lat, location_lng=real_lng, status='Active',
+        )
+
+        lat, lng = self._fetch_coords(service, provider)
+
+        assert float(lat) == pytest.approx(float(real_lat), abs=1e-4), (
+            "Owner received fuzzed latitude — owner bypass is broken."
+        )
+
+    def test_online_service_coordinates_not_fuzzed(self):
+        """Online services have no physical location — no blur should be applied."""
+        provider = UserFactory()
+        viewer = UserFactory()
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='Online',
+            location_lat=None, location_lng=None, status='Active',
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        resp = client.get(f'/api/services/{service.id}/')
+        assert resp.status_code == 200
+        # location_lat/lng are null for Online services — no blur needed
+        assert resp.data.get('location_lat') is None or resp.data.get('location_type') == 'Online'
+
+
+# ---------------------------------------------------------------------------
+# xfail tests — FR-19h conditional reveal on ACCEPTED handshake (not yet implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.unit
+@pytest.mark.xfail(
+    reason="FR-19h: blur is always-on; conditional reveal on ACCEPTED handshake not implemented",
+    strict=False,
+)
+class TestLocationBlurConditional:
+    """
+    Once a handshake between the requester and provider reaches status='accepted',
+    the requester should receive the exact (unblurred) service coordinates.
+
+    These tests are xfail because the serializer currently blurs for all non-owners
+    regardless of handshake status.
+    """
+
+    def _fetch_coords(self, service, user):
+        client = APIClient()
+        client.force_authenticate(user=user)
+        resp = client.get(f'/api/services/{service.id}/')
+        assert resp.status_code == 200
+        return resp.data.get('location_lat'), resp.data.get('location_lng')
+
+    def test_accepted_handshake_requester_sees_exact_coords(self):
+        """A user with an accepted handshake should receive unblurred coordinates."""
+        provider = UserFactory()
+        requester = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=real_lat, location_lng=real_lng, status='Active',
+        )
+        HandshakeFactory(service=service, requester=requester, status='accepted')
+
+        lat, lng = self._fetch_coords(service, requester)
+
+        assert float(lat) == pytest.approx(float(real_lat), abs=1e-4), (
+            "Requester with accepted handshake still received fuzzed coordinates."
+        )
+        assert float(lng) == pytest.approx(float(real_lng), abs=1e-4)
+
+    def test_pending_handshake_requester_still_sees_fuzzed_coords(self):
+        """A user with only a pending handshake should still see blurred coordinates."""
+        provider = UserFactory()
+        requester = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=real_lat, location_lng=real_lng, status='Active',
+        )
+        HandshakeFactory(service=service, requester=requester, status='pending')
+
+        lat, lng = self._fetch_coords(service, requester)
+
+        assert float(lat) != pytest.approx(float(real_lat), abs=1e-4), (
+            "Requester with pending handshake received exact coordinates before acceptance."
+        )
+
+    def test_unrelated_user_with_no_handshake_sees_fuzzed_coords(self):
+        """A user with no handshake relationship should always see blurred coordinates."""
+        provider = UserFactory()
+        unrelated = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=real_lat, location_lng=real_lng, status='Active',
+        )
+
+        lat, lng = self._fetch_coords(service, unrelated)
+
+        assert float(lat) != pytest.approx(float(real_lat), abs=1e-4)
+
+    def test_provider_always_sees_exact_coords_regardless_of_handshake(self):
+        """Service owner should always see exact coordinates — handshake status is irrelevant."""
+        provider = UserFactory()
+        real_lat, real_lng = Decimal('41.012345'), Decimal('28.974321')
+        service = ServiceFactory(
+            user=provider, type='Offer', location_type='In-Person',
+            location_lat=real_lat, location_lng=real_lng, status='Active',
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=provider)
+        resp = client.get(f'/api/services/{service.id}/')
+        lat = resp.data.get('location_lat')
+        lng = resp.data.get('location_lng')
+
+        assert float(lat) == pytest.approx(float(real_lat), abs=1e-4)


### PR DESCRIPTION
- Added unit tests for QR token validation and GPS proximity check-in as part of FR-19i.
- Tests include scenarios for valid and invalid QR tokens, single-use token enforcement, and GPS coordinate validation.
- Marked tests as xfail due to incomplete implementation in EventHandshakeService.
- Enhanced test coverage for in-person and online event check-in requirements.