### PR TITLE
feat(ranking): add proximity decay factor to the hot recommendation feed

### DIFF
--- a/backend/api/ranking.py
+++ b/backend/api/ranking.py
@@ -79,6 +79,27 @@ def apply_stochastic_social_proximity(boosts: dict, probability: float, rng=None
     }
 
 
+def proximity_multiplier(distance_km, half_life_km: float) -> float:
+    """Smooth distance decay used as a Phase 2 ranking factor.
+
+    Returns 1 / (1 + distance_km / half_life_km), bounded at 1.0 from above.
+    A service at the viewer's location keeps full score, a service at the
+    half life distance keeps half its score, and the curve approaches zero
+    asymptotically at very large distances.
+
+    Returns 1.0 (no effect) when distance_km is None (viewer location
+    unknown), when half_life_km is non-positive, or when the distance is
+    non-positive (defensive against PostGIS rounding noise).
+    """
+    if distance_km is None:
+        return 1.0
+    if half_life_km is None or half_life_km <= 0:
+        return 1.0
+    if distance_km <= 0:
+        return 1.0
+    return 1.0 / (1.0 + distance_km / half_life_km)
+
+
 def wilson_score_lower_bound(positives: int, total: int, z: float = 1.96) -> float:
     """
     Wilson score lower bound for the positive rate of a Bernoulli sample.

--- a/backend/api/tests/unit/test_proximity_ranking.py
+++ b/backend/api/tests/unit/test_proximity_ranking.py
@@ -1,0 +1,133 @@
+"""Tests for proximity as a ranking factor (issue #479).
+
+When the viewer has a known location, services closer to the viewer should
+rank higher on the hot feed even when the user has not set an explicit
+distance filter. The factor is 1 / (1 + distance_km / half_life_km), so a
+service at the viewer's location keeps full score, a service at the half life
+distance keeps half its score, and the curve decays smoothly. When the viewer
+has no known location the factor is 1.0 and ranking is unchanged.
+"""
+import pytest
+from django.test import override_settings
+
+
+class TestProximityMultiplier:
+    """Pure unit tests for the multiplier helper."""
+
+    def test_zero_distance_returns_one(self):
+        from api.ranking import proximity_multiplier
+
+        assert proximity_multiplier(0.0, half_life_km=10.0) == 1.0
+
+    def test_at_half_life_returns_one_half(self):
+        from api.ranking import proximity_multiplier
+
+        assert proximity_multiplier(10.0, half_life_km=10.0) == pytest.approx(0.5)
+
+    def test_at_three_half_lives_returns_one_quarter(self):
+        from api.ranking import proximity_multiplier
+
+        assert proximity_multiplier(30.0, half_life_km=10.0) == pytest.approx(0.25)
+
+    def test_none_distance_returns_one(self):
+        from api.ranking import proximity_multiplier
+
+        assert proximity_multiplier(None, half_life_km=10.0) == 1.0
+
+    def test_negative_distance_clamps_to_one(self):
+        from api.ranking import proximity_multiplier
+
+        # Defensive: negative distances should not produce > 1.0 multipliers.
+        assert proximity_multiplier(-5.0, half_life_km=10.0) == 1.0
+
+    def test_invalid_half_life_returns_one(self):
+        from api.ranking import proximity_multiplier
+
+        assert proximity_multiplier(10.0, half_life_km=0.0) == 1.0
+        assert proximity_multiplier(10.0, half_life_km=-1.0) == 1.0
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestProximityComposite:
+    """Verify the composite score annotation built by the hot sort path
+    in ServiceViewSet ranks closer services ahead of farther ones when
+    base hot scores are equal."""
+
+    def _make_authenticated_request(self, user, params):
+        from rest_framework.request import Request
+        from rest_framework.test import APIRequestFactory
+
+        factory = APIRequestFactory()
+        django_request = factory.get('/api/services/', params)
+        request = Request(django_request)
+        request.user = user
+        return request
+
+    def _make_service_with(self, owner, lat, lng, hot_score):
+        from decimal import Decimal as Dec
+        from api.models import Service
+        from api.tests.helpers.factories import ServiceFactory
+
+        svc = ServiceFactory(
+            user=owner, type='Offer', status='Active',
+            location_lat=Dec(str(lat)), location_lng=Dec(str(lng)),
+        )
+        Service.objects.filter(pk=svc.id).update(hot_score=hot_score)
+        svc.refresh_from_db()
+        return svc
+
+    def test_closer_service_outranks_equally_hot_farther_service(self):
+        from datetime import timedelta
+        from django.utils import timezone
+
+        from api.tests.helpers.factories import UserFactory
+        from api.views import ServiceViewSet
+
+        viewer = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+
+        # Both services within the LocationStrategy filter radius (20km),
+        # both with the same stored hot_score. Proximity should break the tie.
+        near = self._make_service_with(owner, lat=0.001, lng=0.0, hot_score=5.0)
+        far = self._make_service_with(owner, lat=0.05, lng=0.0, hot_score=5.0)
+
+        request = self._make_authenticated_request(
+            viewer,
+            {'sort': 'hot', 'lat': '0.0', 'lng': '0.0', 'distance': '20'},
+        )
+        viewset = ServiceViewSet()
+        viewset.action = 'list'
+        viewset.request = request
+        with override_settings(RANKING_PROXIMITY_HALF_LIFE_KM=10.0):
+            qs = viewset.get_queryset()
+            ordered_ids = list(qs.values_list('id', flat=True))
+
+        assert near.id in ordered_ids
+        assert far.id in ordered_ids
+        assert ordered_ids.index(near.id) < ordered_ids.index(far.id), (
+            'Closer service should outrank an equally hot farther service'
+        )
+
+    def test_no_viewer_location_preserves_hot_score_ordering(self):
+        from datetime import timedelta
+        from django.utils import timezone
+
+        from api.tests.helpers.factories import UserFactory
+        from api.views import ServiceViewSet
+
+        viewer = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+
+        higher = self._make_service_with(owner, lat=0.0, lng=0.0, hot_score=5.0)
+        lower = self._make_service_with(owner, lat=0.0, lng=0.0, hot_score=1.0)
+
+        request = self._make_authenticated_request(viewer, {'sort': 'hot'})
+        viewset = ServiceViewSet()
+        viewset.action = 'list'
+        viewset.request = request
+        with override_settings(RANKING_PROXIMITY_HALF_LIFE_KM=10.0):
+            qs = viewset.get_queryset()
+            ordered_ids = list(qs.values_list('id', flat=True))
+
+        assert ordered_ids.index(higher.id) < ordered_ids.index(lower.id)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1939,38 +1939,65 @@ class ServiceViewSet(viewsets.ModelViewSet):
         lng_param = self.request.query_params.get('lng')
         sort_param = self.request.query_params.get('sort', 'latest')
         
-        # If location-based search, distance ordering takes priority
-        if is_valid_coordinate(lat_param) and is_valid_coordinate(lng_param):
-            queryset = queryset.order_by('-is_pinned', *queryset.query.order_by)
-        elif sort_param == 'hot':
+        # Hot sort wraps both viewer-aware factors (proximity + social).
+        # When the viewer has a location, hot_score is multiplied by a
+        # distance-decay factor so closer services rank higher even when
+        # base scores are equal. When the viewer has no location, the
+        # multiplier is 1.0 and ordering matches today's hot behavior.
+        if sort_param == 'hot':
+            from .ranking import apply_stochastic_social_proximity
+
+            proximity_active = (
+                is_valid_coordinate(lat_param) and is_valid_coordinate(lng_param)
+            )
+            half_life_km = getattr(settings, 'RANKING_PROXIMITY_HALF_LIFE_KM', 10.0)
+            if proximity_active and half_life_km > 0:
+                # PostGIS Distance annotation is in metres (srid=4326).
+                proximity_expr = ExpressionWrapper(
+                    Value(1.0, output_field=FloatField()) / (
+                        Value(1.0, output_field=FloatField())
+                        + F('distance') / Value(
+                            1000.0 * half_life_km, output_field=FloatField()
+                        )
+                    ),
+                    output_field=FloatField(),
+                )
+            else:
+                proximity_expr = Value(1.0, output_field=FloatField())
+            queryset = queryset.annotate(proximity_factor=proximity_expr)
+
+            social_addend = Value(0.0, output_field=FloatField())
             if self.request.user.is_authenticated:
-                # Apply social proximity boost (weight 0.5) for authenticated users.
-                # composite_score = hot_score + 0.5 * social_boost
-                # social_boost: 1.0 (1st-degree) or 0.5 (2nd-degree), 0 otherwise.
-                # Single SQL CTE call — no pre-evaluation of the service queryset.
-                from .ranking import apply_stochastic_social_proximity
                 boosts = get_social_proximity_boosts(self.request.user.id)
                 boosts = apply_stochastic_social_proximity(
                     boosts,
                     getattr(settings, 'RANKING_SOCIAL_PROXIMITY_PROBABILITY', 1.0),
                 )
                 if boosts:
-                    # boosts keys are UUID objects; user_id on Service is also UUID — no coercion needed.
                     whens = [
                         When(user_id=uid, then=Value(boost, output_field=FloatField()))
                         for uid, boost in boosts.items()
                     ]
                     queryset = queryset.annotate(
-                        social_boost=Case(*whens, default=Value(0.0, output_field=FloatField()), output_field=FloatField()),
-                        composite_score=ExpressionWrapper(
-                            F('hot_score') + Value(0.5, output_field=FloatField()) * F('social_boost'),
+                        social_boost=Case(
+                            *whens,
+                            default=Value(0.0, output_field=FloatField()),
                             output_field=FloatField(),
                         ),
-                    ).order_by('-is_pinned', '-composite_score', '-created_at')
-                else:
-                    queryset = queryset.order_by('-is_pinned', '-hot_score', '-created_at')
-            else:
-                queryset = queryset.order_by('-is_pinned', '-hot_score', '-created_at')
+                    )
+                    social_addend = Value(
+                        0.5, output_field=FloatField()
+                    ) * F('social_boost')
+
+            queryset = queryset.annotate(
+                composite_score=ExpressionWrapper(
+                    F('hot_score') * F('proximity_factor') + social_addend,
+                    output_field=FloatField(),
+                ),
+            ).order_by('-is_pinned', '-composite_score', '-created_at')
+        elif is_valid_coordinate(lat_param) and is_valid_coordinate(lng_param):
+            # Non-hot sorts with a location: distance-only ordering, as before.
+            queryset = queryset.order_by('-is_pinned', *queryset.query.order_by)
         else:
             # Default: sort by latest (created_at descending)
             queryset = queryset.order_by('-is_pinned', '-created_at')

--- a/backend/hive_project/settings.py
+++ b/backend/hive_project/settings.py
@@ -874,3 +874,10 @@ RANKING_NEWCOMER_BOOST = float(os.environ.get('RANKING_NEWCOMER_BOOST', '1.2'))
 RANKING_NEWCOMER_BOOST_PROBABILITY = float(os.environ.get('RANKING_NEWCOMER_BOOST_PROBABILITY', '1.0'))
 RANKING_CAPACITY_BOOST_PROBABILITY = float(os.environ.get('RANKING_CAPACITY_BOOST_PROBABILITY', '1.0'))
 RANKING_SOCIAL_PROXIMITY_PROBABILITY = float(os.environ.get('RANKING_SOCIAL_PROXIMITY_PROBABILITY', '1.0'))
+
+# Proximity ranking factor (#479). Distance decay applied to the hot score on
+# the recommendation feed when the viewer has a known location. The
+# multiplier is 1 / (1 + distance_km / half_life_km); a service at the half
+# life distance keeps half its score. Skipped when the viewer has no
+# location (multiplier = 1.0).
+RANKING_PROXIMITY_HALF_LIFE_KM = float(os.environ.get('RANKING_PROXIMITY_HALF_LIFE_KM', '10.0'))


### PR DESCRIPTION
## Summary

Proximity becomes a real ranking factor on the hot feed instead of being a hard filter only when lat/lng are passed. When the viewer has a known location, `hot_score` is multiplied by `1 / (1 + distance_km / RANKING_PROXIMITY_HALF_LIFE_KM)` (default half life 10km). A service at the viewer's location keeps full score, one at the half life keeps half. Without a viewer location the multiplier is 1.0 and ordering matches today's hot feed.

The hot path in `ServiceViewSet` now always builds a composite score from `hot_score`, the proximity factor, and the social boost. `sort=latest` with location is unchanged.

Refs #479

## Test plan

- [ ] `cd backend && .venv/bin/python -m pytest api/tests/unit/test_proximity_ranking.py api/tests/unit/test_ranking.py api/tests/integration/test_service_hot_social_boost.py`
- [ ] `make dev`, log in with location enabled, confirm closer services rise above further ones for the same viewer when their stored hot scores are similar
- [ ] Without location enabled, confirm ordering matches today's hot feed
- [ ] `sort=latest` with `lat`/`lng` still orders by distance
