### PR TITLE
fix(web,mobile): keep websockets reconnecting + render hygiene

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -438,7 +438,7 @@ export function MapView({ services, height = '400px', onServiceClick, userLocati
       canvas.removeEventListener('webglcontextlost', onLost)
       canvas.removeEventListener('webglcontextrestored', onRestored)
     }
-  })
+  }, [])
 
   // Fly to user location only on the FIRST time it becomes available
   const didFlyToUser = useRef(false)

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -32,6 +32,7 @@ export function useWebSocket({
   const [reconnectAttempts, setReconnectAttempts] = useState(0)
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const stableTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const openedAtRef = useRef<number>(0)
   const connectedUrlRef = useRef<string | null>(null)
   const onMessageRef = useRef(onMessage)
@@ -69,7 +70,14 @@ export function useWebSocket({
       ws.onopen = () => {
         openedAtRef.current = Date.now()
         setIsConnected(true)
-        setReconnectAttempts(0)
+        // Reset the reconnect budget only after the connection has been stable
+        // for >2s, so flapping connections (open→close→open) don't keep
+        // refilling credits and masking a chronically broken socket.
+        if (stableTimerRef.current) clearTimeout(stableTimerRef.current)
+        stableTimerRef.current = setTimeout(() => {
+          setReconnectAttempts(0)
+          stableTimerRef.current = null
+        }, 2000)
         onOpenRef.current?.()
       }
 
@@ -93,6 +101,10 @@ export function useWebSocket({
       ws.onclose = (event) => {
         setIsConnected(false)
         connectedUrlRef.current = null
+        if (stableTimerRef.current) {
+          clearTimeout(stableTimerRef.current)
+          stableTimerRef.current = null
+        }
         onCloseRef.current?.()
 
         // 4xxx = application-level rejection — never retry.
@@ -122,6 +134,10 @@ export function useWebSocket({
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current)
       reconnectTimeoutRef.current = null
+    }
+    if (stableTimerRef.current) {
+      clearTimeout(stableTimerRef.current)
+      stableTimerRef.current = null
     }
     if (wsRef.current) {
       wsRef.current.close(1000)

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -387,11 +387,6 @@ const UserProfile = () => {
       setReviewsAsTaker(rTaker.results)
       setReviewsAsOrganizer(rOrganizer.results)
     }).catch(() => {}).finally(() => setReviewsLoading(false))
-    setEventsLoading(true)
-    handshakeAPI.list(ac.signal)
-      .then((list) => setEventHandshakes(list.filter((h) => h.service_type === 'Event')))
-      .catch(() => {})
-      .finally(() => setEventsLoading(false))
     return () => ac.abort()
   }, [user])
 

--- a/mobile-client/src/hooks/useNotificationSocket.ts
+++ b/mobile-client/src/hooks/useNotificationSocket.ts
@@ -96,7 +96,18 @@ export function useNotificationSocket() {
     const handleAppState = (nextState: AppStateStatus) => {
       if (nextState === 'active') {
         const ws = wsRef.current;
-        if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          // iOS often suspends the socket in CLOSING. Force-close with a
+          // normal closure code so the original onclose skips its
+          // scheduleReconnect path, then reconnect atomically.
+          if (ws && ws.readyState !== WebSocket.CLOSED) {
+            ws.close(1000);
+            wsRef.current = null;
+          }
+          if (reconnectTimeoutRef.current) {
+            clearTimeout(reconnectTimeoutRef.current);
+            reconnectTimeoutRef.current = null;
+          }
           enabledRef.current = true;
           reconnectAttemptsRef.current = 0;
           connect();


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  Two small but real bug clusters that compound silently in production.                                                                                                                                              
                                                                              
  ### #451 — Real-time connections silently die                                                                                                                                                                      
                                                                              
  - **Web (`useWebSocket.ts`)** — the `reconnectAttempts` budget was reset eagerly inside `onopen`. A flapping connection (`open → close < 2s → open`) refilled the credits indefinitely, hiding the underlying      
  instability. The reset is now gated behind a 2-second stability timer that gets cleared on close or disconnect.
  - **Mobile (`useNotificationSocket.ts`)** — on foreground, the handler now treats any non-OPEN socket as broken: it force-closes the existing socket with code 1000 (so the original `onclose` skips               
  `scheduleReconnect`) and immediately calls `connect()`. This fixes the iOS quirk where the socket sticks in CLOSING after backgrounding and the user gets no notifications until app restart.                      
                                                                                                                                                                                                                     
  ### #454 — Frontend render hygiene                                                                                                                                                                                 
                                                                                                                                                                                                                     
  - `UserProfile.tsx` was running the same `handshakeAPI.list` call twice in the same effect. Removed the duplicate block.                                                                                           
  - `MapView.tsx`'s WebGL context-loss/restore listener effect was missing its dependency array (`})` instead of `}, [])`), so it cleanup-and-rebind every render. Added `[]`.                                       
                                                                                                                                                                                                                     
  Closes #451                                                                                                                                                                                                        
  Closes #454                                                                                                                                                                                                        
                                                                                                                                                                                                                     
  ## Test plan                                                                
                                      
  - [ ] **Repro #451 (2a)**: open the app, kill wifi for ~10s, restore — repeat 6×. After the 6th drop, chat/notifications still arrive.                                                                             
  - [ ] **Repro #451 (2b)**: background the iOS app, leave for >30s, foreground — push notifications continue to arrive without an app restart.
  - [ ] **Repro #454 (a)**: open DevTools → Network on `/profile`. Only one `GET /api/handshakes/` request fires per mount.                                                                                          
  - [ ] **Repro #454 (b)**: profile MapView mounts. Listener bind/unbind events fire once, not on every render.                                                                                                      
  - [ ] `cd frontend && npm run build` clean.                                                                                                                                                                        
  - [ ] `cd mobile-client && npm test` green.       