### PR TITLE
fix(timebank): defer cache invalidation to transaction.on_commit

### DIFF
--- a/backend/api/tests/integration/test_timebank_cache_invalidation.py
+++ b/backend/api/tests/integration/test_timebank_cache_invalidation.py
@@ -1,0 +1,98 @@
+"""Integration tests for #348 — Redis invalidation in provision_timebank
+and cancel_timebank_transfer must run on commit, not while the row lock is
+held, and must NOT run when the surrounding transaction rolls back.
+"""
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.db import transaction
+
+from api.tests.helpers.factories import HandshakeFactory, ServiceFactory, UserFactory
+from api.utils import cancel_timebank_transfer, provision_timebank
+
+
+def _build_offer_handshake(receiver_balance: Decimal = Decimal('5.00')):
+    provider = UserFactory(timebank_balance=Decimal('5.00'))
+    receiver = UserFactory(timebank_balance=receiver_balance)
+    service = ServiceFactory(user=provider, type='Offer', duration=Decimal('2.00'))
+    handshake = HandshakeFactory(
+        service=service,
+        requester=receiver,
+        status='accepted',
+        provisioned_hours=Decimal('2.00'),
+    )
+    return provider, receiver, service, handshake
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.integration
+class TestProvisionTimebankInvalidation:
+    """provision_timebank wraps Redis invalidation in transaction.on_commit()."""
+
+    def test_invalidations_run_after_commit_on_success(self):
+        _, _, _, handshake = _build_offer_handshake()
+
+        with patch('api.utils.invalidate_conversations') as inv_conv, \
+             patch('api.utils.invalidate_transactions') as inv_tx:
+            with transaction.atomic():
+                provision_timebank(handshake)
+                # While still inside the atomic block, neither callable
+                # should have run yet — they're queued via on_commit.
+                inv_conv.assert_not_called()
+                inv_tx.assert_not_called()
+
+            # After the outer transaction commits, on_commit fires.
+            assert inv_conv.call_count == 2  # receiver + provider
+            assert inv_tx.call_count == 1    # receiver only on provision
+
+    def test_invalidations_skipped_on_rollback(self):
+        _, _, _, handshake = _build_offer_handshake()
+
+        with patch('api.utils.invalidate_conversations') as inv_conv, \
+             patch('api.utils.invalidate_transactions') as inv_tx:
+            try:
+                with transaction.atomic():
+                    provision_timebank(handshake)
+                    raise RuntimeError('forced rollback for the test')
+            except RuntimeError:
+                pass
+
+            # Cache invalidation must NOT fire on rollback — otherwise we'd
+            # purge cache for state that never persisted.
+            inv_conv.assert_not_called()
+            inv_tx.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.integration
+class TestCancelTimebankInvalidation:
+    """cancel_timebank_transfer wraps Redis invalidation in transaction.on_commit()."""
+
+    def test_invalidations_run_after_commit_on_success(self):
+        _, _, _, handshake = _build_offer_handshake()
+
+        with patch('api.utils.invalidate_conversations') as inv_conv, \
+             patch('api.utils.invalidate_transactions') as inv_tx:
+            with transaction.atomic():
+                cancel_timebank_transfer(handshake)
+                inv_conv.assert_not_called()
+                inv_tx.assert_not_called()
+
+            assert inv_conv.call_count == 2  # receiver + provider
+            assert inv_tx.call_count == 2    # receiver + provider on cancel
+
+    def test_invalidations_skipped_on_rollback(self):
+        _, _, _, handshake = _build_offer_handshake()
+
+        with patch('api.utils.invalidate_conversations') as inv_conv, \
+             patch('api.utils.invalidate_transactions') as inv_tx:
+            try:
+                with transaction.atomic():
+                    cancel_timebank_transfer(handshake)
+                    raise RuntimeError('forced rollback for the test')
+            except RuntimeError:
+                pass
+
+            inv_conv.assert_not_called()
+            inv_tx.assert_not_called()

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -116,10 +116,20 @@ def provision_timebank(handshake: Handshake) -> bool:
         )
         
         provider, _ = get_provider_and_receiver(handshake)
-        invalidate_conversations(str(receiver.id))
-        invalidate_conversations(str(provider.id))
-        invalidate_transactions(str(receiver.id))
-        
+        receiver_id = str(receiver.id)
+        provider_id = str(provider.id)
+
+        def _invalidate_after_commit() -> None:
+            invalidate_conversations(receiver_id)
+            invalidate_conversations(provider_id)
+            invalidate_transactions(receiver_id)
+
+        # Defer Redis SCAN+DEL until after the row lock is released and the
+        # transaction has actually committed — running these inside the atomic
+        # block both stretches the lock window and risks invalidating cache
+        # for a transaction that ends up rolling back.
+        transaction.on_commit(_invalidate_after_commit)
+
         return True
 
 def _is_group_one_time_service(service: Service) -> bool:
@@ -259,10 +269,19 @@ def cancel_timebank_transfer(handshake: Handshake) -> bool:
         )
         
         provider, _ = get_provider_and_receiver(handshake)
-        invalidate_conversations(str(receiver.id))
-        invalidate_conversations(str(provider.id))
-        invalidate_transactions(str(receiver.id))
-        invalidate_transactions(str(provider.id))
+        receiver_id = str(receiver.id)
+        provider_id = str(provider.id)
+
+        def _invalidate_after_commit() -> None:
+            invalidate_conversations(receiver_id)
+            invalidate_conversations(provider_id)
+            invalidate_transactions(receiver_id)
+            invalidate_transactions(provider_id)
+
+        # Defer Redis SCAN+DEL until after commit — same reasoning as
+        # provision_timebank: keep the row lock short and avoid invalidating
+        # cache for a rolled-back transaction.
+        transaction.on_commit(_invalidate_after_commit)
 
     handshake.status = "cancelled"
     handshake.save(update_fields=["status"])


### PR DESCRIPTION
## Summary                                                          
                                                                                                                                                                                                                     
  `provision_timebank` and `cancel_timebank_transfer` were calling Redis `invalidate_conversations` / `invalidate_transactions` *inside* `transaction.atomic()` while the `select_for_update()` row lock on the user 
  was still held. That had two real consequences:                                                                                                                                                                    
                                                                                                                                                                                                                     
  1. Stretched lock window — `invalidate_transactions` runs a Redis `SCAN + DEL` over matching keys; that network round-trip was happening with the Postgres row lock open, blocking concurrent writes against the
  same user.                                                                                                                                                                                                         
  2. Cache invalidated on rollback — if the surrounding transaction rolled back, we'd already have purged Redis for state that never persisted.
                                                                                                                                                                                                                     
  `complete_timebank_transfer` already does this correctly via `transaction.on_commit()`. This PR brings the other two functions onto the same pattern.
                                                                                                                                                                                                                     
  Closes #348                                                                                                                                                                                                        
                                                      
  ## Files                                                                                                                                                                                                           
                                                                                                                                                                                                                     
  - `backend/api/utils.py` — wrap the Redis calls in `transaction.on_commit()` in both functions                                                                                                                     
  - `backend/api/tests/integration/test_timebank_cache_invalidation.py` — 4 new tests:                                                                                                                               
    - provision: invalidations run after commit, not during the lock                                                                                                                                                 
    - provision: invalidations skipped on rollback                             
    - cancel: invalidations run after commit                          
    - cancel: invalidations skipped on rollback                       
                                                                                                                                                                                                                     
  ## Test plan                                        
                                                                                                                                                                                                                     
  - [ ] `cd backend && .venv/bin/python -m pytest api/tests/integration/test_timebank_cache_invalidation.py -v` — 4 green                                                                                            
  - [ ] `cd backend && .venv/bin/python -m pytest api/tests/unit/test_utils.py api/tests/integration/test_handshake_api.py -v` — existing timebank tests still green (no regressions)                                
  - [ ] `make test` — full backend suite green; coverage ≥ 70   