### PR TITLE
Feat/mobile follow final

### DIFF
--- a/mobile-client/src/api/__tests__/users.test.ts
+++ b/mobile-client/src/api/__tests__/users.test.ts
@@ -12,6 +12,8 @@ import {
   getBadgeProgress,
   getUserHistory,
   getVerifiedReviews,
+  followUser,
+  unfollowUser,
 } from "../users";
 import { mockFetchResolve, getLastFetchCall, getLastFetchBody } from "./helpers";
 
@@ -80,5 +82,21 @@ describe("users", () => {
     mockFetchResolve({ results: [] });
     await getVerifiedReviews("u1", { page: 1 });
     expect(getLastFetchCall().url).toContain("/users/u1/verified-reviews/");
+  });
+
+  it("followUser POSTs /users/:id/follow/", async () => {
+    mockFetchResolve(null);
+    await followUser("u2");
+    const { url, init } = getLastFetchCall();
+    expect(url).toContain("/users/u2/follow/");
+    expect(init?.method).toBe("POST");
+  });
+
+  it("unfollowUser DELETEs /users/:id/follow/", async () => {
+    mockFetchResolve(null);
+    await unfollowUser("u2");
+    const { url, init } = getLastFetchCall();
+    expect(url).toContain("/users/u2/follow/");
+    expect(init?.method).toBe("DELETE");
   });
 });

--- a/mobile-client/src/api/__tests__/users.test.ts
+++ b/mobile-client/src/api/__tests__/users.test.ts
@@ -14,6 +14,8 @@ import {
   getVerifiedReviews,
   followUser,
   unfollowUser,
+  getFollowers,
+  getFollowing,
 } from "../users";
 import { mockFetchResolve, getLastFetchCall, getLastFetchBody } from "./helpers";
 
@@ -98,5 +100,19 @@ describe("users", () => {
     const { url, init } = getLastFetchCall();
     expect(url).toContain("/users/u2/follow/");
     expect(init?.method).toBe("DELETE");
+  });
+
+  it("getFollowers GETs /users/:id/followers/ and normalizes results", async () => {
+    mockFetchResolve({ results: [{ id: "a", first_name: "A", last_name: "B" }] });
+    const list = await getFollowers("u1");
+    expect(getLastFetchCall().url).toContain("/users/u1/followers/");
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe("a");
+  });
+
+  it("getFollowing GETs /users/:id/following/", async () => {
+    mockFetchResolve({ results: [] });
+    await getFollowing("u1");
+    expect(getLastFetchCall().url).toContain("/users/u1/following/");
   });
 });

--- a/mobile-client/src/api/types.ts
+++ b/mobile-client/src/api/types.ts
@@ -27,6 +27,8 @@ export interface UserSummary {
   featured_achievement_id?: string | null;
   /** When false, other users should not see exchange history (web parity). */
   show_history?: boolean;
+  followers_count?: number;
+  following_count?: number;
 }
 
 /**

--- a/mobile-client/src/api/types.ts
+++ b/mobile-client/src/api/types.ts
@@ -54,6 +54,10 @@ export interface PublicUserProfile {
   portfolio_images?: string[];
   /** Public exchange history visibility; when false, do not fetch history for viewers. */
   show_history?: boolean;
+  followers_count?: number;
+  following_count?: number;
+  /** Whether the authenticated viewer follows this user (absent when unauthenticated). */
+  is_following?: boolean;
 }
 
 /** GET /users/{id}/history/ row shape (web `UserHistoryItem`). */

--- a/mobile-client/src/api/users.ts
+++ b/mobile-client/src/api/users.ts
@@ -5,7 +5,12 @@
  */
 
 import { apiRequest } from "./client";
-import type { PublicUserProfile, UserHistoryItem, UserSummary } from "./types";
+import type {
+  PaginatedResponse,
+  PublicUserProfile,
+  UserHistoryItem,
+  UserSummary,
+} from "./types";
 
 export interface UserProfileRequest {
   first_name?: string;
@@ -44,6 +49,25 @@ export function followUser(userId: string): Promise<void> {
 
 export function unfollowUser(userId: string): Promise<void> {
   return apiRequest<void>(`/users/${userId}/follow/`, { method: "DELETE" });
+}
+
+function normalizeUserSummaryList(
+  data: UserSummary[] | PaginatedResponse<UserSummary>,
+): UserSummary[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+export function getFollowers(userId: string): Promise<UserSummary[]> {
+  return apiRequest<UserSummary[] | PaginatedResponse<UserSummary>>(
+    `/users/${userId}/followers/`,
+  ).then(normalizeUserSummaryList);
+}
+
+export function getFollowing(userId: string): Promise<UserSummary[]> {
+  return apiRequest<UserSummary[] | PaginatedResponse<UserSummary>>(
+    `/users/${userId}/following/`,
+  ).then(normalizeUserSummaryList);
 }
 
 export function updateUser(

--- a/mobile-client/src/api/users.ts
+++ b/mobile-client/src/api/users.ts
@@ -35,6 +35,17 @@ export function getUser(id: string): Promise<PublicUserProfile> {
   return apiRequest<PublicUserProfile>(`/users/${id}/`);
 }
 
+export function followUser(userId: string): Promise<void> {
+  return apiRequest<void>(`/users/${userId}/follow/`, {
+    method: "POST",
+    body: {},
+  });
+}
+
+export function unfollowUser(userId: string): Promise<void> {
+  return apiRequest<void>(`/users/${userId}/follow/`, { method: "DELETE" });
+}
+
 export function updateUser(
   id: string,
   body: Partial<UserProfileRequest>,

--- a/mobile-client/src/navigation/ProfileStack.tsx
+++ b/mobile-client/src/navigation/ProfileStack.tsx
@@ -5,7 +5,7 @@ import LoginScreen from "../presentation/screens/LoginScreen";
 import RegisterScreen from "../presentation/screens/RegisterScreen";
 import PublicProfileScreen from "../presentation/screens/PublicProfileScreen";
 import AchievementsListScreen from "../presentation/screens/AchievementsListScreen";
-import NotificationsScreen from "../presentation/screens/NotificationsScreen";
+import FollowListScreen from "../presentation/screens/FollowListScreen";
 
 export type ProfileStackParamList = {
   ProfileHome: undefined;
@@ -13,7 +13,7 @@ export type ProfileStackParamList = {
   Register: undefined;
   PublicProfile: { userId: string };
   AchievementsList: { userId: string };
-  Notifications: undefined;
+  FollowList: { userId: string; kind: "followers" | "following" };
 };
 
 const Stack = createNativeStackNavigator<ProfileStackParamList>();
@@ -42,7 +42,18 @@ export default function ProfileStack() {
           animation: "slide_from_right",
         }}
       />
-      <Stack.Screen name="Notifications" component={NotificationsScreen} />
+      <Stack.Screen
+        name="FollowList"
+        component={FollowListScreen}
+        options={{
+          headerShown: true,
+          headerStyle: { backgroundColor: "#fff" },
+          headerTitleStyle: { fontSize: 17, fontWeight: "600" },
+          headerShadowVisible: true,
+          gestureEnabled: true,
+          animation: "slide_from_right",
+        }}
+      />
     </Stack.Navigator>
   );
 }

--- a/mobile-client/src/presentation/screens/FollowListScreen.tsx
+++ b/mobile-client/src/presentation/screens/FollowListScreen.tsx
@@ -1,0 +1,257 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import type { RouteProp } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { getFollowers, getFollowing } from "../../api/users";
+import type { UserSummary } from "../../api/types";
+import type { ProfileStackParamList } from "../../navigation/ProfileStack";
+import { colors } from "../../constants/colors";
+import { useAuth } from "../../context/AuthContext";
+
+type Nav = NativeStackNavigationProp<ProfileStackParamList, "FollowList">;
+type FollowRoute = RouteProp<ProfileStackParamList, "FollowList">;
+
+function rowDisplayName(u: UserSummary): string {
+  const n = [u.first_name, u.last_name]
+    .map((p) => (p == null ? "" : String(p).trim()))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  if (n) return n;
+  if (u.email && String(u.email).trim()) {
+    return String(u.email).split("@")[0] ?? "User";
+  }
+  return "User";
+}
+
+function initials(u: UserSummary): string {
+  const f = (u.first_name || "").trim().charAt(0);
+  const l = (u.last_name || "").trim().charAt(0);
+  const s = (f + l).toUpperCase();
+  if (s) return s;
+  return (u.email || "U").charAt(0).toUpperCase();
+}
+
+export default function FollowListScreen() {
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<FollowRoute>();
+  const { userId, kind } = route.params;
+  const { user: authUser } = useAuth();
+  const insets = useSafeAreaInsets();
+
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "error"; message: string }
+    | { status: "success"; users: UserSummary[] }
+  >({ status: "loading" });
+
+  const title = kind === "followers" ? "Followers" : "Following";
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title });
+  }, [navigation, title]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    const req = kind === "followers" ? getFollowers(userId) : getFollowing(userId);
+    req
+      .then((users) => {
+        if (!cancelled) setState({ status: "success", users });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const message =
+            err instanceof Error ? err.message : "Could not load this list.";
+          setState({ status: "error", message });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, kind]);
+
+  const onPressUser = useCallback(
+    (target: UserSummary) => {
+      const targetId = String(target.id);
+      if (authUser?.id != null && targetId === String(authUser.id)) {
+        navigation.popToTop();
+        return;
+      }
+      navigation.navigate("PublicProfile", { userId: targetId });
+    },
+    [authUser?.id, navigation],
+  );
+
+  const styles = useMemo(
+    () => getStyles(insets.bottom),
+    [insets.bottom],
+  );
+
+  if (state.status === "loading") {
+    return (
+      <View style={[styles.centered, styles.fill]}>
+        <ActivityIndicator size="large" color={colors.GREEN} />
+      </View>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <View style={[styles.centered, styles.fill, styles.errorPad]}>
+        <Text style={styles.errorText}>{state.message}</Text>
+      </View>
+    );
+  }
+
+  const { users } = state;
+
+  return (
+    <View style={styles.fill}>
+      <FlatList
+        data={users}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={
+          users.length === 0 ? styles.emptyListContent : styles.listContent
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyWrap}>
+            <Text style={styles.emptyTitle}>No users to show</Text>
+            <Text style={styles.emptySubtitle}>
+              {kind === "followers"
+                ? "Nobody is following this user yet."
+                : "This user is not following anyone yet."}
+            </Text>
+          </View>
+        }
+        renderItem={({ item }) => {
+          const name = rowDisplayName(item);
+          const uri =
+            item.avatar_url != null && String(item.avatar_url).trim()
+              ? String(item.avatar_url).trim()
+              : null;
+          return (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Open profile for ${name}`}
+              onPress={() => onPressUser(item)}
+              style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+            >
+              {uri ? (
+                <Image source={{ uri }} style={styles.avatar} />
+              ) : (
+                <View style={styles.avatarPlaceholder}>
+                  <Text style={styles.avatarInitials}>{initials(item)}</Text>
+                </View>
+              )}
+              <Text style={styles.name} numberOfLines={1}>
+                {name}
+              </Text>
+              <Ionicons
+                name="chevron-forward"
+                size={20}
+                color={colors.GRAY400}
+              />
+            </Pressable>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+function getStyles(bottomInset: number) {
+  return StyleSheet.create({
+    fill: {
+      flex: 1,
+      backgroundColor: colors.GRAY100,
+    },
+    centered: {
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    errorPad: {
+      padding: 24,
+    },
+    errorText: {
+      fontSize: 15,
+      color: colors.GRAY600,
+      textAlign: "center",
+    },
+    listContent: {
+      paddingBottom: Math.max(24, bottomInset + 16),
+    },
+    emptyListContent: {
+      flexGrow: 1,
+      paddingBottom: Math.max(24, bottomInset + 16),
+    },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      backgroundColor: colors.WHITE,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.GRAY200,
+      gap: 12,
+    },
+    rowPressed: {
+      backgroundColor: colors.GRAY50,
+    },
+    avatar: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: colors.GRAY200,
+    },
+    avatarPlaceholder: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      backgroundColor: colors.GREEN,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    avatarInitials: {
+      color: colors.WHITE,
+      fontSize: 16,
+      fontWeight: "700",
+    },
+    name: {
+      flex: 1,
+      fontSize: 16,
+      fontWeight: "600",
+      color: colors.GRAY900,
+    },
+    emptyWrap: {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+      padding: 32,
+      minHeight: 220,
+    },
+    emptyTitle: {
+      fontSize: 17,
+      fontWeight: "700",
+      color: colors.GRAY800,
+      marginBottom: 8,
+    },
+    emptySubtitle: {
+      fontSize: 14,
+      color: colors.GRAY500,
+      textAlign: "center",
+      lineHeight: 20,
+    },
+  });
+}

--- a/mobile-client/src/presentation/screens/FollowListScreen.tsx
+++ b/mobile-client/src/presentation/screens/FollowListScreen.tsx
@@ -17,7 +17,6 @@ import { getFollowers, getFollowing } from "../../api/users";
 import type { UserSummary } from "../../api/types";
 import type { ProfileStackParamList } from "../../navigation/ProfileStack";
 import { colors } from "../../constants/colors";
-import { useAuth } from "../../context/AuthContext";
 
 type Nav = NativeStackNavigationProp<ProfileStackParamList, "FollowList">;
 type FollowRoute = RouteProp<ProfileStackParamList, "FollowList">;
@@ -47,7 +46,6 @@ export default function FollowListScreen() {
   const navigation = useNavigation<Nav>();
   const route = useRoute<FollowRoute>();
   const { userId, kind } = route.params;
-  const { user: authUser } = useAuth();
   const insets = useSafeAreaInsets();
 
   const [state, setState] = useState<
@@ -82,17 +80,9 @@ export default function FollowListScreen() {
     };
   }, [userId, kind]);
 
-  const onPressUser = useCallback(
-    (target: UserSummary) => {
-      const targetId = String(target.id);
-      if (authUser?.id != null && targetId === String(authUser.id)) {
-        navigation.popToTop();
-        return;
-      }
-      navigation.navigate("PublicProfile", { userId: targetId });
-    },
-    [authUser?.id, navigation],
-  );
+  const onPressUser = useCallback((target: UserSummary) => {
+    navigation.navigate("PublicProfile", { userId: String(target.id) });
+  }, [navigation]);
 
   const styles = useMemo(
     () => getStyles(insets.bottom),

--- a/mobile-client/src/presentation/screens/FollowListScreen.tsx
+++ b/mobile-client/src/presentation/screens/FollowListScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
+  BackHandler,
   FlatList,
   Image,
   Pressable,
@@ -9,17 +10,40 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useNavigation, useRoute } from "@react-navigation/native";
+import {
+  useFocusEffect,
+  useNavigation,
+  useRoute,
+} from "@react-navigation/native";
 import type { RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { getFollowers, getFollowing } from "../../api/users";
+import { getFollowers, getFollowing, getUser } from "../../api/users";
 import type { UserSummary } from "../../api/types";
 import type { ProfileStackParamList } from "../../navigation/ProfileStack";
 import { colors } from "../../constants/colors";
+import { useAuth } from "../../context/AuthContext";
 
 type Nav = NativeStackNavigationProp<ProfileStackParamList, "FollowList">;
 type FollowRoute = RouteProp<ProfileStackParamList, "FollowList">;
+
+const headerBackStyles = StyleSheet.create({
+  wrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingLeft: 6,
+    paddingVertical: 8,
+    paddingRight: 8,
+    maxWidth: 260,
+  },
+  pressed: { opacity: 0.65 },
+  label: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: colors.GRAY900,
+    flexShrink: 1,
+  },
+});
 
 function rowDisplayName(u: UserSummary): string {
   const n = [u.first_name, u.last_name]
@@ -42,12 +66,26 @@ function initials(u: UserSummary): string {
   return (u.email || "U").charAt(0).toUpperCase();
 }
 
+function profileOwnerLabelFromApiUser(u: {
+  first_name?: string;
+  last_name?: string;
+}): string {
+  const n = [u.first_name, u.last_name]
+    .map((p) => (p == null ? "" : String(p).trim()))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  return n || "User";
+}
+
 export default function FollowListScreen() {
   const navigation = useNavigation<Nav>();
   const route = useRoute<FollowRoute>();
   const { userId, kind } = route.params;
+  const { user: authUser } = useAuth();
   const insets = useSafeAreaInsets();
 
+  const [ownerLabel, setOwnerLabel] = useState("");
   const [state, setState] = useState<
     | { status: "loading" }
     | { status: "error"; message: string }
@@ -56,9 +94,74 @@ export default function FollowListScreen() {
 
   const title = kind === "followers" ? "Followers" : "Following";
 
+  useEffect(() => {
+    let cancelled = false;
+    setOwnerLabel("");
+    getUser(userId)
+      .then((u) => {
+        if (!cancelled) setOwnerLabel(profileOwnerLabelFromApiUser(u));
+      })
+      .catch(() => {
+        if (!cancelled) setOwnerLabel("User");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const goBackToOwnerProfile = useCallback(() => {
+    if (authUser?.id != null && String(userId) === String(authUser.id)) {
+      navigation.navigate("ProfileHome");
+      return;
+    }
+    navigation.navigate("PublicProfile", { userId });
+  }, [authUser?.id, navigation, userId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+        goBackToOwnerProfile();
+        return true;
+      });
+      return () => sub.remove();
+    }, [goBackToOwnerProfile]),
+  );
+
   useLayoutEffect(() => {
-    navigation.setOptions({ title });
-  }, [navigation, title]);
+    const backTitle = ownerLabel || "…";
+    navigation.setOptions({
+      title,
+      headerBackVisible: false,
+      headerLeft: () => (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            authUser?.id != null && String(userId) === String(authUser.id)
+              ? "Back to my profile"
+              : `Back to ${backTitle} profile`
+          }
+          onPress={goBackToOwnerProfile}
+          style={({ pressed }) => [
+            headerBackStyles.wrap,
+            pressed && headerBackStyles.pressed,
+          ]}
+          hitSlop={10}
+        >
+          <Ionicons name="chevron-back" size={24} color={colors.GREEN} />
+          <Text style={headerBackStyles.label} numberOfLines={1}>
+            {backTitle}
+          </Text>
+        </Pressable>
+      ),
+    });
+  }, [
+    authUser?.id,
+    goBackToOwnerProfile,
+    navigation,
+    ownerLabel,
+    title,
+    userId,
+  ]);
 
   useEffect(() => {
     let cancelled = false;

--- a/mobile-client/src/presentation/screens/ProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Image,
@@ -15,6 +15,7 @@ import {
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 import {
+  useFocusEffect,
   useNavigation,
   type CompositeNavigationProp,
 } from "@react-navigation/native";
@@ -53,7 +54,7 @@ type EditableProfile = {
 };
 
 export default function ProfileScreen() {
-  const { user, logout } = useAuth();
+  const { user, logout, refreshUser } = useAuth();
   const navigation = useNavigation<ProfileHomeNavigation>();
   const insets = useSafeAreaInsets();
   const unreadCount = useNotificationStore((s) => s.unreadCount);
@@ -66,6 +67,13 @@ export default function ProfileScreen() {
   const [activeServices, setActiveServices] = useState<Service[]>([]);
   const [activeServicesOpen, setActiveServicesOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<UserHistoryItem[]>([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!user?.id) return;
+      void refreshUser();
+    }, [refreshUser, user?.id]),
+  );
 
   const initialForm = useMemo<EditableProfile>(
     () => ({

--- a/mobile-client/src/presentation/screens/ProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/ProfileScreen.tsx
@@ -203,6 +203,8 @@ export default function ProfileScreen() {
     kind_count?: number;
     punctual_count?: number;
     achievements?: string[];
+    followers_count?: number;
+    following_count?: number;
   };
 
   const fullName = `${form.first_name} ${form.last_name}`.trim();
@@ -282,6 +284,40 @@ export default function ProfileScreen() {
                 {form.email ? (
                   <Text style={styles.email}>{form.email}</Text>
                 ) : null}
+
+                <View style={styles.followMetaRow}>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="View your followers"
+                    onPress={() => {
+                      if (!user?.id) return;
+                      navigation.navigate("FollowList", {
+                        userId: String(user.id),
+                        kind: "followers",
+                      });
+                    }}
+                  >
+                    <Text style={styles.followMetaLink}>
+                      {typedUser.followers_count ?? 0} followers
+                    </Text>
+                  </Pressable>
+                  <Text style={styles.followMetaDot}> · </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="View users you follow"
+                    onPress={() => {
+                      if (!user?.id) return;
+                      navigation.navigate("FollowList", {
+                        userId: String(user.id),
+                        kind: "following",
+                      });
+                    }}
+                  >
+                    <Text style={styles.followMetaLink}>
+                      {typedUser.following_count ?? 0} following
+                    </Text>
+                  </Pressable>
+                </View>
 
                 {form.location ? (
                   <Text style={styles.location}>{form.location}</Text>
@@ -703,6 +739,22 @@ const getStyles = (top: number, bottom: number) =>
       fontSize: 14,
       color: colors.GRAY500,
       marginBottom: 6,
+    },
+    followMetaRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    followMetaLink: {
+      fontSize: 13,
+      fontWeight: "600",
+      color: colors.GREEN,
+      textDecorationLine: "underline",
+    },
+    followMetaDot: {
+      fontSize: 13,
+      color: colors.GRAY500,
     },
     location: {
       fontSize: 14,

--- a/mobile-client/src/presentation/screens/PublicProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/PublicProfileScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Image,
   Pressable,
   ScrollView,
@@ -18,7 +19,12 @@ import type { RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import { Ionicons, SimpleLineIcons } from "@expo/vector-icons";
-import { getUser, getUserHistory } from "../../api/users";
+import {
+  followUser,
+  getUser,
+  getUserHistory,
+  unfollowUser,
+} from "../../api/users";
 import { listServices } from "../../api/services";
 import type { PublicUserProfile, Service, UserHistoryItem } from "../../api/types";
 import { groupHistoryItems, isOwnHistoryItem } from "../../utils/historyGrouping";
@@ -55,7 +61,7 @@ function achievementIdsForDisplay(user: PublicUserProfile): string[] {
 export default function PublicProfileScreen() {
   const route = useRoute<RouteProp<ProfileStackParamList, "PublicProfile">>();
   const navigation = useNavigation<PublicProfileNavigation>();
-  const { user: authUser } = useAuth();
+  const { user: authUser, isAuthenticated, refreshUser } = useAuth();
   const { userId } = route.params;
   const insets = useSafeAreaInsets();
   const styles = useMemo(
@@ -67,6 +73,7 @@ export default function PublicProfileScreen() {
   const [activeServices, setActiveServices] = useState<Service[]>([]);
   const [activeServicesOpen, setActiveServicesOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<UserHistoryItem[]>([]);
+  const [followBusy, setFollowBusy] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -128,6 +135,20 @@ export default function PublicProfileScreen() {
       cancelled = true;
     };
   }, [state, userId]);
+
+  const openFollowList = useCallback(
+    (kind: "followers" | "following") => {
+      if (!isAuthenticated) {
+        navigation.navigate("Login");
+        return;
+      }
+      navigation.navigate("FollowList", {
+        userId: String(userId),
+        kind,
+      });
+    },
+    [isAuthenticated, navigation, userId],
+  );
 
   if (state.status === "loading") {
     return (
@@ -191,6 +212,29 @@ export default function PublicProfileScreen() {
   const achievementIds = achievementIdsForDisplay(user);
   const canOpenAchievementsList =
     authUser?.id != null && String(authUser.id) === String(user.id);
+  const isOwnProfile =
+    authUser?.id != null && String(authUser.id) === String(user.id);
+
+  const handleFollowToggle = async () => {
+    if (!isAuthenticated || followBusy || isOwnProfile) return;
+    setFollowBusy(true);
+    try {
+      if (user.is_following) {
+        await unfollowUser(String(user.id));
+      } else {
+        await followUser(String(user.id));
+      }
+      const fresh = await getUser(userId);
+      setState({ status: "success", user: fresh });
+      void refreshUser();
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong. Try again.";
+      Alert.alert("Could not update follow", message);
+    } finally {
+      setFollowBusy(false);
+    }
+  };
 
   const offersCount = activeServices.filter((s) => s.type === "Offer").length;
   const needsCount = activeServices.filter((s) => s.type === "Need").length;
@@ -212,8 +256,89 @@ export default function PublicProfileScreen() {
           </View>
 
           <View style={styles.profileHeaderContent}>
-            <View style={styles.nameRow}>
-              <Text style={styles.name}>{fullName || "Unnamed User"}</Text>
+            <View style={styles.nameAndActionRow}>
+              <View style={styles.nameBlock}>
+                <Text style={styles.name} numberOfLines={2}>
+                  {fullName || "Unnamed User"}
+                </Text>
+              </View>
+              {!isOwnProfile ? (
+                <View style={styles.followButtonColumn}>
+                  {isAuthenticated ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={
+                        user.is_following
+                          ? "Unfollow this user"
+                          : "Follow this user"
+                      }
+                      disabled={followBusy}
+                      onPress={() => void handleFollowToggle()}
+                      style={({ pressed }) => [
+                        user.is_following
+                          ? styles.followOutlineButton
+                          : styles.followFilledButton,
+                        (pressed || followBusy) && styles.followButtonPressed,
+                        followBusy && styles.followButtonDisabled,
+                      ]}
+                    >
+                      {followBusy ? (
+                        <ActivityIndicator
+                          color={
+                            user.is_following ? colors.GRAY700 : colors.WHITE
+                          }
+                          size="small"
+                        />
+                      ) : (
+                        <Text
+                          style={
+                            user.is_following
+                              ? styles.followOutlineButtonText
+                              : styles.followFilledButtonText
+                          }
+                        >
+                          {user.is_following ? "Unfollow" : "Follow"}
+                        </Text>
+                      )}
+                    </Pressable>
+                  ) : (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Sign in to follow this user"
+                      accessibilityHint="Opens the sign in screen"
+                      onPress={() => navigation.navigate("Login")}
+                      style={({ pressed }) => [
+                        styles.followFilledButton,
+                        pressed && styles.followButtonPressed,
+                      ]}
+                    >
+                      <Text style={styles.followFilledButtonText}>Sign in</Text>
+                    </Pressable>
+                  )}
+                </View>
+              ) : null}
+            </View>
+
+            <View style={styles.followMetaRow}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="View followers"
+                onPress={() => openFollowList("followers")}
+              >
+                <Text style={styles.followMetaLink}>
+                  {user.followers_count ?? 0} followers
+                </Text>
+              </Pressable>
+              <Text style={styles.followMetaDot}> · </Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="View following"
+                onPress={() => openFollowList("following")}
+              >
+                <Text style={styles.followMetaLink}>
+                  {user.following_count ?? 0} following
+                </Text>
+              </Pressable>
             </View>
 
             {locationText ? (
@@ -463,12 +588,75 @@ const getStyles = (top: number, bottom: number) =>
       paddingTop: 62,
       paddingBottom: 20,
     },
-    nameRow: {
+    nameAndActionRow: {
       flexDirection: "row",
-      alignItems: "center",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: 12,
+      marginBottom: 8,
+    },
+    nameBlock: {
+      flex: 1,
+      minWidth: 0,
+      paddingTop: 2,
+    },
+    followButtonColumn: {
+      flexShrink: 0,
+      maxWidth: "42%",
+    },
+    followMetaRow: {
+      flexDirection: "row",
       flexWrap: "wrap",
-      gap: 8,
-      marginBottom: 6,
+      alignItems: "center",
+      marginBottom: 8,
+    },
+    followMetaLink: {
+      fontSize: 13,
+      fontWeight: "600",
+      color: colors.GREEN,
+      textDecorationLine: "underline",
+    },
+    followMetaDot: {
+      fontSize: 13,
+      color: colors.GRAY500,
+    },
+    followFilledButton: {
+      alignSelf: "flex-end",
+      backgroundColor: colors.GREEN,
+      paddingHorizontal: 16,
+      paddingVertical: 9,
+      borderRadius: 999,
+      minWidth: 88,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    followOutlineButton: {
+      alignSelf: "flex-end",
+      backgroundColor: colors.WHITE,
+      paddingHorizontal: 16,
+      paddingVertical: 9,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: colors.GRAY400,
+      minWidth: 88,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    followButtonPressed: {
+      opacity: 0.85,
+    },
+    followButtonDisabled: {
+      opacity: 0.7,
+    },
+    followFilledButtonText: {
+      color: colors.WHITE,
+      fontSize: 14,
+      fontWeight: "700",
+    },
+    followOutlineButtonText: {
+      color: colors.GRAY700,
+      fontSize: 14,
+      fontWeight: "700",
     },
     name: {
       fontSize: 24,


### PR DESCRIPTION
# Mobile: public profile follow & following (complete feature)

Closes #375

## Summary

Delivers the full mobile follow experience on **public profiles**: visible **followers / following** counts, navigation to lists (with authentication where required), **Follow / Unfollow** (and **Sign in** when logged out), and **reliable counts** that stay aligned with the API and follow lists.

## What’s included

### Public profile (`PublicProfileScreen`)
- **Followers** and **following** counts (from `GET /users/{id}/`), tappable to open the existing **FollowList** flow.
- **Sign-in gate** for opening lists when the user is anonymous (navigate to login).
- **Follow / Unfollow** control next to the name; **Sign in** CTA when logged out.
- After a successful follow/unfollow, **`refreshUser()`** runs so the signed-in user’s profile stats (e.g. `following_count`) update immediately.

### Own profile (`ProfileScreen`)
- **`useFocusEffect`** + **`refreshUser()`** when the profile home screen gains focus so **followers/following numbers** match freshly loaded **Followers/Following** lists (no more stale counts until a manual/full refresh).

### Types (`PublicUserProfile`)
- **`followers_count`**, **`following_count`**, **`is_following`** added to mirror the backend public profile serializer.

## Context (earlier commits)

Previous work added **API helpers** and **list/navigation** pieces, but commit messages sometimes **overshot what landed in code** (e.g. public-profile UI described while only API or `ProfileScreen` changed). **`PublicProfileScreen` was missing** the public follow UX, and **cached `AuthContext` user** caused **count vs. list** drift. This PR **finishes the feature** and **corrects that behavior**.

## How to test

1. Open another user’s public profile: counts, list navigation, Follow/Unfollow, and logged-out **Sign in** path.
2. From **your** profile, open **Following** / **Followers**, then go back: header counts should match the list.
3. Follow or unfollow someone: your profile counts should update without restarting the app.