### PR TITLE
test(api): fix backend test suite teardown race

### DIFF
--- a/backend/api/tests/unit/test_tag_hierarchy.py
+++ b/backend/api/tests/unit/test_tag_hierarchy.py
@@ -1,15 +1,15 @@
 """
 Tests for Tag model hierarchy fields (parent_qid, entity_type, depth).
-
-Phase 1.1 RED tests — these should fail until the model migration is applied.
 """
-from django.test import TestCase
+import pytest
 
 from api.models import Tag
 
 
-class TagHierarchyFieldsTestCase(TestCase):
-    """Test that Tag model has hierarchy fields."""
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestTagHierarchyFields:
+    """Tag model has hierarchy fields."""
 
     def test_tag_has_parent_qid_field(self):
         """Tag with parent_qid persists and is retrievable."""
@@ -17,7 +17,7 @@ class TagHierarchyFieldsTestCase(TestCase):
             id='Q28865', name='Python', parent_qid='Q9143'
         )
         tag.refresh_from_db()
-        self.assertEqual(tag.parent_qid, 'Q9143')
+        assert tag.parent_qid == 'Q9143'
 
     def test_tag_has_entity_type_field(self):
         """Tag with entity_type persists."""
@@ -25,30 +25,30 @@ class TagHierarchyFieldsTestCase(TestCase):
             id='Q28865', name='Python', entity_type='technology'
         )
         tag.refresh_from_db()
-        self.assertEqual(tag.entity_type, 'technology')
+        assert tag.entity_type == 'technology'
 
     def test_tag_has_depth_field(self):
         """Depth defaults to 0 and can be set to other values."""
         tag_default = Tag.objects.create(id='Q9143', name='Programming language')
-        self.assertEqual(tag_default.depth, 0)
+        assert tag_default.depth == 0
 
         tag_with_depth = Tag.objects.create(
             id='Q28865', name='Python', depth=1
         )
         tag_with_depth.refresh_from_db()
-        self.assertEqual(tag_with_depth.depth, 1)
+        assert tag_with_depth.depth == 1
 
     def test_parent_qid_nullable(self):
         """Existing tags work fine with parent_qid=None."""
         tag = Tag.objects.create(id='Q28865', name='Python')
         tag.refresh_from_db()
-        self.assertIsNone(tag.parent_qid)
+        assert tag.parent_qid is None
 
     def test_entity_type_blank_by_default(self):
         """New tags have entity_type=None by default."""
         tag = Tag.objects.create(id='Q28865', name='Python')
         tag.refresh_from_db()
-        self.assertIsNone(tag.entity_type)
+        assert tag.entity_type is None
 
     def test_all_hierarchy_fields_together(self):
         """Tag can store all hierarchy fields at once."""
@@ -60,9 +60,9 @@ class TagHierarchyFieldsTestCase(TestCase):
             depth=1,
         )
         tag.refresh_from_db()
-        self.assertEqual(tag.parent_qid, 'Q9143')
-        self.assertEqual(tag.entity_type, 'technology')
-        self.assertEqual(tag.depth, 1)
+        assert tag.parent_qid == 'Q9143'
+        assert tag.entity_type == 'technology'
+        assert tag.depth == 1
 
     def test_entity_type_choices_are_valid(self):
         """All expected entity type values can be stored."""
@@ -75,4 +75,4 @@ class TagHierarchyFieldsTestCase(TestCase):
                 id=f'Q{10000 + i}', name=f'Test {et}', entity_type=et
             )
             tag.refresh_from_db()
-            self.assertEqual(tag.entity_type, et)
+            assert tag.entity_type == et


### PR DESCRIPTION
## Summary

- Refactor `api/tests/unit/test_tag_hierarchy.py` from `django.test.TestCase` to pytest-django style.
- Drops the shared-DB-teardown side effect that left subsequent pytest-django tests running against a torn-down schema, manifesting as `TestUserLocationField` failures with `column "featured_achievement_id" of relation "api_user" does not exist`.
- Aligns with the existing convention in `api/tests/unit/test_models.py` (plain class + `@pytest.mark.django_db` + `@pytest.mark.unit` + plain `assert`).

Class renamed to `TestTagHierarchyFields` so it matches `python_classes = Test*` in `pytest.ini` and is collected by pytest's normal class discovery rather than Django's TestCase machinery.

Closes #369

## Test plan

- [ ] `cd backend && .venv/bin/python -m pytest api/tests/unit/test_tag_hierarchy.py api/tests/unit/test_user_profile_skills.py -v` passes with 0 failures and 0 errors (per acceptance criteria).
- [ ] `make test` clean (no regressions).
- [ ] Pytest collection verified locally: 7 tests under `TestTagHierarchyFields` are picked up.