### PR TITLE
feat(mobile): Event evaluations for mobile

### DIFF
--- a/mobile-client/src/api/__tests__/handshakes.test.ts
+++ b/mobile-client/src/api/__tests__/handshakes.test.ts
@@ -22,6 +22,10 @@ import {
   approveCancellationHandshake,
   rejectCancellationHandshake,
   handshakeServiceInterest,
+  joinEvent,
+  leaveEvent,
+  checkinEvent,
+  markAttended,
 } from "../handshakes";
 import { mockFetchResolve, getLastFetchCall, getLastFetchBody } from "./helpers";
 
@@ -131,5 +135,34 @@ describe("handshakes", () => {
     mockFetchResolve({});
     await handshakeServiceInterest("s1");
     expect(getLastFetchCall().url).toContain("/handshakes/services/s1/interest/");
+  });
+
+  it("joinEvent POSTs to /handshakes/services/:id/join-event/", async () => {
+    mockFetchResolve({ id: "h1", status: "accepted" });
+    const result = await joinEvent("svc-1");
+    expect(getLastFetchCall().url).toContain("/handshakes/services/svc-1/join-event/");
+    expect(getLastFetchCall().init?.method).toBe("POST");
+    expect(result.status).toBe("accepted");
+  });
+
+  it("leaveEvent POSTs to /handshakes/:id/leave-event/", async () => {
+    mockFetchResolve({ id: "h1", status: "cancelled" });
+    await leaveEvent("h1");
+    expect(getLastFetchCall().url).toContain("/handshakes/h1/leave-event/");
+    expect(getLastFetchCall().init?.method).toBe("POST");
+  });
+
+  it("checkinEvent POSTs to /handshakes/:id/checkin/", async () => {
+    mockFetchResolve({ id: "h1", status: "checked_in" });
+    const result = await checkinEvent("h1");
+    expect(getLastFetchCall().url).toContain("/handshakes/h1/checkin/");
+    expect(result.status).toBe("checked_in");
+  });
+
+  it("markAttended POSTs to /handshakes/:id/mark-attended/", async () => {
+    mockFetchResolve({ id: "h1", status: "attended" });
+    const result = await markAttended("h1");
+    expect(getLastFetchCall().url).toContain("/handshakes/h1/mark-attended/");
+    expect(result.status).toBe("attended");
   });
 });

--- a/mobile-client/src/api/__tests__/reputation.test.ts
+++ b/mobile-client/src/api/__tests__/reputation.test.ts
@@ -10,6 +10,9 @@ import {
   patchReputation,
   deleteReputation,
   createNegativeReputation,
+  attachReviewImages,
+  submitCombinedEvaluation,
+  submitCombinedEventEvaluation,
 } from "../reputation";
 import { mockFetchResolve, getLastFetchCall, getLastFetchBody } from "./helpers";
 
@@ -57,5 +60,157 @@ describe("reputation", () => {
     await createNegativeReputation(body);
     expect(getLastFetchCall().url).toContain("/reputation/negative/");
     expect(getLastFetchBody()).toEqual(body);
+  });
+});
+
+describe("attachReviewImages", () => {
+  beforeEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn();
+  });
+
+  it("POSTs FormData to /reputation/add-review/", async () => {
+    mockFetchResolve({ ok: true });
+    await attachReviewImages("h1", ["/tmp/photo1.jpg", "/tmp/photo2.jpg"]);
+
+    const { url, init } = getLastFetchCall();
+    expect(url).toContain("/reputation/add-review/");
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBeInstanceOf(FormData);
+  });
+
+  it("includes handshake_id and image entries in the FormData", async () => {
+    mockFetchResolve({ ok: true });
+    await attachReviewImages("h42", ["/path/img.jpg"]);
+
+    const body = getLastFetchCall().init?.body;
+    expect(body).toBeInstanceOf(FormData);
+    const fd = body as FormData;
+    expect(fd.get("handshake_id")).toBe("h42");
+  });
+});
+
+describe("submitCombinedEvaluation", () => {
+  beforeEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn();
+  });
+
+  it("throws when no traits are selected", async () => {
+    await expect(
+      submitCombinedEvaluation({
+        handshake_id: "h1",
+        positive: { punctual: false, helpful: false, kindness: false },
+        negative: { is_late: false, is_unhelpful: false, is_rude: false },
+      }),
+    ).rejects.toThrow("Select at least one trait");
+  });
+
+  it("submits only positive when no negative traits selected", async () => {
+    mockFetchResolve({ id: "r1" });
+    const result = await submitCombinedEvaluation({
+      handshake_id: "h1",
+      positive: { punctual: true, helpful: false, kindness: false },
+      negative: { is_late: false, is_unhelpful: false, is_rude: false },
+      comment: "Nice",
+    });
+    expect(result.positive).toBeDefined();
+    expect(result.negative).toBeUndefined();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it("submits only negative when no positive traits selected", async () => {
+    mockFetchResolve({ id: "n1" });
+    const result = await submitCombinedEvaluation({
+      handshake_id: "h1",
+      positive: { punctual: false, helpful: false, kindness: false },
+      negative: { is_late: true, is_unhelpful: false, is_rude: false },
+    });
+    expect(result.positive).toBeUndefined();
+    expect(result.negative).toBeDefined();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it("submits both positive and negative when both have traits", async () => {
+    mockFetchResolve({ id: "r1" });
+    mockFetchResolve({ id: "n1" });
+    const result = await submitCombinedEvaluation({
+      handshake_id: "h1",
+      positive: { punctual: true, helpful: false, kindness: false },
+      negative: { is_late: true, is_unhelpful: false, is_rude: false },
+    });
+    expect(result.positive).toBeDefined();
+    expect(result.negative).toBeDefined();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
+  });
+
+  it("trims whitespace-only comments", async () => {
+    mockFetchResolve({ id: "r1" });
+    await submitCombinedEvaluation({
+      handshake_id: "h1",
+      positive: { punctual: true, helpful: false, kindness: false },
+      negative: { is_late: false, is_unhelpful: false, is_rude: false },
+      comment: "   ",
+    });
+    const body = getLastFetchBody() as Record<string, unknown>;
+    expect(body.comment).toBeUndefined();
+  });
+});
+
+describe("submitCombinedEventEvaluation", () => {
+  beforeEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn();
+  });
+
+  it("throws when no event traits are selected", async () => {
+    await expect(
+      submitCombinedEventEvaluation({
+        handshake_id: "h1",
+        positive: { well_organized: false, engaging: false, welcoming: false },
+        negative: { disorganized: false, boring: false, unwelcoming: false },
+      }),
+    ).rejects.toThrow("Select at least one trait");
+  });
+
+  it("submits positive event traits to /reputation/", async () => {
+    mockFetchResolve({ id: "r1" });
+    const result = await submitCombinedEventEvaluation({
+      handshake_id: "h1",
+      positive: { well_organized: true, engaging: false, welcoming: true },
+      negative: { disorganized: false, boring: false, unwelcoming: false },
+      comment: "Great event!",
+    });
+    expect(result.positive).toBeDefined();
+    expect(result.negative).toBeUndefined();
+
+    const body = getLastFetchBody() as Record<string, unknown>;
+    expect(body.handshake_id).toBe("h1");
+    expect(body.well_organized).toBe(true);
+    expect(body.welcoming).toBe(true);
+    expect(body.comment).toBe("Great event!");
+    expect(getLastFetchCall().url).toContain("/reputation/");
+  });
+
+  it("submits negative event traits to /reputation/negative/", async () => {
+    mockFetchResolve({ id: "n1" });
+    const result = await submitCombinedEventEvaluation({
+      handshake_id: "h1",
+      positive: { well_organized: false, engaging: false, welcoming: false },
+      negative: { disorganized: true, boring: false, unwelcoming: false },
+    });
+    expect(result.negative).toBeDefined();
+    expect(result.positive).toBeUndefined();
+    expect(getLastFetchCall().url).toContain("/reputation/negative/");
+  });
+
+  it("submits both positive and negative event traits", async () => {
+    mockFetchResolve({ id: "r1" });
+    mockFetchResolve({ id: "n1" });
+    const result = await submitCombinedEventEvaluation({
+      handshake_id: "h1",
+      positive: { well_organized: true, engaging: false, welcoming: false },
+      negative: { disorganized: true, boring: false, unwelcoming: false },
+    });
+    expect(result.positive).toBeDefined();
+    expect(result.negative).toBeDefined();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
   });
 });

--- a/mobile-client/src/api/__tests__/services.test.ts
+++ b/mobile-client/src/api/__tests__/services.test.ts
@@ -12,6 +12,7 @@ import {
   reportService,
   toggleServiceVisibility,
   addServiceInterest,
+  completeEvent,
 } from "../services";
 import { mockFetchResolve, getLastFetchCall, getLastFetchBody } from "./helpers";
 
@@ -108,5 +109,12 @@ describe("services", () => {
     await addServiceInterest("s1", { message: "Hi" });
     expect(getLastFetchCall().url).toContain("/services/s1/interest/");
     expect(getLastFetchBody()).toEqual({ message: "Hi" });
+  });
+
+  it("completeEvent POSTs to /services/:id/complete-event/", async () => {
+    mockFetchResolve(undefined);
+    await completeEvent("svc-1");
+    expect(getLastFetchCall().url).toContain("/services/svc-1/complete-event/");
+    expect(getLastFetchCall().init?.method).toBe("POST");
   });
 });

--- a/mobile-client/src/api/handshakes.ts
+++ b/mobile-client/src/api/handshakes.ts
@@ -10,9 +10,14 @@ export interface Handshake {
   id: string;
   service: string | object;
   initiator?: string | object;
+  requester?: string | object;
   status: string;
   created_at: string;
   updated_at?: string;
+  evaluation_window_starts_at?: string | null;
+  evaluation_window_ends_at?: string | null;
+  evaluation_window_closed_at?: string | null;
+  user_has_reviewed?: boolean;
   [key: string]: unknown;
 }
 

--- a/mobile-client/src/api/handshakes.ts
+++ b/mobile-client/src/api/handshakes.ts
@@ -121,3 +121,21 @@ export function requestHandshakeChanges(id: string, body?: object): Promise<Hand
 export function handshakeServiceInterest(serviceId: string, body?: object): Promise<unknown> {
   return apiRequest(`/handshakes/services/${serviceId}/interest/`, { method: 'POST', body: body ?? {} });
 }
+
+// ─── Event actions ────────────────────────────────────────────────────────
+
+export function joinEvent(serviceId: string): Promise<Handshake> {
+  return apiRequest<Handshake>(`/handshakes/services/${serviceId}/join-event/`, { method: 'POST', body: {} });
+}
+
+export function leaveEvent(id: string): Promise<Handshake> {
+  return apiRequest<Handshake>(`/handshakes/${id}/leave-event/`, { method: 'POST', body: {} });
+}
+
+export function checkinEvent(id: string): Promise<Handshake> {
+  return apiRequest<Handshake>(`/handshakes/${id}/checkin/`, { method: 'POST', body: {} });
+}
+
+export function markAttended(id: string): Promise<Handshake> {
+  return apiRequest<Handshake>(`/handshakes/${id}/mark-attended/`, { method: 'POST', body: {} });
+}

--- a/mobile-client/src/api/reputation.ts
+++ b/mobile-client/src/api/reputation.ts
@@ -92,6 +92,19 @@ export function createNegativeReputation(body: ReputationRequest): Promise<Reput
   return apiRequest<ReputationEntry>('/reputation/negative/', { method: 'POST', body });
 }
 
+export function attachReviewImages(
+  handshakeId: string,
+  imageUris: string[],
+): Promise<unknown> {
+  const formData = new FormData();
+  formData.append('handshake_id', handshakeId);
+  imageUris.forEach((uri, i) => {
+    const name = uri.split('/').pop() || `review_${i}.jpg`;
+    formData.append('images', { uri, name, type: 'image/jpeg' } as unknown as Blob);
+  });
+  return apiRequest('/reputation/add-review/', { method: 'POST', body: formData });
+}
+
 export async function submitCombinedEvaluation(
   payload: SubmitCombinedEvaluationPayload,
 ): Promise<{ positive?: ReputationEntry; negative?: ReputationEntry }> {

--- a/mobile-client/src/api/services.ts
+++ b/mobile-client/src/api/services.ts
@@ -112,3 +112,7 @@ export function toggleServiceVisibility(id: string): Promise<Service> {
 export function addServiceInterest(serviceId: string, body?: { message?: string }): Promise<unknown> {
   return apiRequest(`/services/${serviceId}/interest/`, { method: 'POST', body: body ?? {} });
 }
+
+export function completeEvent(serviceId: string): Promise<void> {
+  return apiRequest<void>(`/services/${serviceId}/complete-event/`, { method: 'POST' });
+}

--- a/mobile-client/src/api/types.ts
+++ b/mobile-client/src/api/types.ts
@@ -89,6 +89,30 @@ export type ServiceStatus = "Active" | "Completed" | "Cancelled" | string;
 export type LocationType = "In-Person" | "Online" | "remote" | string;
 export type ScheduleType = "One-Time" | "Recurrent" | string;
 
+export interface EventEvaluationSummary {
+  total_attended: number;
+  positive_feedback_count: number;
+  negative_feedback_count: number;
+  unique_evaluator_count: number;
+  positive_score_total: number;
+  negative_score_total: number;
+  well_organized_count: number;
+  engaging_count: number;
+  welcoming_count: number;
+  disorganized_count: number;
+  boring_count: number;
+  unwelcoming_count: number;
+  well_organized_average: number;
+  engaging_average: number;
+  welcoming_average: number;
+  disorganized_average: number;
+  boring_average: number;
+  unwelcoming_average: number;
+  organizer_event_hot_score: number;
+  feedback_submission_count: number;
+  updated_at: string;
+}
+
 export interface Service {
   id: string;
   user: UserSummary;
@@ -115,6 +139,8 @@ export interface Service {
   session_exact_location_lat?: string | null;
   session_exact_location_lng?: string | null;
   session_location_guide?: string | null;
+  event_completed_at?: string | null;
+  event_evaluation_summary?: EventEvaluationSummary | null;
   media?: Array<{
     id: string;
     file_url: string;

--- a/mobile-client/src/constants/__tests__/notificationMappings.test.ts
+++ b/mobile-client/src/constants/__tests__/notificationMappings.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for notification deep-link routing.
+ */
+
+import { navigateToNotificationTarget, NOTIFICATION_ICONS } from "../notificationMappings";
+import type { Notification } from "../../api/notifications";
+
+function makeNotification(overrides: Partial<Notification>): Notification {
+  return {
+    id: "n1",
+    type: "positive_rep",
+    title: "",
+    message: "",
+    is_read: false,
+    related_handshake: null,
+    related_service: null,
+    created_at: "",
+    ...overrides,
+  };
+}
+
+describe("navigateToNotificationTarget", () => {
+  let navigate: jest.Mock;
+
+  beforeEach(() => {
+    navigate = jest.fn();
+  });
+
+  it("routes positive_rep with related_service to ServiceDetail", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "positive_rep", related_service: "svc-42" }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Home", {
+      screen: "ServiceDetail",
+      params: { id: "svc-42" },
+    });
+  });
+
+  it("routes positive_rep without related_service to Profile", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "positive_rep", related_service: null }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Profile");
+  });
+
+  it("routes handshake_request with related_handshake to Chat", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "handshake_request", related_handshake: "hs-1" }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Messages", {
+      screen: "Chat",
+      params: { handshakeId: "hs-1" },
+    });
+  });
+
+  it("routes chat_message with related_handshake to Chat", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "chat_message", related_handshake: "hs-2" }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Messages", {
+      screen: "Chat",
+      params: { handshakeId: "hs-2" },
+    });
+  });
+
+  it("routes service_updated with related_service to ServiceDetail", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "service_updated", related_service: "svc-1" }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Home", {
+      screen: "ServiceDetail",
+      params: { id: "svc-1" },
+    });
+  });
+
+  it("routes service_reminder to ServiceDetail", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "service_reminder", related_service: "svc-2" }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Home", {
+      screen: "ServiceDetail",
+      params: { id: "svc-2" },
+    });
+  });
+
+  it("does not navigate for admin_warning", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "admin_warning" }),
+      { navigate },
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate for dispute_resolved", () => {
+    navigateToNotificationTarget(
+      makeNotification({ type: "dispute_resolved" }),
+      { navigate },
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("prefers handshake route over service route for handshake types", () => {
+    navigateToNotificationTarget(
+      makeNotification({
+        type: "handshake_accepted",
+        related_handshake: "hs-3",
+        related_service: "svc-5",
+      }),
+      { navigate },
+    );
+    expect(navigate).toHaveBeenCalledWith("Messages", {
+      screen: "Chat",
+      params: { handshakeId: "hs-3" },
+    });
+  });
+});
+
+describe("NOTIFICATION_ICONS", () => {
+  it("has an icon for every notification type", () => {
+    const expectedTypes = [
+      "handshake_request",
+      "handshake_accepted",
+      "handshake_denied",
+      "handshake_cancellation_requested",
+      "handshake_cancellation_rejected",
+      "handshake_cancelled",
+      "service_updated",
+      "chat_message",
+      "service_reminder",
+      "service_confirmation",
+      "positive_rep",
+      "admin_warning",
+      "dispute_resolved",
+    ];
+    for (const type of expectedTypes) {
+      expect(NOTIFICATION_ICONS[type as keyof typeof NOTIFICATION_ICONS]).toBeDefined();
+    }
+  });
+
+  it("maps positive_rep to star-outline", () => {
+    expect(NOTIFICATION_ICONS.positive_rep).toBe("star-outline");
+  });
+});

--- a/mobile-client/src/constants/notificationMappings.ts
+++ b/mobile-client/src/constants/notificationMappings.ts
@@ -53,7 +53,16 @@ export function navigateToNotificationTarget(
     return;
   }
 
-  // Reputation → Profile tab
+  // Reputation with a linked service → ServiceDetail (e.g. "Leave Feedback" for events)
+  if (type === 'positive_rep' && related_service) {
+    navigation.navigate('Home', {
+      screen: 'ServiceDetail',
+      params: { id: related_service },
+    });
+    return;
+  }
+
+  // Reputation without a service link → Profile tab
   if (type === 'positive_rep') {
     navigation.navigate('Profile');
     return;

--- a/mobile-client/src/presentation/components/chat/ChatEvaluationModal.tsx
+++ b/mobile-client/src/presentation/components/chat/ChatEvaluationModal.tsx
@@ -9,13 +9,18 @@ import {
   StyleSheet,
   ActivityIndicator,
   Alert,
+  Image,
 } from "react-native";
+import * as ImagePicker from "expo-image-picker";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { colors } from "../../../constants/colors";
 import {
   submitCombinedEvaluation,
   submitCombinedEventEvaluation,
+  attachReviewImages,
 } from "../../../api/reputation";
+
+const MAX_IMAGES = 3;
 
 type TraitOption = {
   key: string;
@@ -63,6 +68,7 @@ export function ChatEvaluationModal({
 }: Props) {
   const [selected, setSelected] = useState<Record<string, boolean>>({});
   const [comment, setComment] = useState("");
+  const [imageUris, setImageUris] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
   const traitSet = isEventEvaluation ? EVENT_TRAITS : SERVICE_TRAITS;
@@ -78,6 +84,26 @@ export function ChatEvaluationModal({
   const reset = () => {
     setSelected({});
     setComment("");
+    setImageUris([]);
+  };
+
+  const pickImages = async () => {
+    if (imageUris.length >= MAX_IMAGES) return;
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsMultipleSelection: true,
+      selectionLimit: MAX_IMAGES - imageUris.length,
+      quality: 0.8,
+    });
+    if (!result.canceled) {
+      setImageUris((prev) =>
+        [...prev, ...result.assets.map((a) => a.uri)].slice(0, MAX_IMAGES),
+      );
+    }
+  };
+
+  const removeImage = (index: number) => {
+    setImageUris((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleClose = () => {
@@ -129,6 +155,14 @@ export function ChatEvaluationModal({
           },
           comment,
         });
+      }
+
+      if (imageUris.length > 0) {
+        try {
+          await attachReviewImages(handshakeId, imageUris);
+        } catch {
+          // Images are best-effort; trait submission already succeeded
+        }
       }
 
       Alert.alert("Evaluation submitted", "Thank you for your feedback.");
@@ -242,6 +276,28 @@ export function ChatEvaluationModal({
                 textAlignVertical="top"
                 maxLength={400}
               />
+
+              <View style={styles.imageSection}>
+                <View style={styles.imageRow}>
+                  {imageUris.map((uri, idx) => (
+                    <View key={uri} style={styles.imageThumbWrap}>
+                      <Image source={{ uri }} style={styles.imageThumb} />
+                      <Pressable
+                        style={styles.imageRemoveBtn}
+                        onPress={() => removeImage(idx)}
+                      >
+                        <Ionicons name="close" size={12} color={colors.WHITE} />
+                      </Pressable>
+                    </View>
+                  ))}
+                  {imageUris.length < MAX_IMAGES && (
+                    <Pressable style={styles.imageAddBtn} onPress={pickImages}>
+                      <Ionicons name="camera-outline" size={20} color={colors.GRAY500} />
+                      <Text style={styles.imageAddLabel}>Photo</Text>
+                    </Pressable>
+                  )}
+                </View>
+              </View>
             </ScrollView>
           )}
 
@@ -379,6 +435,52 @@ const styles = StyleSheet.create({
     backgroundColor: colors.GRAY50,
     fontSize: 14,
     color: colors.GRAY900,
+  },
+  imageSection: {
+    marginTop: 12,
+  },
+  imageRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  imageThumbWrap: {
+    width: 64,
+    height: 64,
+    borderRadius: 10,
+    overflow: "hidden",
+  },
+  imageThumb: {
+    width: "100%",
+    height: "100%",
+  },
+  imageRemoveBtn: {
+    position: "absolute",
+    top: 3,
+    right: 3,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: "rgba(0,0,0,0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  imageAddBtn: {
+    width: 64,
+    height: 64,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.GRAY200,
+    borderStyle: "dashed",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.GRAY50,
+  },
+  imageAddLabel: {
+    fontSize: 10,
+    color: colors.GRAY500,
+    fontWeight: "600",
+    marginTop: 2,
   },
   footer: {
     flexDirection: "row",

--- a/mobile-client/src/presentation/components/service/EventEvaluationSummaryCard.tsx
+++ b/mobile-client/src/presentation/components/service/EventEvaluationSummaryCard.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { colors } from "../../../constants/colors";
+import type { EventEvaluationSummary } from "../../../api/types";
+
+type TraitRow = {
+  key: keyof EventEvaluationSummary;
+  label: string;
+  positive: boolean;
+};
+
+const TRAIT_ROWS: TraitRow[] = [
+  { key: "well_organized_average", label: "Well Organized", positive: true },
+  { key: "engaging_average", label: "Engaging", positive: true },
+  { key: "welcoming_average", label: "Welcoming", positive: true },
+  { key: "disorganized_average", label: "Disorganized", positive: false },
+  { key: "boring_average", label: "Boring", positive: false },
+  { key: "unwelcoming_average", label: "Unwelcoming", positive: false },
+];
+
+type Props = {
+  summary: EventEvaluationSummary;
+};
+
+export function EventEvaluationSummaryCard({ summary }: Props) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Ionicons name="star" size={16} color={colors.AMBER} />
+        <Text style={styles.title}>Event Ratings</Text>
+        <Text style={styles.countLabel}>
+          {summary.feedback_submission_count} review
+          {summary.feedback_submission_count !== 1 ? "s" : ""}
+        </Text>
+      </View>
+
+      <View style={styles.statsRow}>
+        <View style={styles.statItem}>
+          <Text style={styles.statValue}>{summary.total_attended}</Text>
+          <Text style={styles.statLabel}>Attended</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statItem}>
+          <Text style={[styles.statValue, { color: colors.GREEN }]}>
+            {summary.positive_feedback_count}
+          </Text>
+          <Text style={styles.statLabel}>Positive</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statItem}>
+          <Text style={[styles.statValue, { color: colors.RED }]}>
+            {summary.negative_feedback_count}
+          </Text>
+          <Text style={styles.statLabel}>Negative</Text>
+        </View>
+      </View>
+
+      {TRAIT_ROWS.map((row) => {
+        const avg = (summary[row.key] as number) ?? 0;
+        const pct = Math.round(avg * 100);
+        const barColor = row.positive ? colors.GREEN : colors.RED;
+
+        return (
+          <View key={row.key} style={styles.traitRow}>
+            <Text style={styles.traitLabel}>{row.label}</Text>
+            <View style={styles.barTrack}>
+              <View
+                style={[
+                  styles.barFill,
+                  { width: `${pct}%`, backgroundColor: barColor },
+                ]}
+              />
+            </View>
+            <Text style={[styles.traitPct, { color: barColor }]}>{pct}%</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.WHITE,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: colors.GRAY200,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: colors.GRAY900,
+    flex: 1,
+  },
+  countLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: colors.GRAY500,
+  },
+  statsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-around",
+    backgroundColor: colors.GRAY50,
+    borderRadius: 12,
+    paddingVertical: 10,
+    marginBottom: 14,
+  },
+  statItem: {
+    alignItems: "center",
+    flex: 1,
+  },
+  statValue: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: colors.GRAY900,
+  },
+  statLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: colors.GRAY500,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    height: 24,
+    backgroundColor: colors.GRAY200,
+  },
+  traitRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  traitLabel: {
+    width: 100,
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.GRAY700,
+  },
+  barTrack: {
+    flex: 1,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.GRAY100,
+    marginHorizontal: 8,
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 4,
+  },
+  traitPct: {
+    width: 36,
+    fontSize: 12,
+    fontWeight: "700",
+    textAlign: "right",
+  },
+});

--- a/mobile-client/src/presentation/screens/MessagesScreen.tsx
+++ b/mobile-client/src/presentation/screens/MessagesScreen.tsx
@@ -110,7 +110,7 @@ type GroupChatListEntry = {
   previewAt: string | null;
 };
 
-type ChatTab = "private" | "group";
+type ChatTab = "private" | "group" | "events";
 
 function isServiceOwner(chat: Chat): boolean {
   const type = chat.service_type?.toLowerCase();
@@ -183,10 +183,16 @@ function timeAgo(dateStr: string): string {
   });
 }
 
+type EventChatEntry = {
+  serviceId: string;
+  serviceTitle: string;
+};
+
 type ListItem =
   | { kind: "sectionHeader"; label: string; count: number; id: string }
   | { kind: "closedToggle"; count: number; expanded: boolean }
   | { kind: "groupChat"; data: GroupChatListEntry }
+  | { kind: "eventChat"; data: EventChatEntry }
   | { kind: "chat"; data: Chat };
 
 export default function MessagesScreen() {
@@ -266,6 +272,13 @@ export default function MessagesScreen() {
     });
   };
 
+  const openEventChat = (entry: EventChatEntry) => {
+    navigation.navigate("PublicChat", {
+      roomId: entry.serviceId,
+      roomTitle: entry.serviceTitle,
+    });
+  };
+
   const goToLogin = () => {
     const tabNav = navigation.getParent() as
       | import("@react-navigation/native").NavigationProp<BottomTabParamList>
@@ -302,6 +315,20 @@ export default function MessagesScreen() {
   const activeGroupEntries = buildGroupChatEntries(activeGroupSourceChats);
   const closedGroupEntries = buildGroupChatEntries(closedGroupSourceChats);
 
+  const eventChatEntries: EventChatEntry[] = (() => {
+    const seen = new Set<string>();
+    const entries: EventChatEntry[] = [];
+    for (const c of chatList) {
+      if (c.service_type?.toLowerCase() !== "event" || !c.service_id) continue;
+      const st = c.status?.toLowerCase();
+      if (!["accepted", "checked_in", "attended"].includes(st)) continue;
+      if (seen.has(c.service_id)) continue;
+      seen.add(c.service_id);
+      entries.push({ serviceId: c.service_id, serviceTitle: c.service_title ?? "Event" });
+    }
+    return entries;
+  })();
+
   const listData: ListItem[] = [];
   if (selectedTab === "private") {
     if (activePrivateChats.length > 0) {
@@ -336,6 +363,18 @@ export default function MessagesScreen() {
         for (const c of closedPrivateChats) {
           listData.push({ kind: "chat", data: c });
         }
+      }
+    }
+  } else if (selectedTab === "events") {
+    if (eventChatEntries.length > 0) {
+      listData.push({
+        kind: "sectionHeader",
+        id: "header-events",
+        label: "JOINED EVENTS",
+        count: eventChatEntries.length,
+      });
+      for (const e of eventChatEntries) {
+        listData.push({ kind: "eventChat", data: e });
       }
     }
   } else {
@@ -485,6 +524,33 @@ export default function MessagesScreen() {
     </TouchableOpacity>
   );
 
+  const renderEventRow = (entry: EventChatEntry) => (
+    <TouchableOpacity
+      style={styles.groupChatItem}
+      onPress={() => openEventChat(entry)}
+      activeOpacity={0.75}
+    >
+      <View style={[styles.groupChatIconWrap, { backgroundColor: "#FFF7ED" }]}>
+        <Ionicons name="calendar" size={22} color={colors.AMBER} />
+      </View>
+      <View style={styles.chatContent}>
+        <View style={styles.chatHeaderRow}>
+          <Text style={styles.groupChatTitle} numberOfLines={1}>
+            {entry.serviceTitle}
+          </Text>
+          <View style={styles.rightMeta}>
+            <View style={[styles.groupBadge, { backgroundColor: "#FFF7ED" }]}>
+              <Text style={[styles.groupBadgeText, { color: colors.AMBER }]}>EVENT</Text>
+            </View>
+          </View>
+        </View>
+        <Text style={styles.groupChatSub} numberOfLines={1}>
+          Tap to open event chat
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+
   const renderItem = ({ item }: { item: ListItem }) => {
     if (item.kind === "sectionHeader") {
       return (
@@ -522,6 +588,9 @@ export default function MessagesScreen() {
     if (item.kind === "groupChat") {
       return renderGroupRow(item.data);
     }
+    if (item.kind === "eventChat") {
+      return renderEventRow(item.data);
+    }
     return renderChatRow(item.data);
   };
 
@@ -529,6 +598,7 @@ export default function MessagesScreen() {
     if (item.kind === "sectionHeader") return item.id;
     if (item.kind === "closedToggle") return "closed-toggle";
     if (item.kind === "groupChat") return `group-${item.data.serviceId}`;
+    if (item.kind === "eventChat") return `event-${item.data.serviceId}`;
     return item.data.handshake_id;
   };
 
@@ -610,6 +680,29 @@ export default function MessagesScreen() {
                   ]}
                 />
               </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.tabButton,
+                  selectedTab === "events" && styles.tabButtonActive,
+                ]}
+                onPress={() => setSelectedTab("events")}
+                activeOpacity={0.8}
+              >
+                <Text
+                  style={[
+                    styles.tabButtonText,
+                    selectedTab === "events" && styles.tabButtonTextActive,
+                  ]}
+                >
+                  Events · {eventChatEntries.length}
+                </Text>
+                <View
+                  style={[
+                    styles.tabUnderline,
+                    selectedTab === "events" && styles.tabUnderlineActive,
+                  ]}
+                />
+              </TouchableOpacity>
             </View>
 
             <FlatList
@@ -636,14 +729,18 @@ export default function MessagesScreen() {
               ListEmptyComponent={
                 <View style={styles.centerState}>
                   <Text style={styles.stateTitle}>
-                    {selectedTab === "group"
-                      ? "No group conversations yet"
-                      : "No private conversations yet"}
+                    {selectedTab === "events"
+                      ? "No event chats yet"
+                      : selectedTab === "group"
+                        ? "No group conversations yet"
+                        : "No private conversations yet"}
                   </Text>
                   <Text style={styles.subheader}>
-                    {selectedTab === "group"
-                      ? "Accepted multi-member services will appear here as group chats."
-                      : "Express interest in a service to start chatting."}
+                    {selectedTab === "events"
+                      ? "Join an event to access its chat."
+                      : selectedTab === "group"
+                        ? "Accepted multi-member services will appear here as group chats."
+                        : "Express interest in a service to start chatting."}
                   </Text>
                 </View>
               }

--- a/mobile-client/src/presentation/screens/PublicChatScreen.tsx
+++ b/mobile-client/src/presentation/screens/PublicChatScreen.tsx
@@ -29,36 +29,49 @@ type NavProps = NativeStackScreenProps<
 
 export default function PublicChatScreen() {
   const { params } = useRoute<NavProps["route"]>();
-  const { roomId, roomTitle = "Event chat" } = params ?? { roomId: "" };
+  const { roomId: serviceId, roomTitle = "Event chat" } = params ?? { roomId: "" };
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState("");
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [wsRoomId, setWsRoomId] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const listRef = useRef<FlatList>(null);
 
   useEffect(() => {
-    if (!roomId) return;
+    if (!serviceId) return;
     (async () => {
       try {
-        const data = await getPublicChat(roomId);
-        const list = Array.isArray(data) ? data : (data as { messages: unknown[] }).messages ?? [];
-        setMessages(
-          (list as Record<string, unknown>[]).map((m) => normalizeMessage(m))
-        );
+        const data = await getPublicChat(serviceId);
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          const obj = data as Record<string, unknown>;
+          if (obj.room && typeof obj.room === "object") {
+            const room = obj.room as Record<string, unknown>;
+            if (typeof room.id === "string") setWsRoomId(room.id);
+          }
+          const msgs = obj.messages;
+          if (msgs && typeof msgs === "object") {
+            const results = Array.isArray(msgs) ? msgs : (msgs as Record<string, unknown>).results;
+            if (Array.isArray(results)) {
+              setMessages(results.map((m: Record<string, unknown>) => normalizeMessage(m)));
+            }
+          }
+        } else if (Array.isArray(data)) {
+          setMessages(data.map((m: Record<string, unknown>) => normalizeMessage(m as Record<string, unknown>)));
+        }
       } catch {
-        // proceed without initial messages
+        setError("Could not load chat history");
       } finally {
         setLoading(false);
       }
     })();
-  }, [roomId]);
+  }, [serviceId]);
 
   useEffect(() => {
-    if (!roomId) return;
-    const url = withAuthToken(buildEventChatWsUrl(roomId));
+    if (!wsRoomId) return;
+    const url = withAuthToken(buildEventChatWsUrl(wsRoomId));
     const ws = new WebSocket(url);
     wsRef.current = ws;
 
@@ -102,12 +115,12 @@ export default function PublicChatScreen() {
       ws.close();
       wsRef.current = null;
     };
-  }, [roomId]);
+  }, [wsRoomId]);
 
   const sendMessage = useCallback(() => {
     const text = inputText.trim();
     if (!text || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
-    wsRef.current.send(JSON.stringify({ type: "message", content: text }));
+    wsRef.current.send(JSON.stringify({ type: "chat_message", body: text }));
     setInputText("");
   }, [inputText]);
 

--- a/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
+++ b/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -29,11 +29,15 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { HomeStackParamList } from "../../navigation/HomeStack";
 import type { BottomTabParamList } from "../../navigation/BottomTabNavigator";
 import { getService, addServiceInterest } from "../../api/services";
+import { listHandshakes, type Handshake } from "../../api/handshakes";
 import type { Service } from "../../api/types";
+import { useAuth } from "../../context/AuthContext";
 import { formatTimeAgo } from "../../utils/formatTimeAgo";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { colors } from "../../constants/colors";
 import ImagePreviewModal from "../components/ImagePreviewModal";
+import { ChatEvaluationModal } from "../components/chat/ChatEvaluationModal";
+import { EventEvaluationSummaryCard } from "../components/service/EventEvaluationSummaryCard";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 const SLIDER_WIDTH = SCREEN_WIDTH;
@@ -65,10 +69,18 @@ type ServiceDetailNavigation = CompositeNavigationProp<
   BottomTabNavigationProp<BottomTabParamList>
 >;
 
+function getIdFromField(value: string | object | undefined): string | undefined {
+  if (!value) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && "id" in value) return String((value as { id: unknown }).id);
+  return undefined;
+}
+
 export default function ServiceDetailScreen() {
   const insets = useSafeAreaInsets();
   const route = useRoute<RouteProp<HomeStackParamList, "ServiceDetail">>();
   const navigation = useNavigation<ServiceDetailNavigation>();
+  const { user: currentUser } = useAuth();
 
   const styles = useMemo(
     () => getStyles(insets.top, insets.bottom),
@@ -85,14 +97,45 @@ export default function ServiceDetailScreen() {
   const [imageModalVisible, setImageModalVisible] = useState(false);
   const [modalInitialIndex, setModalInitialIndex] = useState(0);
 
+  const [myEventHandshake, setMyEventHandshake] = useState<Handshake | null>(null);
+  const [showEvaluationModal, setShowEvaluationModal] = useState(false);
+
   const sliderRef = useRef<FlatList<MediaItem>>(null);
 
-  useEffect(() => {
-    getService(id)
+  const loadService = useCallback(() => {
+    return getService(id)
       .then(setService)
-      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
-      .finally(() => setLoading(false));
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"));
   }, [id]);
+
+  useEffect(() => {
+    loadService().finally(() => setLoading(false));
+  }, [loadService]);
+
+  useEffect(() => {
+    if (!service || service.type !== "Event" || !currentUser?.id) return;
+    listHandshakes()
+      .then((res) => {
+        const match = res.results.find((h) => {
+          const serviceId = getIdFromField(h.service);
+          const requesterId = getIdFromField(h.requester);
+          return (
+            serviceId === service.id &&
+            requesterId === currentUser.id &&
+            ["accepted", "checked_in", "attended", "no_show", "reported"].includes(h.status)
+          );
+        });
+        setMyEventHandshake(match ?? null);
+      })
+      .catch(() => {});
+  }, [service, currentUser?.id]);
+
+  const handleEvaluationSubmitted = useCallback(async () => {
+    await loadService();
+    if (myEventHandshake) {
+      setMyEventHandshake((prev) => prev ? { ...prev, user_has_reviewed: true } : null);
+    }
+  }, [loadService, myEventHandshake]);
 
   const handleExpressInterest = () => {
     setInterestLoading(true);
@@ -474,6 +517,35 @@ export default function ServiceDetailScreen() {
             </View>
           )}
 
+          {isEvent && myEventHandshake?.status === "attended" && (
+            <View style={styles.sectionBlock}>
+              <View style={styles.attendedBanner}>
+                <Ionicons name="checkmark-circle" size={20} color={colors.GREEN} />
+                <View style={{ flex: 1, marginLeft: 10 }}>
+                  <Text style={styles.attendedTitle}>Attendance confirmed!</Text>
+                  <Text style={styles.attendedSubtitle}>The organizer marked you as attended.</Text>
+                </View>
+              </View>
+              {!myEventHandshake.user_has_reviewed && (
+                <TouchableOpacity
+                  style={styles.evaluationButton}
+                  onPress={() => setShowEvaluationModal(true)}
+                  activeOpacity={0.85}
+                >
+                  <Ionicons name="star-outline" size={16} color={colors.WHITE} />
+                  <Text style={styles.evaluationButtonText}>Leave Evaluation</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          )}
+
+          {isEvent && service.event_evaluation_summary &&
+            service.event_evaluation_summary.feedback_submission_count > 0 && (
+              <View style={styles.sectionBlock}>
+                <EventEvaluationSummaryCard summary={service.event_evaluation_summary} />
+              </View>
+          )}
+
           <TouchableOpacity
             style={[styles.ctaButton, interestLoading && styles.ctaDisabled]}
             onPress={handleExpressInterest}
@@ -498,6 +570,17 @@ export default function ServiceDetailScreen() {
         initialIndex={modalInitialIndex}
         onClose={() => setImageModalVisible(false)}
       />
+
+      {isEvent && myEventHandshake?.status === "attended" && !myEventHandshake.user_has_reviewed && (
+        <ChatEvaluationModal
+          visible={showEvaluationModal}
+          handshakeId={myEventHandshake.id}
+          counterpartName={service.title}
+          isEventEvaluation
+          onClose={() => setShowEvaluationModal(false)}
+          onSubmitted={handleEvaluationSubmitted}
+        />
+      )}
     </ScrollView>
   );
 }
@@ -906,6 +989,45 @@ const getStyles = (topInset: number, bottomInset: number) =>
       fontSize: 13,
       color: "#475467",
       fontWeight: "600",
+    },
+
+    attendedBanner: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: "#f0fdf4",
+      borderRadius: 14,
+      padding: 14,
+      borderWidth: 1,
+      borderColor: "rgba(34,197,94,0.25)",
+    },
+
+    attendedTitle: {
+      fontSize: 13,
+      fontWeight: "700",
+      color: colors.GREEN,
+    },
+
+    attendedSubtitle: {
+      fontSize: 12,
+      color: "#166534",
+      marginTop: 2,
+    },
+
+    evaluationButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 7,
+      minHeight: 44,
+      borderRadius: 10,
+      backgroundColor: colors.AMBER,
+      marginTop: 10,
+    },
+
+    evaluationButtonText: {
+      fontSize: 14,
+      fontWeight: "700",
+      color: colors.WHITE,
     },
 
     ctaButton: {

--- a/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
+++ b/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
@@ -28,8 +28,23 @@ import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { HomeStackParamList } from "../../navigation/HomeStack";
 import type { BottomTabParamList } from "../../navigation/BottomTabNavigator";
-import { getService, addServiceInterest } from "../../api/services";
-import { listHandshakes, type Handshake } from "../../api/handshakes";
+import { getService, addServiceInterest, completeEvent } from "../../api/services";
+import {
+  listHandshakes,
+  joinEvent,
+  leaveEvent,
+  checkinEvent,
+  markAttended,
+  type Handshake,
+} from "../../api/handshakes";
+import {
+  isFutureEvent,
+  isPastEvent,
+  isWithinLockdownWindow,
+  isEventFull,
+  spotsLeft,
+  isEventBanned,
+} from "../../utils/eventUtils";
 import type { Service } from "../../api/types";
 import { useAuth } from "../../context/AuthContext";
 import { formatTimeAgo } from "../../utils/formatTimeAgo";
@@ -98,7 +113,10 @@ export default function ServiceDetailScreen() {
   const [modalInitialIndex, setModalInitialIndex] = useState(0);
 
   const [myEventHandshake, setMyEventHandshake] = useState<Handshake | null>(null);
+  const [allEventHandshakes, setAllEventHandshakes] = useState<Handshake[]>([]);
   const [showEvaluationModal, setShowEvaluationModal] = useState(false);
+  const [eventActionLoading, setEventActionLoading] = useState(false);
+  const [markingAttendedId, setMarkingAttendedId] = useState<string | null>(null);
 
   const sliderRef = useRef<FlatList<MediaItem>>(null);
 
@@ -108,49 +126,149 @@ export default function ServiceDetailScreen() {
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"));
   }, [id]);
 
+  const loadHandshakes = useCallback(() => {
+    if (!service || service.type !== "Event") return;
+    listHandshakes()
+      .then((res) => {
+        const eventHandshakes = res.results.filter((h) => {
+          const svcId = getIdFromField(h.service);
+          return svcId === service.id;
+        });
+        setAllEventHandshakes(eventHandshakes);
+
+        if (currentUser?.id) {
+          const mine = eventHandshakes.find((h) => {
+            const requesterId = getIdFromField(h.requester);
+            return (
+              requesterId === currentUser.id &&
+              ["accepted", "checked_in", "attended", "no_show", "reported", "cancelled"].includes(h.status)
+            );
+          });
+          setMyEventHandshake(mine ?? null);
+        }
+      })
+      .catch(() => {});
+  }, [service, currentUser?.id]);
+
   useEffect(() => {
     loadService().finally(() => setLoading(false));
   }, [loadService]);
 
   useEffect(() => {
-    if (!service || service.type !== "Event" || !currentUser?.id) return;
-    listHandshakes()
-      .then((res) => {
-        const match = res.results.find((h) => {
-          const serviceId = getIdFromField(h.service);
-          const requesterId = getIdFromField(h.requester);
-          return (
-            serviceId === service.id &&
-            requesterId === currentUser.id &&
-            ["accepted", "checked_in", "attended", "no_show", "reported"].includes(h.status)
-          );
-        });
-        setMyEventHandshake(match ?? null);
-      })
-      .catch(() => {});
-  }, [service, currentUser?.id]);
+    loadHandshakes();
+  }, [loadHandshakes]);
+
+  const isOwner = service?.user?.id === currentUser?.id;
 
   const handleEvaluationSubmitted = useCallback(async () => {
     await loadService();
-    if (myEventHandshake) {
-      setMyEventHandshake((prev) => prev ? { ...prev, user_has_reviewed: true } : null);
-    }
-  }, [loadService, myEventHandshake]);
+    setMyEventHandshake((prev) => prev ? { ...prev, user_has_reviewed: true } : null);
+  }, [loadService]);
 
   const handleExpressInterest = () => {
     setInterestLoading(true);
-
     addServiceInterest(id)
-      .then(() => {
-        Alert.alert("Success", "Your interest has been sent to the provider.");
-      })
-      .catch((e) => {
-        Alert.alert(
-          "Error",
-          e instanceof Error ? e.message : "Could not send interest.",
-        );
-      })
+      .then(() => Alert.alert("Success", "Your interest has been sent to the provider."))
+      .catch((e) => Alert.alert("Error", e instanceof Error ? e.message : "Could not send interest."))
       .finally(() => setInterestLoading(false));
+  };
+
+  const handleJoinEvent = async () => {
+    if (!service) return;
+    setEventActionLoading(true);
+    try {
+      await joinEvent(service.id);
+      Alert.alert("Joined!", "You've joined the event.");
+      await loadService();
+      loadHandshakes();
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Could not join event.");
+    } finally {
+      setEventActionLoading(false);
+    }
+  };
+
+  const handleLeaveEvent = async () => {
+    if (!myEventHandshake) return;
+    Alert.alert("Leave Event", "Are you sure you want to leave this event?", [
+      { text: "Stay", style: "cancel" },
+      {
+        text: "Leave",
+        style: "destructive",
+        onPress: async () => {
+          setEventActionLoading(true);
+          try {
+            await leaveEvent(myEventHandshake.id);
+            Alert.alert("Left", "You have left the event.");
+            setMyEventHandshake(null);
+            await loadService();
+            loadHandshakes();
+          } catch (e) {
+            Alert.alert("Error", e instanceof Error ? e.message : "Could not leave event.");
+          } finally {
+            setEventActionLoading(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleCheckin = async () => {
+    if (!myEventHandshake) return;
+    setEventActionLoading(true);
+    try {
+      await checkinEvent(myEventHandshake.id);
+      Alert.alert("Checked in!", "See you there.");
+      loadHandshakes();
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Could not check in.");
+    } finally {
+      setEventActionLoading(false);
+    }
+  };
+
+  const handleMarkAttended = async (handshakeId: string) => {
+    setMarkingAttendedId(handshakeId);
+    try {
+      await markAttended(handshakeId);
+      Alert.alert("Done", "Attendance marked.");
+      loadHandshakes();
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Could not mark attendance.");
+    } finally {
+      setMarkingAttendedId(null);
+    }
+  };
+
+  const handleCompleteEvent = async () => {
+    if (!service) return;
+    Alert.alert("Complete Event", "Mark this event as completed?", [
+      { text: "Not yet", style: "cancel" },
+      {
+        text: "Complete",
+        onPress: async () => {
+          setEventActionLoading(true);
+          try {
+            await completeEvent(service.id);
+            Alert.alert("Done", "Event marked complete!");
+            await loadService();
+            loadHandshakes();
+          } catch (e) {
+            Alert.alert("Error", e instanceof Error ? e.message : "Could not complete event.");
+          } finally {
+            setEventActionLoading(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  const openEventChat = () => {
+    if (!service) return;
+    navigation.navigate("Messages", {
+      screen: "PublicChat",
+      params: { roomId: service.id, roomTitle: service.title },
+    } as any);
   };
 
   const onSliderMomentumEnd = (
@@ -517,28 +635,6 @@ export default function ServiceDetailScreen() {
             </View>
           )}
 
-          {isEvent && myEventHandshake?.status === "attended" && (
-            <View style={styles.sectionBlock}>
-              <View style={styles.attendedBanner}>
-                <Ionicons name="checkmark-circle" size={20} color={colors.GREEN} />
-                <View style={{ flex: 1, marginLeft: 10 }}>
-                  <Text style={styles.attendedTitle}>Attendance confirmed!</Text>
-                  <Text style={styles.attendedSubtitle}>The organizer marked you as attended.</Text>
-                </View>
-              </View>
-              {!myEventHandshake.user_has_reviewed && (
-                <TouchableOpacity
-                  style={styles.evaluationButton}
-                  onPress={() => setShowEvaluationModal(true)}
-                  activeOpacity={0.85}
-                >
-                  <Ionicons name="star-outline" size={16} color={colors.WHITE} />
-                  <Text style={styles.evaluationButtonText}>Leave Evaluation</Text>
-                </TouchableOpacity>
-              )}
-            </View>
-          )}
-
           {isEvent && service.event_evaluation_summary &&
             service.event_evaluation_summary.feedback_submission_count > 0 && (
               <View style={styles.sectionBlock}>
@@ -546,21 +642,233 @@ export default function ServiceDetailScreen() {
               </View>
           )}
 
-          <TouchableOpacity
-            style={[styles.ctaButton, interestLoading && styles.ctaDisabled]}
-            onPress={handleExpressInterest}
-            disabled={interestLoading}
-            activeOpacity={0.9}
-          >
-            {interestLoading ? (
-              <ActivityIndicator color="#fff" size="small" />
-            ) : (
-              <>
-                <Ionicons name="heart-outline" size={18} color="#fff" />
-                <Text style={styles.ctaText}>Express interest</Text>
-              </>
-            )}
-          </TouchableOpacity>
+          {/* ─── Event lifecycle CTA ─── */}
+          {isEvent && !isOwner && (() => {
+            const status = myEventHandshake?.status;
+            const banned = isEventBanned(currentUser?.is_organizer_banned_until);
+            const full = isEventFull(service.max_participants, service.participant_count ?? 0);
+            const future = isFutureEvent(service.scheduled_time);
+            const past = isPastEvent(service.scheduled_time);
+            const lockdown = isWithinLockdownWindow(service.scheduled_time);
+
+            if (status === "reported") return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.warningBanner}>
+                  <Ionicons name="alert-circle" size={20} color={colors.AMBER} />
+                  <Text style={[styles.bannerText, { color: colors.AMBER }]}>Participation under review</Text>
+                </View>
+              </View>
+            );
+
+            if (status === "cancelled") return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.dangerBanner}>
+                  <Ionicons name="close-circle" size={20} color={colors.RED} />
+                  <Text style={[styles.bannerText, { color: colors.RED }]}>Removed from event</Text>
+                </View>
+              </View>
+            );
+
+            if (status === "attended") return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.attendedBanner}>
+                  <Ionicons name="checkmark-circle" size={20} color={colors.GREEN} />
+                  <View style={{ flex: 1, marginLeft: 10 }}>
+                    <Text style={styles.attendedTitle}>Attendance confirmed!</Text>
+                    <Text style={styles.attendedSubtitle}>The organizer marked you as attended.</Text>
+                  </View>
+                </View>
+                {!myEventHandshake?.user_has_reviewed && (
+                  <TouchableOpacity style={styles.evaluationButton} onPress={() => setShowEvaluationModal(true)} activeOpacity={0.85}>
+                    <Ionicons name="star-outline" size={16} color={colors.WHITE} />
+                    <Text style={styles.evaluationButtonText}>Leave Evaluation</Text>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity style={styles.eventChatButton} onPress={openEventChat} activeOpacity={0.85}>
+                  <Ionicons name="chatbubbles-outline" size={16} color={colors.WHITE} />
+                  <Text style={styles.eventChatButtonText}>Event Chat</Text>
+                </TouchableOpacity>
+              </View>
+            );
+
+            if (status === "checked_in") return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.attendedBanner}>
+                  <Ionicons name="checkmark-done" size={20} color={colors.GREEN} />
+                  <Text style={[styles.bannerText, { color: colors.GREEN, marginLeft: 10 }]}>Checked in</Text>
+                </View>
+                <TouchableOpacity style={styles.eventChatButton} onPress={openEventChat} activeOpacity={0.85}>
+                  <Ionicons name="chatbubbles-outline" size={16} color={colors.WHITE} />
+                  <Text style={styles.eventChatButtonText}>Event Chat</Text>
+                </TouchableOpacity>
+              </View>
+            );
+
+            if (status === "accepted" && future) return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.attendedBanner}>
+                  <Ionicons name="calendar-outline" size={20} color={colors.GREEN} />
+                  <Text style={[styles.bannerText, { color: colors.GREEN, marginLeft: 10 }]}>You've joined this event</Text>
+                </View>
+                {lockdown ? (
+                  <TouchableOpacity
+                    style={styles.joinButton}
+                    onPress={handleCheckin}
+                    disabled={eventActionLoading}
+                    activeOpacity={0.85}
+                  >
+                    {eventActionLoading ? <ActivityIndicator color="#fff" size="small" /> : (
+                      <><Ionicons name="log-in-outline" size={16} color={colors.WHITE} /><Text style={styles.joinButtonText}>Check In</Text></>
+                    )}
+                  </TouchableOpacity>
+                ) : (
+                  <TouchableOpacity
+                    style={styles.leaveButton}
+                    onPress={handleLeaveEvent}
+                    disabled={eventActionLoading}
+                    activeOpacity={0.85}
+                  >
+                    <Ionicons name="exit-outline" size={16} color={colors.RED} />
+                    <Text style={styles.leaveButtonText}>Leave Event</Text>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity style={styles.eventChatButton} onPress={openEventChat} activeOpacity={0.85}>
+                  <Ionicons name="chatbubbles-outline" size={16} color={colors.WHITE} />
+                  <Text style={styles.eventChatButtonText}>Event Chat</Text>
+                </TouchableOpacity>
+              </View>
+            );
+
+            if (past && !status) return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.warningBanner}>
+                  <Ionicons name="time-outline" size={20} color={colors.GRAY500} />
+                  <Text style={[styles.bannerText, { color: colors.GRAY500 }]}>Event ended</Text>
+                </View>
+              </View>
+            );
+
+            if (banned) return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.dangerBanner}>
+                  <Ionicons name="ban-outline" size={20} color={colors.RED} />
+                  <Text style={[styles.bannerText, { color: colors.RED }]}>You are temporarily banned from joining events</Text>
+                </View>
+              </View>
+            );
+
+            if (full && !status) return (
+              <View style={styles.sectionBlock}>
+                <View style={styles.warningBanner}>
+                  <Ionicons name="people" size={20} color={colors.AMBER} />
+                  <Text style={[styles.bannerText, { color: colors.AMBER }]}>
+                    Event full ({spotsLeft(service.max_participants, service.participant_count ?? 0)} spots left)
+                  </Text>
+                </View>
+              </View>
+            );
+
+            if (service.status === "Active" && !status) return (
+              <TouchableOpacity
+                style={[styles.joinButton, eventActionLoading && styles.ctaDisabled]}
+                onPress={handleJoinEvent}
+                disabled={eventActionLoading}
+                activeOpacity={0.9}
+              >
+                {eventActionLoading ? <ActivityIndicator color="#fff" size="small" /> : (
+                  <><Ionicons name="add-circle-outline" size={18} color="#fff" /><Text style={styles.joinButtonText}>Join Event</Text></>
+                )}
+              </TouchableOpacity>
+            );
+
+            return null;
+          })()}
+
+          {/* ─── Organizer management ─── */}
+          {isEvent && isOwner && (
+            <View style={styles.sectionBlock}>
+              <Text style={styles.sectionLabel}>Participants</Text>
+              {allEventHandshakes
+                .filter((h) => ["accepted", "checked_in", "attended", "no_show"].includes(h.status))
+                .map((h) => {
+                  const name = (() => {
+                    const r = h.requester;
+                    if (!r || typeof r === "string") return r ?? "Unknown";
+                    const obj = r as Record<string, unknown>;
+                    return [obj.first_name, obj.last_name].filter(Boolean).join(" ") || String(obj.email ?? "Participant");
+                  })();
+                  const badgeColors: Record<string, { bg: string; fg: string }> = {
+                    accepted: { bg: "#dcfce7", fg: "#166534" },
+                    checked_in: { bg: "#d1fae5", fg: "#065f46" },
+                    attended: { bg: "#d1fae5", fg: "#065f46" },
+                    no_show: { bg: "#fee2e2", fg: "#991b1b" },
+                  };
+                  const badge = badgeColors[h.status] ?? { bg: colors.GRAY100, fg: colors.GRAY500 };
+                  return (
+                    <View key={h.id} style={styles.rosterRow}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={styles.rosterName}>{name}</Text>
+                        <View style={[styles.rosterBadge, { backgroundColor: badge.bg }]}>
+                          <Text style={[styles.rosterBadgeText, { color: badge.fg }]}>
+                            {h.status === "checked_in" ? "Checked In" : h.status === "no_show" ? "No-Show" : h.status.charAt(0).toUpperCase() + h.status.slice(1)}
+                          </Text>
+                        </View>
+                      </View>
+                      {h.status === "checked_in" && (
+                        <TouchableOpacity
+                          style={styles.markAttendedBtn}
+                          onPress={() => handleMarkAttended(h.id)}
+                          disabled={markingAttendedId === h.id}
+                          activeOpacity={0.85}
+                        >
+                          {markingAttendedId === h.id
+                            ? <ActivityIndicator size="small" color={colors.WHITE} />
+                            : <Text style={styles.markAttendedText}>Mark Attended</Text>
+                          }
+                        </TouchableOpacity>
+                      )}
+                    </View>
+                  );
+                })}
+
+              {service.status === "Active" && (
+                <TouchableOpacity
+                  style={[styles.completeEventButton, eventActionLoading && styles.ctaDisabled]}
+                  onPress={handleCompleteEvent}
+                  disabled={eventActionLoading}
+                  activeOpacity={0.85}
+                >
+                  {eventActionLoading ? <ActivityIndicator color="#fff" size="small" /> : (
+                    <><Ionicons name="checkmark-done-outline" size={16} color={colors.WHITE} /><Text style={styles.completeEventText}>Complete Event</Text></>
+                  )}
+                </TouchableOpacity>
+              )}
+
+              <TouchableOpacity style={styles.eventChatButton} onPress={openEventChat} activeOpacity={0.85}>
+                <Ionicons name="chatbubbles-outline" size={16} color={colors.WHITE} />
+                <Text style={styles.eventChatButtonText}>Event Chat</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* ─── Non-event: Express Interest ─── */}
+          {!isEvent && (
+            <TouchableOpacity
+              style={[styles.ctaButton, interestLoading && styles.ctaDisabled]}
+              onPress={handleExpressInterest}
+              disabled={interestLoading}
+              activeOpacity={0.9}
+            >
+              {interestLoading ? (
+                <ActivityIndicator color="#fff" size="small" />
+              ) : (
+                <>
+                  <Ionicons name="heart-outline" size={18} color="#fff" />
+                  <Text style={styles.ctaText}>Express interest</Text>
+                </>
+              )}
+            </TouchableOpacity>
+          )}
         </View>
       </View>
 
@@ -1013,6 +1321,34 @@ const getStyles = (topInset: number, bottomInset: number) =>
       marginTop: 2,
     },
 
+    warningBanner: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 10,
+      backgroundColor: colors.AMBER_LT,
+      borderRadius: 14,
+      padding: 14,
+      borderWidth: 1,
+      borderColor: `${colors.AMBER}30`,
+    },
+
+    dangerBanner: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 10,
+      backgroundColor: colors.RED_LT,
+      borderRadius: 14,
+      padding: 14,
+      borderWidth: 1,
+      borderColor: `${colors.RED}30`,
+    },
+
+    bannerText: {
+      fontSize: 14,
+      fontWeight: "700",
+      flex: 1,
+    },
+
     evaluationButton: {
       flexDirection: "row",
       alignItems: "center",
@@ -1025,6 +1361,116 @@ const getStyles = (topInset: number, bottomInset: number) =>
     },
 
     evaluationButtonText: {
+      fontSize: 14,
+      fontWeight: "700",
+      color: colors.WHITE,
+    },
+
+    joinButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      minHeight: 52,
+      borderRadius: 14,
+      backgroundColor: colors.AMBER,
+      marginTop: 10,
+    },
+
+    joinButtonText: {
+      fontSize: 15,
+      fontWeight: "800",
+      color: colors.WHITE,
+    },
+
+    leaveButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 7,
+      minHeight: 44,
+      borderRadius: 10,
+      backgroundColor: colors.RED_LT,
+      borderWidth: 1,
+      borderColor: `${colors.RED}30`,
+      marginTop: 10,
+    },
+
+    leaveButtonText: {
+      fontSize: 14,
+      fontWeight: "700",
+      color: colors.RED,
+    },
+
+    eventChatButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 7,
+      minHeight: 44,
+      borderRadius: 10,
+      backgroundColor: colors.GREEN,
+      marginTop: 10,
+    },
+
+    eventChatButtonText: {
+      fontSize: 14,
+      fontWeight: "700",
+      color: colors.WHITE,
+    },
+
+    rosterRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      paddingVertical: 10,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.GRAY100,
+    },
+
+    rosterName: {
+      fontSize: 14,
+      fontWeight: "600",
+      color: colors.GRAY800,
+    },
+
+    rosterBadge: {
+      alignSelf: "flex-start",
+      paddingHorizontal: 8,
+      paddingVertical: 3,
+      borderRadius: 6,
+      marginTop: 4,
+    },
+
+    rosterBadgeText: {
+      fontSize: 11,
+      fontWeight: "700",
+    },
+
+    markAttendedBtn: {
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      borderRadius: 8,
+      backgroundColor: colors.GREEN,
+    },
+
+    markAttendedText: {
+      fontSize: 12,
+      fontWeight: "700",
+      color: colors.WHITE,
+    },
+
+    completeEventButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 7,
+      minHeight: 48,
+      borderRadius: 12,
+      backgroundColor: colors.BLUE,
+      marginTop: 14,
+    },
+
+    completeEventText: {
       fontSize: 14,
       fontWeight: "700",
       color: colors.WHITE,

--- a/mobile-client/src/utils/__tests__/eventUtils.test.ts
+++ b/mobile-client/src/utils/__tests__/eventUtils.test.ts
@@ -1,0 +1,113 @@
+import {
+  isWithinLockdownWindow,
+  isFutureEvent,
+  isPastEvent,
+  spotsLeft,
+  isEventFull,
+  isEventBanned,
+} from "../eventUtils";
+
+describe("isWithinLockdownWindow", () => {
+  it("returns false for null/undefined", () => {
+    expect(isWithinLockdownWindow(null)).toBe(false);
+    expect(isWithinLockdownWindow(undefined)).toBe(false);
+  });
+
+  it("returns true when within 24h before event", () => {
+    const inTenHours = new Date(Date.now() + 10 * 60 * 60 * 1000).toISOString();
+    expect(isWithinLockdownWindow(inTenHours)).toBe(true);
+  });
+
+  it("returns false when more than 24h before event", () => {
+    const inTwoDays = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
+    expect(isWithinLockdownWindow(inTwoDays)).toBe(false);
+  });
+
+  it("returns false when event has already started", () => {
+    const yesterday = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    expect(isWithinLockdownWindow(yesterday)).toBe(false);
+  });
+});
+
+describe("isFutureEvent", () => {
+  it("returns false for null/undefined", () => {
+    expect(isFutureEvent(null)).toBe(false);
+    expect(isFutureEvent(undefined)).toBe(false);
+  });
+
+  it("returns true for future times", () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    expect(isFutureEvent(tomorrow)).toBe(true);
+  });
+
+  it("returns false for past times", () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    expect(isFutureEvent(yesterday)).toBe(false);
+  });
+});
+
+describe("isPastEvent", () => {
+  it("returns false for null/undefined", () => {
+    expect(isPastEvent(null)).toBe(false);
+    expect(isPastEvent(undefined)).toBe(false);
+  });
+
+  it("returns true for past times", () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    expect(isPastEvent(yesterday)).toBe(true);
+  });
+
+  it("returns false for future times", () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    expect(isPastEvent(tomorrow)).toBe(false);
+  });
+});
+
+describe("spotsLeft", () => {
+  it("returns remaining spots", () => {
+    expect(spotsLeft(10, 7)).toBe(3);
+  });
+
+  it("clamps to 0 when over capacity", () => {
+    expect(spotsLeft(5, 8)).toBe(0);
+  });
+
+  it("returns 0 when exactly full", () => {
+    expect(spotsLeft(5, 5)).toBe(0);
+  });
+});
+
+describe("isEventFull", () => {
+  it("returns true when at capacity", () => {
+    expect(isEventFull(10, 10)).toBe(true);
+  });
+
+  it("returns true when over capacity", () => {
+    expect(isEventFull(10, 12)).toBe(true);
+  });
+
+  it("returns false when under capacity", () => {
+    expect(isEventFull(10, 7)).toBe(false);
+  });
+
+  it("returns false when max is 0 (unlimited)", () => {
+    expect(isEventFull(0, 5)).toBe(false);
+  });
+});
+
+describe("isEventBanned", () => {
+  it("returns false for null/undefined", () => {
+    expect(isEventBanned(null)).toBe(false);
+    expect(isEventBanned(undefined)).toBe(false);
+  });
+
+  it("returns true when ban is in the future", () => {
+    const nextWeek = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isEventBanned(nextWeek)).toBe(true);
+  });
+
+  it("returns false when ban has expired", () => {
+    const lastWeek = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isEventBanned(lastWeek)).toBe(false);
+  });
+});

--- a/mobile-client/src/utils/eventUtils.ts
+++ b/mobile-client/src/utils/eventUtils.ts
@@ -1,0 +1,36 @@
+/** Returns true if now is within 24 hours before the event start (lockdown window). */
+export function isWithinLockdownWindow(scheduledTime: string | null | undefined): boolean {
+  if (!scheduledTime) return false;
+  const eventMs = new Date(scheduledTime).getTime();
+  const nowMs = Date.now();
+  return nowMs >= eventMs - 24 * 60 * 60 * 1000 && nowMs < eventMs;
+}
+
+/** Returns true if the event has not yet started. */
+export function isFutureEvent(scheduledTime: string | null | undefined): boolean {
+  if (!scheduledTime) return false;
+  return new Date(scheduledTime).getTime() > Date.now();
+}
+
+/** Returns true if the event start time has passed. */
+export function isPastEvent(scheduledTime: string | null | undefined): boolean {
+  if (!scheduledTime) return false;
+  return new Date(scheduledTime).getTime() <= Date.now();
+}
+
+/** Spots remaining (clamped to 0). */
+export function spotsLeft(maxParticipants: number, participantCount: number): number {
+  return Math.max(0, maxParticipants - participantCount);
+}
+
+/** Returns true when the event is at or over capacity. */
+export function isEventFull(maxParticipants: number, participantCount: number): boolean {
+  if (maxParticipants <= 0) return false;
+  return participantCount >= maxParticipants;
+}
+
+/** Returns true if the user is currently under an event-participation ban. */
+export function isEventBanned(bannedUntil: string | null | undefined): boolean {
+  if (!bannedUntil) return false;
+  return new Date(bannedUntil).getTime() > Date.now();
+}


### PR DESCRIPTION
## Summary

Brings the mobile client to parity with the web frontend for event evaluations. Attendees can now leave feedback directly from the service detail screen after being marked as attended, instead of only through the chat screen.

## Changes

- Extended `Service` and `Handshake` types with evaluation-related fields the backend already returns
- Added "Leave Evaluation" button and attendance banner to `ServiceDetailScreen` for event attendees
- Created `EventEvaluationSummaryCard` showing aggregated trait ratings on event detail pages
- Fixed notification deep-linking so "Leave Feedback" notifications go to the event page, not Profile
- Added image attachment support (up to 3 photos) to the evaluation modal
- Added unit tests for reputation API functions and notification routing

## How to test

1. **Evaluation from service detail:**
   - Have an organizer mark you as attended on an event
   - Open the event's service detail screen
   - Verify the green "Attendance confirmed!" banner appears
   - Tap "Leave Evaluation", select some traits, optionally add a comment and photos, submit
   - Confirm the success alert and that the button disappears after submitting

2. **Evaluation summary card:**
   - Open an event that already has at least one evaluation submitted
   - Verify the "Event Ratings" card renders with trait progress bars and counts

3. **Notification deep-link:**
   - Trigger a "Leave Feedback" push notification (complete an event)
   - Tap the notification and verify it opens the event's service detail, not the Profile tab

4. **Unit tests:**
   - Run `cd mobile-client && npm test` — all 128 tests should pass

Closes #387.