### PR TITLE
chore: Streamline dev environment setup & add mobile workflow support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # ─── Database (PostGIS) ───────────────────────────────────────────────────────
-# Local dev (docker-compose.infra.yml): DB_HOST=127.0.0.1
-# Full Docker stack (docker-compose.yml):  DB_HOST=db
+# local: DB_HOST=localhost   |   docker: DB_HOST=db
 #
 # PostGIS image — override for Apple Silicon (ARM64):
 # POSTGIS_IMAGE=imresamu/postgis:15-3.4-alpine
@@ -13,20 +12,17 @@ DB_HOST=localhost
 DB_PORT=5432
 
 # ─── Redis ────────────────────────────────────────────────────────────────────
+# local: REDIS_HOST=localhost   |   docker: REDIS_HOST=redis
 REDIS_HOST=localhost
 REDIS_PORT=6379
-# REDIS_DB=0
-# REDIS_URL=redis://localhost:6379/0
 
 # ─── MinIO (S3-compatible object storage) ─────────────────────────────────────
-# Local infra (docker-compose.infra.yml): keep localhost:9000 / localhost:9001
-# Full Docker stacks override MINIO_ENDPOINT internally to minio:9000
+# local: MINIO_ENDPOINT=localhost:9000   |   docker: MINIO_ENDPOINT=minio:9000
 MINIO_ENDPOINT=localhost:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin123
 MINIO_BUCKET_NAME=hive-media
 MINIO_USE_SSL=false
-# Optional local/admin convenience only
 MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001
 
@@ -34,7 +30,7 @@ MINIO_CONSOLE_PORT=9001
 # Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 SECRET_KEY='change-me-to-a-long-random-string'
 DEBUG=True
-ALLOWED_HOSTS=localhost,127.0.0.1,10.0.2.2,192.168.1.13
+ALLOWED_HOSTS=localhost,127.0.0.1,10.0.2.2
 CORS_ALLOWED_ORIGINS=http://localhost,http://localhost:5173,http://localhost:3000
 
 # ─── Throttling ───────────────────────────────────────────────────────────────
@@ -44,25 +40,30 @@ THROTTLE_RELAXED=True
 DISABLE_THROTTLING=False
 
 # ─── Frontend ─────────────────────────────────────────────────────────────────
-# Port mappings used by docker-compose.yml / docker-compose.prod.yml
 VITE_API_URL=/api
 FRONTEND_PORT=5173
 BACKEND_PORT=8000
-# Mobile Expo physical device access:
-# Replace with your machine's current LAN IP when testing from a real phone.
-EXPO_PUBLIC_API_URL=http://192.168.1.13:8000/api
-# Full public URL — used by Django to build email verification / password-reset links
-# Local dev:   http://localhost:5173
-# Production:  https://yourdomain.com
+# local: http://localhost:5173   |   production: https://apiary.selmangunes.com
 FRONTEND_URL=http://localhost:5173
+VITE_MAPBOX_TOKEN=
+
+# ─── Mobile (Expo) ───────────────────────────────────────────────────────────
+# Expo dev:    http://<YOUR_LAN_IP>:8000/api
+# Production:  https://apiary.selmangunes.com/api
+EXPO_PUBLIC_API_URL=http://192.168.1.13:8000/api
+EXPO_PUBLIC_MAPBOX_TOKEN=
+#
+# Firebase credentials (file-based, not env vars):
+#   mobile-client/google-services.json      (Android)
+#   mobile-client/GoogleService-Info.plist   (iOS)
+# Copy manually or run:  make mobile-firebase ANDROID=<path> IOS=<path>
 
 # ─── Resend (email service) ───────────────────────────────────────────────────
 # Sign up at https://resend.com and get your key at https://resend.com/api-keys
 RESEND_API_KEY=re_YOUR_API_KEY_HERE
 #
 # RESEND_CUSTOM_DOMAIN:
-#   true  → the "from" address is derived automatically from FRONTEND_URL:
-#            e.g. https://apiary.selmangunes.com → noreply@apiary.selmangunes.com
+#   true  → "from" address derived from FRONTEND_URL domain
 #            Requires your domain to be verified in Resend's dashboard.
 #   false → use the RESEND_FROM_EMAIL value below.
 RESEND_CUSTOM_DOMAIN=false
@@ -72,11 +73,7 @@ RESEND_CUSTOM_DOMAIN=false
 RESEND_FROM_EMAIL=onboarding@resend.dev
 
 # ─── TLS / Domain (production only) ──────────────────────────────────────────
-# Your public domain — used in nginx server_name and HTTPS redirect
-# DOMAIN=yourdomain.com
-# Root of the Let's Encrypt directory (contains live/ and archive/).
-# Certbot default: /etc/letsencrypt
-# CI override: point to a self-signed cert tree (see ci-docker.yml)
+# DOMAIN=apiary.selmangunes.com
 # LETSENCRYPT_DIR=/etc/letsencrypt
 
 # ─── Misc (optional) ──────────────────────────────────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,8 @@ frontend/.env.production
 # Docker / local env
 .env
 .env.local
+.env.production
+.env.*.bak
 
 # Marimo
 marimo/_static/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: help env setup setup-demo dev stop reset install migrate lint test test-unit test-integration \
-        test-docker coverage coverage-backend coverage-frontend coverage-report \
-        clean build \
+.PHONY: help env env-local env-prod env-status \
+        setup setup-demo dev dev-all stop reset install migrate makemigrations lint build clean \
+        mobile mobile-setup mobile-firebase mobile-build-android mobile-build-ios \
+        db-shell db-time db-time-reset \
         infra-up infra-down infra-reset infra-demo \
         docker-up docker-down docker-logs docker-build docker-reset docker-demo \
-        prod-up prod-down prod-logs prod-build prod-reset prod-demo
+        prod-up prod-down prod-logs prod-build prod-reset prod-demo \
+        shell-backend shell-db shell-redis \
+        test test-unit test-integration test-docker coverage coverage-backend coverage-frontend coverage-report
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -22,11 +25,27 @@ COMPOSE_DEV    = docker compose --env-file .env
 COMPOSE_PROD   = docker compose -f docker-compose.prod.yml --env-file .env
 
 # ─────────────────────────────────────────────────────────────────────────────
-#  ENVIRONMENT VARIABLES
+#  ENVIRONMENT PROFILES
 # ─────────────────────────────────────────────────────────────────────────────
-# ── Guard: require .env ──────────────────────────────────────────────────────
+
+# MODE support: make dev MODE=prod  →  auto-switch before running
+ifdef MODE
+ifeq ($(MODE),prod)
+  _AUTO_SWITCH = @$(MAKE) --no-print-directory env-prod
+else ifeq ($(MODE),production)
+  _AUTO_SWITCH = @$(MAKE) --no-print-directory env-prod
+else ifeq ($(MODE),local)
+  _AUTO_SWITCH = @$(MAKE) --no-print-directory env-local
+else
+  $(error Unknown MODE '$(MODE)'. Use MODE=local or MODE=prod)
+endif
+else
+  _AUTO_SWITCH =
+endif
+
+# Guard: require .env (symlink or file)
 _check_env:
-	@test -f .env || (echo "ERROR: .env not found. Copy .env.example → .env first." && exit 1)
+	@test -f .env || (printf '\033[1;31mERROR: .env not found.\033[0m Run \033[1mmake env\033[0m to generate environment profiles.\n' && exit 1)
 
 -include .env
 export
@@ -40,61 +59,138 @@ export POSTGIS_IMAGE
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-#  Help
+#  HELP
 # ─────────────────────────────────────────────────────────────────────────────
 
 help: ## Show this help message
-	@echo 'Usage: make [target]'
 	@echo ''
-	@echo 'Local development (infra in Docker, backend/frontend native):'
-	@grep -E '^(env|setup|setup-demo|dev|stop|reset|install|migrate|lint|build|clean):.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@printf '\033[1mUsage:\033[0m make [target] [MODE=local|prod]\n'
 	@echo ''
-	@echo 'Infra only (PostGIS + Redis + MinIO containers):'
-	@grep -E '^infra-.*:.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo '\033[1;4mGetting Started:\033[0m'
+	@grep -E '^(env|setup|setup-demo):.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 	@echo ''
-	@echo 'Docker dev (full stack in containers):'
-	@grep -E '^docker-.*:.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo '\033[1;4mEnvironment Profiles:\033[0m'
+	@grep -E '^env-(local|prod|status):.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 	@echo ''
-	@echo 'Docker prod (production stack):'
-	@grep -E '^prod-.*:.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo '\033[1;4mLocal Development:\033[0m'
+	@grep -E '^(dev|dev-all|stop|reset|install|migrate|makemigrations|lint|build|clean):.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 	@echo ''
-	@echo 'Testing (native):'
-	@grep -E '^(test|test-unit|test-integration|coverage|coverage-backend|coverage-frontend|coverage-report):.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo '\033[1;4mMobile:\033[0m'
+	@grep -E '^mobile[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 	@echo ''
-	@echo 'Docker testing:'
-	@grep -E '^test-docker:.*## ' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo '\033[1;4mDatabase:\033[0m'
+	@grep -E '^db-[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+	@echo '\033[1;4mInfra Only (PostGIS + Redis + MinIO):\033[0m'
+	@grep -E '^infra-[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+	@echo '\033[1;4mDocker Dev (full stack in containers):\033[0m'
+	@grep -E '^docker-[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+	@echo '\033[1;4mDocker Prod (production stack):\033[0m'
+	@grep -E '^prod-[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+	@echo '\033[1;4mShells:\033[0m'
+	@grep -E '^shell-[^:]*:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+	@echo '\033[1;4mTesting:\033[0m'
+	@grep -E '^(test|test-unit|test-integration|test-docker|coverage|coverage-backend|coverage-frontend|coverage-report):.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
+	@echo ''
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  ENVIRONMENT
+# ─────────────────────────────────────────────────────────────────────────────
+
+env: ## Interactive .env generator (creates local + production profiles)
+	@bash scripts/setup-env.sh
+
+env-local: ## Switch to local development profile
+	@if [ ! -f .env.local ]; then \
+	  printf '\033[1;31mERROR: .env.local not found.\033[0m Run \033[1mmake env\033[0m first.\n'; exit 1; \
+	fi
+	@rm -f .env
+	@ln -s .env.local .env
+	$(call _ok,"Switched to LOCAL profile")
+
+env-prod: ## Switch to production profile
+	@if [ ! -f .env.production ]; then \
+	  printf '\033[1;31mERROR: .env.production not found.\033[0m Run \033[1mmake env\033[0m first.\n'; exit 1; \
+	fi
+	@rm -f .env
+	@ln -s .env.production .env
+	$(call _ok,"Switched to PRODUCTION profile")
+
+env-status: ## Show active profile and config status
+	@echo ""
+	@if [ -L .env ]; then \
+	  target=$$(readlink .env); \
+	  if [ "$$target" = ".env.local" ]; then \
+	    printf '  Active profile: \033[1;32mlocal\033[0m (→ .env.local)\n'; \
+	  elif [ "$$target" = ".env.production" ]; then \
+	    printf '  Active profile: \033[1;33mproduction\033[0m (→ .env.production)\n'; \
+	  else \
+	    printf '  Active profile: \033[1;35mcustom\033[0m (→ %s)\n' "$$target"; \
+	  fi; \
+	elif [ -f .env ]; then \
+	  printf '  Active profile: \033[1;35mmanual .env file\033[0m (not a symlink)\n'; \
+	else \
+	  printf '  Active profile: \033[1;31mnone\033[0m — run \033[1mmake env\033[0m\n'; \
+	fi
+	@echo ""
+	@echo "  Profiles:"
+	@[ -f .env.local ]      && printf '    .env.local       \033[1;32m✓\033[0m\n' || printf '    .env.local       \033[0;90m✗ missing\033[0m\n'
+	@[ -f .env.production ] && printf '    .env.production  \033[1;32m✓\033[0m\n' || printf '    .env.production  \033[0;90m✗ missing\033[0m\n'
+	@echo ""
+	@echo "  Firebase (mobile push notifications):"
+	@[ -f mobile-client/google-services.json ]     && printf '    google-services.json      \033[1;32m✓\033[0m\n' || printf '    google-services.json      \033[0;90m✗ missing\033[0m\n'
+	@[ -f mobile-client/GoogleService-Info.plist ]  && printf '    GoogleService-Info.plist   \033[1;32m✓\033[0m\n' || printf '    GoogleService-Info.plist   \033[0;90m✗ missing\033[0m\n'
+	@echo ""
+	@if [ -f .env ]; then \
+	  printf '  Key values:\n'; \
+	  printf '    DB_HOST=%s\n' "$${DB_HOST:-<unset>}"; \
+	  printf '    DEBUG=%s\n' "$${DEBUG:-<unset>}"; \
+	  printf '    FRONTEND_URL=%s\n' "$${FRONTEND_URL:-<unset>}"; \
+	  printf '    EXPO_PUBLIC_API_URL=%s\n' "$${EXPO_PUBLIC_API_URL:-<unset>}"; \
+	  echo ""; \
+	fi
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  LOCAL DEVELOPMENT  (infra via docker compose, backend/frontend natively)
 # ─────────────────────────────────────────────────────────────────────────────
 
-env: ## Interactive .env generator (prompts for API keys, DB creds, etc.)
-	@bash scripts/setup-env.sh
-
-setup: _check_env ## One-time local setup: venv, deps, infra, migrate
-	$(call _log,"[1/5] Python virtual environment...")
+setup: _check_env ## One-time local setup: venv, deps, infra, migrate, mobile deps
+	$(_AUTO_SWITCH)
+	$(call _log,"[1/6] Python virtual environment...")
 	@test -d $(VENV) || $(PYTHON) -m venv $(VENV)
-	$(call _log,"[2/5] Installing backend dependencies...")
+	$(call _log,"[2/6] Installing backend dependencies...")
 	@$(PIP) install -q -r backend/requirements.txt
-	$(call _log,"[3/5] Starting infra (PostGIS + Redis + MinIO)...")
+	$(call _log,"[3/6] Starting infra (PostGIS + Redis + MinIO)...")
 	@$(COMPOSE_INFRA) up -d
 	@echo "  Waiting for database to accept connections..."
 	@$(_wait_db)
 	@sleep 2
-	$(call _log,"[4/5] Running Django migrations...")
+	$(call _log,"[4/6] Running Django migrations...")
 	@sh -c 'set -e; for i in 1 2 3 4 5; do cd "$(CURDIR)/backend" && "$(CURDIR)/$(VENV)/bin/python" manage.py migrate && exit 0; echo "  DB not ready yet (attempt $$i/5), retrying in 3s..."; sleep 3; done; echo "migrate failed after 5 attempts"; exit 1'
-	$(call _log,"[5/5] Installing frontend dependencies...")
+	$(call _log,"[5/6] Installing frontend dependencies...")
 	@cd frontend && npm install --silent
+	$(call _log,"[6/6] Installing mobile dependencies...")
+	@cd mobile-client && npm install --silent
 	@echo ""
 	$(call _ok,"Setup complete! Run  make dev  to start.")
 	@echo "  Tip: Run  make setup-demo  to also seed demo data."
+	@if [ ! -f mobile-client/google-services.json ] || [ ! -f mobile-client/GoogleService-Info.plist ]; then \
+	  printf '  \033[1;33m⚠  Firebase files missing — run  make mobile-firebase  for push notifications.\033[0m\n'; \
+	fi
 
 setup-demo: setup ## One-time local setup + seed demo data
 	$(call _log,"Seeding demo data...")
 	@cd backend && DJANGO_SETTINGS_MODULE=hive_project.settings $(PYEXEC) setup_demo.py
 	$(call _ok,"Demo data seeded. Login: elif@demo.com / demo123")
 
-dev: _check_env ## Start local dev: infra + backend (8000) + frontend (5173) in parallel
+dev: _check_env ## Start local dev: infra + backend (8000) + frontend (5173)
+	$(_AUTO_SWITCH)
 	@for port in 8000 5173; do \
 	  pid=$$(lsof -ti tcp:$$port 2>/dev/null); \
 	  if [ -n "$$pid" ]; then \
@@ -118,16 +214,55 @@ dev: _check_env ## Start local dev: infra + backend (8000) + frontend (5173) in 
 	   | awk '{print "\033[0;35m[frontend]\033[0m " $$0; fflush()}') & FRONTEND_PID=$$!; \
 	 wait
 
+dev-all: _check_env ## Start local dev: backend + frontend + mobile Expo server
+	$(_AUTO_SWITCH)
+	@for port in 8000 5173 8081; do \
+	  pid=$$(lsof -ti tcp:$$port 2>/dev/null); \
+	  if [ -n "$$pid" ]; then \
+	    echo "  Killing process on port $$port (PID $$pid)..."; \
+	    kill -9 $$pid 2>/dev/null || true; \
+	    sleep 0.3; \
+	  fi; \
+	done
+	$(call _log,"Starting infra...")
+	@$(COMPOSE_INFRA) up -d
+	@$(_wait_db)
+	$(call _log,"Starting backend + frontend + mobile...")
+	@echo "  Backend:  http://localhost:8000"
+	@echo "  Frontend: http://localhost:5173"
+	@echo "  Expo:     Press 'a' for Android, 'i' for iOS in the Expo terminal"
+	@echo "  Press Ctrl+C to stop all."
+	@echo ""
+	@BACKEND_PID=0; FRONTEND_PID=0; MOBILE_PID=0; \
+	 cleanup() { kill $$BACKEND_PID $$FRONTEND_PID $$MOBILE_PID 2>/dev/null; wait $$BACKEND_PID $$FRONTEND_PID $$MOBILE_PID 2>/dev/null; }; \
+	 trap cleanup INT TERM; \
+	 (cd backend && $(PYEXEC) -m daphne -b 0.0.0.0 -p 8000 hive_project.asgi:application 2>&1 \
+	   | awk '{print "\033[0;36m[backend]\033[0m " $$0; fflush()}') & BACKEND_PID=$$!; \
+	 (cd frontend && VITE_BACKEND_URL=http://localhost:8000 npm run dev 2>&1 \
+	   | awk '{print "\033[0;35m[frontend]\033[0m " $$0; fflush()}') & FRONTEND_PID=$$!; \
+	 (cd mobile-client && npx expo start 2>&1 \
+	   | awk '{print "\033[0;33m[mobile]\033[0m " $$0; fflush()}') & MOBILE_PID=$$!; \
+	 wait
+
 stop: infra-down ## Stop local infra (alias for infra-down)
 
 reset: infra-reset ## Stop infra AND delete all data volumes (alias for infra-reset)
 
-install: ## Install all dependencies (backend into venv, frontend via npm)
+install: ## Install all dependencies (backend + frontend + mobile)
 	@$(PIP) install -r backend/requirements.txt
 	@cd frontend && npm install
+	@cd mobile-client && npm install
 
 migrate: _check_env ## Run Django migrations (native, requires infra running)
+	$(_AUTO_SWITCH)
 	@cd backend && $(PYEXEC) manage.py migrate
+
+makemigrations: _check_env ## Create new Django migrations (use APP=<name> to scope)
+ifdef APP
+	@cd backend && $(PYEXEC) manage.py makemigrations $(APP)
+else
+	@cd backend && $(PYEXEC) manage.py makemigrations
+endif
 
 lint: ## Run ESLint on the frontend
 	@cd frontend && npm run lint
@@ -143,11 +278,107 @@ clean: ## Clean generated files and caches
 	@rm -rf backend/tests/reports frontend/tests/reports frontend/coverage
 	$(call _ok,"Cleaned.")
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  MOBILE
+# ─────────────────────────────────────────────────────────────────────────────
+
+mobile: _check_env ## Start Expo dev server for mobile
+	$(_AUTO_SWITCH)
+	$(call _log,"Starting Expo dev server...")
+	@cd mobile-client && npx expo start
+
+mobile-setup: ## Install mobile dependencies + check Firebase files
+	$(call _log,"Installing mobile dependencies...")
+	@cd mobile-client && npm install
+	@echo ""
+	@echo "  Firebase status:"
+	@[ -f mobile-client/google-services.json ]    && printf '    google-services.json      \033[1;32m✓\033[0m\n' || printf '    google-services.json      \033[1;33m✗ missing\033[0m  (Android push)\n'
+	@[ -f mobile-client/GoogleService-Info.plist ] && printf '    GoogleService-Info.plist   \033[1;32m✓\033[0m\n' || printf '    GoogleService-Info.plist   \033[1;33m✗ missing\033[0m  (iOS push)\n'
+	@echo ""
+	@if [ ! -f mobile-client/google-services.json ] || [ ! -f mobile-client/GoogleService-Info.plist ]; then \
+	  printf '  Run \033[1mmake mobile-firebase ANDROID=<path> IOS=<path>\033[0m to set up Firebase.\n\n'; \
+	fi
+	$(call _ok,"Mobile setup complete.")
+
+mobile-firebase: ## Copy Firebase credential files (ANDROID=<path> IOS=<path>)
+ifdef ANDROID
+	@if [ ! -f "$(ANDROID)" ]; then \
+	  printf '\033[1;31mERROR: File not found: %s\033[0m\n' "$(ANDROID)"; exit 1; \
+	fi
+	@cp "$(ANDROID)" mobile-client/google-services.json
+	$(call _ok,"Copied google-services.json → mobile-client/")
+endif
+ifdef IOS
+	@if [ ! -f "$(IOS)" ]; then \
+	  printf '\033[1;31mERROR: File not found: %s\033[0m\n' "$(IOS)"; exit 1; \
+	fi
+	@cp "$(IOS)" mobile-client/GoogleService-Info.plist
+	$(call _ok,"Copied GoogleService-Info.plist → mobile-client/")
+endif
+ifndef ANDROID
+ifndef IOS
+	@echo "Usage: make mobile-firebase ANDROID=<path-to-google-services.json> IOS=<path-to-GoogleService-Info.plist>"
+	@echo ""
+	@echo "  Either or both arguments accepted."
+	@echo ""
+	@echo "  Example:"
+	@echo "    make mobile-firebase ANDROID=~/Downloads/google-services.json"
+	@echo "    make mobile-firebase IOS=~/Downloads/GoogleService-Info.plist"
+	@echo "    make mobile-firebase ANDROID=~/Downloads/google-services.json IOS=~/Downloads/GoogleService-Info.plist"
+endif
+endif
+
+mobile-build-android: ## EAS build for Android
+	@cd mobile-client && npx eas build --platform android
+
+mobile-build-ios: ## EAS build for iOS
+	@cd mobile-client && npx eas build --platform ios
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  DATABASE
+# ─────────────────────────────────────────────────────────────────────────────
+
+db-shell: _check_env ## Open psql prompt in the DB container
+	@$(COMPOSE_INFRA) exec db psql -U $${DB_USER:-postgres} -d $${DB_NAME:-the_hive_db}
+
+db-time: _check_env ## Set DB container clock (SET="2026-04-15 10:00" or OFFSET="+2 days")
+ifdef SET
+	$(call _log,"Setting DB container clock to: $(SET)")
+	@docker exec hive_db date -s "$(SET)" 2>/dev/null || \
+	  ($(call _warn,"'date -s' failed — try: make db-time SET=\"YYYY-MM-DD HH:MM:SS\"") && exit 1)
+	$(call _ok,"DB clock set to: $(SET)")
+	@echo "  Current DB time: $$(docker exec hive_db date)"
+else ifdef OFFSET
+	$(call _log,"Shifting DB container clock by: $(OFFSET)")
+	@CURRENT=$$(docker exec hive_db date '+%Y-%m-%d %H:%M:%S'); \
+	 NEW=$$(docker exec hive_db date -d "$$CURRENT $(OFFSET)" '+%Y-%m-%d %H:%M:%S' 2>/dev/null); \
+	 if [ -z "$$NEW" ]; then \
+	   echo "ERROR: Could not parse offset '$(OFFSET)'. Use format like '+2 days', '+5 hours', '-1 day'."; exit 1; \
+	 fi; \
+	 docker exec hive_db date -s "$$NEW"; \
+	 printf '\033[1;32m✓ DB clock shifted by %s → %s\033[0m\n' "$(OFFSET)" "$$NEW"
+else
+	@echo "Usage:"
+	@echo "  make db-time SET=\"2026-04-15 10:00:00\"    Set to specific time"
+	@echo "  make db-time OFFSET=\"+2 days\"              Shift forward/backward"
+	@echo "  make db-time-reset                         Restore real time"
+endif
+
+db-time-reset: _check_env ## Restore DB container to real time (restarts container)
+	$(call _log,"Restarting DB container to restore real time...")
+	@$(COMPOSE_INFRA) restart db
+	@$(_wait_db)
+	$(call _ok,"DB clock restored. Current time: $$(docker exec hive_db date)")
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  INFRA ONLY  (PostGIS + Redis + MinIO — for running backend/frontend natively)
 # ─────────────────────────────────────────────────────────────────────────────
 
 infra-up: _check_env ## Start infra containers (db, redis, minio)
+	$(_AUTO_SWITCH)
 	$(call _log,"Starting infra...")
 	@$(COMPOSE_INFRA) up -d
 	@echo "  Waiting for database..."
@@ -171,6 +402,20 @@ infra-demo: _check_env infra-up ## Start infra + seed demo data (native backend)
 	$(call _log,"Seeding demo data...")
 	@cd backend && DJANGO_SETTINGS_MODULE=hive_project.settings $(PYEXEC) setup_demo.py
 	$(call _ok,"Demo data seeded. Login: elif@demo.com / demo123")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SHELLS
+# ────────────────────────────────────────────────���────────────────────────────
+
+shell-backend: _check_env ## Open bash in the backend container
+	@$(COMPOSE_DEV) exec backend bash
+
+shell-db: _check_env db-shell ## Open psql in the DB container (alias for db-shell)
+
+shell-redis: _check_env ## Open redis-cli in the Redis container
+	@$(COMPOSE_INFRA) exec redis redis-cli
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  TESTING (native — requires venv + node_modules already installed)
@@ -219,11 +464,13 @@ coverage-report: ## Open coverage reports in the default browser
 	   echo "  frontend/tests/reports/coverage/index.html"; \
 	 fi
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  DOCKER DEV  (full stack in containers — docker-compose.yml)
 # ─────────────────────────────────────────────────────────────────────────────
 
 docker-up: _check_env ## Start the full Docker dev stack
+	$(_AUTO_SWITCH)
 	@$(COMPOSE_DEV) up -d
 	$(call _ok,"Docker dev stack running. http://localhost")
 
@@ -243,6 +490,7 @@ docker-reset: ## Stop Docker dev AND delete all data volumes
 	$(call _ok,"Docker dev stopped and volumes deleted.")
 
 docker-demo: _check_env ## Start Docker dev stack + seed demo data
+	$(_AUTO_SWITCH)
 	$(call _log,"Starting Docker dev environment...")
 	@$(COMPOSE_DEV) up -d --build
 	$(call _log,"Waiting for backend to be healthy...")
@@ -252,11 +500,13 @@ docker-demo: _check_env ## Start Docker dev stack + seed demo data
 	$(call _ok,"Docker dev + demo ready: http://localhost")
 	@echo "  Login: elif@demo.com / demo123"
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  DOCKER PROD  (production stack — docker-compose.prod.yml)
 # ─────────────────────────────────────────────────────────────────────────────
 
 prod-up: _check_env ## Start the production Docker stack
+	$(_AUTO_SWITCH)
 	$(call _log,"Starting production stack...")
 	@$(COMPOSE_PROD) up -d
 	$(call _ok,"Production stack running.")
@@ -268,6 +518,7 @@ prod-logs: ## Tail production Docker logs
 	@$(COMPOSE_PROD) logs -f
 
 prod-build: _check_env ## Build production Docker images
+	$(_AUTO_SWITCH)
 	@$(COMPOSE_PROD) build
 
 prod-reset: ## Stop production AND delete all data volumes
@@ -277,6 +528,7 @@ prod-reset: ## Stop production AND delete all data volumes
 	$(call _ok,"Production stopped and volumes deleted.")
 
 prod-demo: _check_env ## Start production stack + seed demo data
+	$(_AUTO_SWITCH)
 	$(call _log,"Starting production environment...")
 	@$(COMPOSE_PROD) up -d --build
 	$(call _log,"Waiting for backend to be healthy...")
@@ -286,9 +538,10 @@ prod-demo: _check_env ## Start production stack + seed demo data
 	$(call _ok,"Production + demo ready.")
 	@echo "  Login: elif@demo.com / demo123"
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  DOCKER TESTING
-# ─────────────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────��──────────────────────────
 
 test-docker: _check_env ## Run backend tests inside Docker dev stack
 	@$(COMPOSE_DEV) up -d db redis backend

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -2,28 +2,28 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Interactive .env generator for The Hive
 #
-# Usage:  ./scripts/setup-env.sh          (creates .env)
-#         Prompts before overwriting if .env already exists.
+# Generates TWO profile files:
+#   .env.local       — local development (DB on localhost, debug on)
+#   .env.production  — production / Docker (DB on 'db', debug off)
+#
+# Then symlinks .env → .env.local so everything Just Works.
+#
+# Usage:  ./scripts/setup-env.sh   or   make env
 # ─────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
-ROOT_ENV=".env"
-
-# ── Guard ────────────────────────────────────────────────────────────────────
-if [[ -f "$ROOT_ENV" ]]; then
-  printf '\033[1;33m⚠  %s already exists.\033[0m\n' "$ROOT_ENV"
-  printf 'Overwrite? [y/N] '
-  read -r ans
-  [[ "${ans:-N}" =~ ^[Yy]$ ]] || { echo "Keeping existing .env."; exit 0; }
-fi
+ENV_LOCAL=".env.local"
+ENV_PROD=".env.production"
+ENV_LINK=".env"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 blue()  { printf '\033[1;34m%s\033[0m' "$1"; }
 green() { printf '\033[1;32m%s\033[0m' "$1"; }
 gray()  { printf '\033[0;90m%s\033[0m' "$1"; }
+warn()  { printf '\033[1;33m%s\033[0m\n' "$1"; }
+ok()    { printf '\033[1;32m✓ %s\033[0m\n' "$1"; }
 
 prompt() {
-  # prompt VAR_NAME "description" "default"
   local var="$1" desc="$2" default="${3:-}"
   if [[ -n "$default" ]]; then
     printf "  %s (%s) [%s]: " "$(blue "$var")" "$desc" "$(gray "$default")"
@@ -35,60 +35,86 @@ prompt() {
   printf -v "$var" '%s' "$value"
 }
 
+prompt_yn() {
+  local desc="$1" default="${2:-N}"
+  printf "  %s [%s]: " "$desc" "$default"
+  read -r ans
+  ans="${ans:-$default}"
+  [[ "$ans" =~ ^[Yy] ]]
+}
+
+detect_lan_ip() {
+  local ip=""
+  if command -v ipconfig &>/dev/null && [[ "$(uname)" == "Darwin" ]]; then
+    ip=$(ipconfig getifaddr en0 2>/dev/null || true)
+  fi
+  if [[ -z "$ip" ]] && command -v hostname &>/dev/null; then
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+  fi
+  if [[ -z "$ip" ]] && command -v ip &>/dev/null; then
+    ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' || true)
+  fi
+  echo "${ip:-192.168.1.100}"
+}
+
+# ── Guard ────────────────────────────────────────────────────────────────────
+existing=()
+[[ -f "$ENV_LOCAL" ]] && existing+=("$ENV_LOCAL")
+[[ -f "$ENV_PROD" ]]  && existing+=("$ENV_PROD")
+if [[ ${#existing[@]} -gt 0 ]]; then
+  warn "⚠  Found existing: ${existing[*]}"
+  if ! prompt_yn "Overwrite? (existing files will be backed up)" "N"; then
+    echo "Keeping existing files."
+    exit 0
+  fi
+  for f in "${existing[@]}"; do
+    cp "$f" "${f}.bak"
+    echo "  Backed up $f → ${f}.bak"
+  done
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 echo ""
 printf '\033[1;34m──── The Hive: Environment Setup ────\033[0m\n'
 echo ""
-echo "This will generate $(blue "$ROOT_ENV") (single file for backend + frontend)."
+echo "This will generate $(blue "$ENV_LOCAL") and $(blue "$ENV_PROD")."
 echo "Press Enter to accept the [default] value."
 echo ""
 
-# ─── Database ────────────────────────────────────────────────────────────────
+# ─── Shared secrets (prompted once) ─────────────────────────────────────────
 echo "$(green "▸ Database (PostGIS)")"
 prompt DB_NAME     "database name"     "the_hive_db"
 prompt DB_USER     "database user"     "postgres"
 prompt DB_PASSWORD "database password" "postgres123"
-prompt DB_HOST     "host"              "localhost"
 prompt DB_PORT     "port"              "5432"
 echo ""
 
-# ─── Redis ───────────────────────────────────────────────────────────────────
 echo "$(green "▸ Redis")"
-prompt REDIS_HOST "host" "localhost"
 prompt REDIS_PORT "port" "6379"
 echo ""
 
-# ─── MinIO ───────────────────────────────────────────────────────────────────
 echo "$(green "▸ MinIO (S3-compatible storage)")"
-prompt MINIO_ENDPOINT    "endpoint"        "localhost:9000"
-prompt MINIO_ACCESS_KEY  "access key"      "minioadmin"
-prompt MINIO_SECRET_KEY  "secret key"      "minioadmin123"
-prompt MINIO_BUCKET_NAME "bucket name"     "hive-media"
-prompt MINIO_API_PORT    "API port"        "9000"
-prompt MINIO_CONSOLE_PORT "console port"   "9001"
+prompt MINIO_ACCESS_KEY   "access key"    "minioadmin"
+prompt MINIO_SECRET_KEY   "secret key"    "minioadmin123"
+prompt MINIO_BUCKET_NAME  "bucket name"   "hive-media"
+prompt MINIO_API_PORT     "API port"      "9000"
+prompt MINIO_CONSOLE_PORT "console port"  "9001"
 echo ""
 
-# ─── Django ──────────────────────────────────────────────────────────────────
 echo "$(green "▸ Django")"
-# Auto-generate a secret key
 if command -v python3 &>/dev/null; then
   DEFAULT_SECRET=$(python3 -c "import secrets; print(secrets.token_urlsafe(50))" 2>/dev/null || echo "change-me-to-a-long-random-string")
 else
   DEFAULT_SECRET="change-me-to-a-long-random-string"
 fi
-prompt SECRET_KEY          "secret key (auto-generated)"  "$DEFAULT_SECRET"
-prompt DEBUG               "debug mode"                   "True"
-prompt ALLOWED_HOSTS       "allowed hosts"                "localhost,127.0.0.1"
-prompt CORS_ALLOWED_ORIGINS "CORS origins"                "http://localhost,http://localhost:5173,http://localhost:3000"
-prompt FRONTEND_URL        "frontend URL"                 "http://localhost:5173"
+prompt SECRET_KEY "secret key (auto-generated)" "$DEFAULT_SECRET"
 echo ""
 
-# ─── Throttling ──────────────────────────────────────────────────────────────
 echo "$(green "▸ Throttling")"
-prompt THROTTLE_RELAXED    "relaxed throttle"  "True"
-prompt DISABLE_THROTTLING  "disable throttling" "False"
+prompt THROTTLE_RELAXED   "relaxed throttle (local)"   "True"
+prompt DISABLE_THROTTLING "disable throttling (local)"  "False"
 echo ""
 
-# ─── API Keys (optional) ────────────────────────────────────────────────────
 echo "$(green "▸ API Keys") $(gray "(leave blank to skip — features will be disabled)")"
 echo ""
 prompt RESEND_API_KEY       "Resend email API key — https://resend.com/api-keys"  ""
@@ -98,27 +124,70 @@ echo ""
 prompt VITE_MAPBOX_TOKEN    "Mapbox token — https://account.mapbox.com/access-tokens/" ""
 echo ""
 
-# ─── Production (optional) ──────────────────────────────────────────────────
-echo "$(green "▸ Production") $(gray "(optional — skip for local dev)")"
-prompt DOMAIN          "production domain"       ""
-prompt LETSENCRYPT_DIR "Let's Encrypt directory" ""
+# ─── Local profile specifics ────────────────────────────────────────────────
+echo "$(green "▸ Local Development Profile")"
+DETECTED_IP=$(detect_lan_ip)
+echo "  Detected LAN IP: $(blue "$DETECTED_IP")"
+prompt LAN_IP "LAN IP for mobile device access" "$DETECTED_IP"
 echo ""
 
-# ─── Write root .env ────────────────────────────────────────────────────────
-cat > "$ROOT_ENV" <<EOF
+# ─── Production profile specifics ───────────────────────────────────────────
+echo "$(green "▸ Production Profile")"
+prompt PROD_DOMAIN "production domain" "apiary.selmangunes.com"
+prompt LETSENCRYPT_DIR "Let's Encrypt directory (leave blank to skip)" ""
+echo ""
+
+# ─── Firebase (optional) ────────────────────────────────────────────────────
+echo "$(green "▸ Firebase for Mobile Push Notifications") $(gray "(optional)")"
+FIREBASE_DONE=false
+if prompt_yn "Set up Firebase credential files now?" "N"; then
+  echo ""
+  prompt ANDROID_JSON "path to google-services.json (Android)" ""
+  prompt IOS_PLIST    "path to GoogleService-Info.plist (iOS)" ""
+
+  if [[ -n "$ANDROID_JSON" ]]; then
+    if [[ -f "$ANDROID_JSON" ]]; then
+      cp "$ANDROID_JSON" mobile-client/google-services.json
+      ok "Copied google-services.json → mobile-client/"
+    else
+      warn "⚠  File not found: $ANDROID_JSON (skipping)"
+    fi
+  fi
+
+  if [[ -n "$IOS_PLIST" ]]; then
+    if [[ -f "$IOS_PLIST" ]]; then
+      cp "$IOS_PLIST" mobile-client/GoogleService-Info.plist
+      ok "Copied GoogleService-Info.plist → mobile-client/"
+    else
+      warn "⚠  File not found: $IOS_PLIST (skipping)"
+    fi
+  fi
+  FIREBASE_DONE=true
+fi
+if [[ "$FIREBASE_DONE" == "false" ]]; then
+  echo "  $(gray "Skipped. Run 'make mobile-firebase' later to set up Firebase.")"
+fi
+echo ""
+
+# ─── Write .env.local ───────────────────────────────────────────────────────
+cat > "$ENV_LOCAL" <<EOF
+# ─── The Hive: Local Development Profile ─────────────────────────────────────
+# Generated by: make env  ($(date +%Y-%m-%d))
+# Switch profiles with: make env-local / make env-prod
+
 # ─── Database (PostGIS) ───────────────────────────────────────────────────────
 DB_NAME=$DB_NAME
 DB_USER=$DB_USER
 DB_PASSWORD=$DB_PASSWORD
-DB_HOST=$DB_HOST
+DB_HOST=localhost
 DB_PORT=$DB_PORT
 
 # ─── Redis ────────────────────────────────────────────────────────────────────
-REDIS_HOST=$REDIS_HOST
+REDIS_HOST=localhost
 REDIS_PORT=$REDIS_PORT
 
 # ─── MinIO (S3-compatible object storage) ─────────────────────────────────────
-MINIO_ENDPOINT=$MINIO_ENDPOINT
+MINIO_ENDPOINT=localhost:$MINIO_API_PORT
 MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY
 MINIO_SECRET_KEY=$MINIO_SECRET_KEY
 MINIO_BUCKET_NAME=$MINIO_BUCKET_NAME
@@ -128,9 +197,9 @@ MINIO_CONSOLE_PORT=$MINIO_CONSOLE_PORT
 
 # ─── Django ───────────────────────────────────────────────────────────────────
 SECRET_KEY='$SECRET_KEY'
-DEBUG=$DEBUG
-ALLOWED_HOSTS=$ALLOWED_HOSTS
-CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1,10.0.2.2,$LAN_IP
+CORS_ALLOWED_ORIGINS=http://localhost,http://localhost:5173,http://localhost:3000
 
 # ─── Throttling ───────────────────────────────────────────────────────────────
 THROTTLE_RELAXED=$THROTTLE_RELAXED
@@ -140,32 +209,104 @@ DISABLE_THROTTLING=$DISABLE_THROTTLING
 VITE_API_URL=/api
 FRONTEND_PORT=5173
 BACKEND_PORT=8000
-FRONTEND_URL=$FRONTEND_URL
+FRONTEND_URL=http://localhost:5173
+VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
+
+# ─── Mobile (Expo) ───────────────────────────────────────────────────────────
+EXPO_PUBLIC_API_URL=http://$LAN_IP:8000/api
+EXPO_PUBLIC_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
+
+# ─── Resend (email service) ───────────────────────────────────────────────────
+RESEND_API_KEY=${RESEND_API_KEY:-}
+RESEND_CUSTOM_DOMAIN=$RESEND_CUSTOM_DOMAIN
+RESEND_FROM_EMAIL=$RESEND_FROM_EMAIL
+EOF
+
+# ─── Write .env.production ──────────────────────────────────────────────────
+cat > "$ENV_PROD" <<EOF
+# ─── The Hive: Production Profile ────────────────────────────────────────────
+# Generated by: make env  ($(date +%Y-%m-%d))
+# Switch profiles with: make env-local / make env-prod
+
+# ─── Database (PostGIS) ───────────────────────────────────────────────────────
+DB_NAME=$DB_NAME
+DB_USER=$DB_USER
+DB_PASSWORD=$DB_PASSWORD
+DB_HOST=db
+DB_PORT=$DB_PORT
+
+# ─── Redis ────────────────────────────────────────────────────────────────────
+REDIS_HOST=redis
+REDIS_PORT=$REDIS_PORT
+
+# ─── MinIO (S3-compatible object storage) ─────────────────────────────────────
+MINIO_ENDPOINT=minio:$MINIO_API_PORT
+MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY
+MINIO_SECRET_KEY=$MINIO_SECRET_KEY
+MINIO_BUCKET_NAME=$MINIO_BUCKET_NAME
+MINIO_USE_SSL=false
+MINIO_API_PORT=$MINIO_API_PORT
+MINIO_CONSOLE_PORT=$MINIO_CONSOLE_PORT
+
+# ─── Django ───────────────────────────────────────────────────────────────────
+SECRET_KEY='$SECRET_KEY'
+DEBUG=False
+ALLOWED_HOSTS=$PROD_DOMAIN
+CORS_ALLOWED_ORIGINS=https://$PROD_DOMAIN
+
+# ─── Throttling ───────────────────────────────────────────────────────────────
+THROTTLE_RELAXED=False
+DISABLE_THROTTLING=False
+
+# ─── Frontend ─────────────────────────────────────────────────────────────────
+VITE_API_URL=/api
+FRONTEND_PORT=5173
+BACKEND_PORT=8000
+FRONTEND_URL=https://$PROD_DOMAIN
+VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
+
+# ─── Mobile (Expo) ───────────────────────────────────────────────────────────
+EXPO_PUBLIC_API_URL=https://$PROD_DOMAIN/api
+EXPO_PUBLIC_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
 
 # ─── Resend (email service) ───────────────────────────────────────────────────
 RESEND_API_KEY=${RESEND_API_KEY:-}
 RESEND_CUSTOM_DOMAIN=$RESEND_CUSTOM_DOMAIN
 RESEND_FROM_EMAIL=$RESEND_FROM_EMAIL
 
-# ─── Mapbox ───────────────────────────────────────────────────────────────────
-VITE_MAPBOX_TOKEN=${VITE_MAPBOX_TOKEN:-}
+# ─── TLS / Domain ────────────────────────────────────────────────────────────
+DOMAIN=$PROD_DOMAIN
 EOF
 
-# Add production section only if values were provided
-if [[ -n "$DOMAIN" || -n "$LETSENCRYPT_DIR" ]]; then
-  cat >> "$ROOT_ENV" <<EOF
-
-# ─── TLS / Domain (production) ───────────────────────────────────────────────
-EOF
-  [[ -n "$DOMAIN" ]]          && echo "DOMAIN=$DOMAIN" >> "$ROOT_ENV"
-  [[ -n "$LETSENCRYPT_DIR" ]] && echo "LETSENCRYPT_DIR=$LETSENCRYPT_DIR" >> "$ROOT_ENV"
+if [[ -n "$LETSENCRYPT_DIR" ]]; then
+  echo "LETSENCRYPT_DIR=$LETSENCRYPT_DIR" >> "$ENV_PROD"
 fi
 
+# ─── Symlink .env → .env.local ──────────────────────────────────────────────
+rm -f "$ENV_LINK"
+ln -s "$ENV_LOCAL" "$ENV_LINK"
+
 echo ""
-printf '\033[1;32m✓ Created %s\033[0m\n' "$ROOT_ENV"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ok "Created $ENV_LOCAL  (local development)"
+ok "Created $ENV_PROD  (production / Docker)"
+ok "Symlinked .env → $ENV_LOCAL"
 echo ""
+echo "  Active profile: $(blue "local")"
+echo ""
+if [[ ! -f mobile-client/google-services.json ]] || [[ ! -f mobile-client/GoogleService-Info.plist ]]; then
+  warn "  ⚠  Firebase files missing — mobile push notifications won't work."
+  echo "     Run: make mobile-firebase ANDROID=<path> IOS=<path>"
+  echo ""
+fi
 echo "  Next steps:"
-echo "    make setup       — first-time setup (no demo data)"
+echo "    make setup       — first-time setup (venv, deps, infra, migrate)"
 echo "    make setup-demo  — first-time setup + demo data"
 echo "    make dev         — start local development"
+echo "    make dev-all     — start backend + frontend + mobile"
+echo ""
+echo "  Switch profiles:"
+echo "    make env-local   — use local development config"
+echo "    make env-prod    — use production config"
+echo "    make env-status  — show active profile"
 echo ""


### PR DESCRIPTION
 **Summary**

  - Add profile-based env system (.env.local / .env.production) with one-command switching
  - Add mobile workflow to Makefile and setup wizard (Expo, Firebase files, LAN IP detection)
  - Add convenience targets: db-shell, db-time, shell-*, makemigrations, dev-all
  - Reorganize make help into clear sections

  **What changed**

  .env.example — added Mobile section (Expo vars, Firebase file docs), added inline local vs docker hints

  scripts/setup-env.sh — rewritten to generate two profiles in one pass, auto-detect LAN IP, optionally copy Firebase credential files, symlink .env to active
  profile

  Makefile — added env switching (env-local/env-prod/env-status, MODE= flag), mobile targets (mobile, mobile-setup, mobile-firebase, EAS builds), database
  utils (db-shell, db-time, db-time-reset), shell access (shell-backend, shell-db, shell-redis), makemigrations, dev-all, reorganized help

  .gitignore — added .env.production and .env.*.bak

  **Test plan**

  - Run make env and verify both .env.local and .env.production are generated correctly
  - Verify make env-local / make env-prod switches the symlink
  - Verify make env-status shows correct profile and Firebase file status
  - Run make dev and confirm backend + frontend start normally
  - Run make mobile-firebase with no args and verify usage is printed
  - Run make makemigrations and confirm it works
  - Run make help and verify all sections render cleanly

Closes #397 