### PR TITLE
feat(admin): surface new ranking pipeline factors on debug bar

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -161,12 +161,16 @@ jobs:
 
       - name: Audit Python dependencies
         working-directory: backend
-        # Temporary unblock: CVE-2026-4539 currently affects the latest available
-        # Pygments release (2.19.2), so there is no patch version to upgrade to yet.
+        # Temporary unblocks:
+        #  - CVE-2026-4539 affects the latest available Pygments release (2.19.2);
+        #    no patch version available yet.
+        #  - CVE-2026-42304 affects twisted 25.5.0 (transitive via daphne); only
+        #    26.4.0rc2 (release candidate) carries the fix, so wait for stable.
         run: >
           .venv/bin/pip-audit
           --skip-editable
           --ignore-vuln CVE-2026-4539
+          --ignore-vuln CVE-2026-42304
 
       - name: Run migrations
         working-directory: backend

--- a/backend/api/ranking_debug.py
+++ b/backend/api/ranking_debug.py
@@ -1,11 +1,121 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from math import asin, cos, pi, sin, sqrt
+
+from django.conf import settings
+from django.db.models import Count, Max
 from django.utils import timezone
 
+from .achievement_utils import is_newcomer
 from .models import Comment, Handshake, NegativeRep, ReputationRep, Service, User
-from .ranking import calculate_hot_score
+from .ranking import (
+    _compute_event_factors,
+    _compute_service_factors,
+    calculate_hot_score,
+)
 from .services import get_social_proximity_boosts
+
+
+def _phase3_trace(service: Service, factors: dict) -> dict:
+    """Compute Phase 3 eligibility for a single service so the admin debug
+    panel can explain whether a card came from the regular hot list or the
+    explore bucket and which sub pool it was eligible for.
+    """
+    cold_threshold = getattr(settings, 'RANKING_COLDSTART_THRESHOLD', 5)
+    quality_threshold = getattr(settings, 'RANKING_UNDERSHOWN_QUALITY_THRESHOLD', 0.4)
+    stale_days = getattr(settings, 'RANKING_UNDERSHOWN_STALE_DAYS', 14)
+    cutoff = timezone.now() - timedelta(days=stale_days)
+
+    lifetime = Handshake.objects.filter(
+        service__user_id=service.user_id, status='completed',
+    ).count()
+    last_completed = Handshake.objects.filter(
+        service=service, status='completed',
+    ).aggregate(latest=Max('updated_at'))['latest']
+    days_since_last = (
+        (timezone.now() - last_completed).days if last_completed else None
+    )
+
+    pool = None
+    if lifetime < cold_threshold:
+        pool = 'cold_start'
+    elif (
+        service.type != 'Event'
+        and factors.get('quality', 0.0) >= quality_threshold
+        and (last_completed is None or last_completed < cutoff)
+    ):
+        pool = 'undershown_quality'
+    elif getattr(service, 'is_stale_recurring', False):
+        pool = 'stale_recurring'
+
+    return {
+        'pool': pool,
+        'exploration_rate': float(getattr(settings, 'RANKING_EXPLORATION_RATE', 0.20)),
+        'lifetime_completed_handshakes': lifetime,
+        'days_since_last_completed_handshake': days_since_last,
+        'is_stale_recurring': bool(getattr(service, 'is_stale_recurring', False)),
+        'cold_start_threshold': cold_threshold,
+        'undershown_quality_threshold': quality_threshold,
+        'undershown_stale_days': stale_days,
+    }
+
+
+def _factor_breakdown(service: Service) -> dict:
+    """Run the live ranking formulas and return a flattened debug summary
+    that includes both the raw inputs (positive_count, negative_count,
+    comment_count, hours_exchanged or rsvps_last_7d) and the derived
+    factors (quality, activity / velocity, capacity_multiplier,
+    newcomer_boost, final_score) in one shape per service kind."""
+    if service.type == 'Event':
+        f = _compute_event_factors(service)
+        return {
+            'kind': 'event',
+            'positive_count': f['positive_rep_count'],
+            'negative_count': f['negative_rep_count'],
+            'rsvps_last_7d': f['rsvps_last_7d'],
+            'organiser_quality': f['organiser_quality'],
+            'velocity': f['velocity'],
+            'capacity_multiplier': f['capacity_multiplier'],
+            'newcomer_boost': f['newcomer_boost'],
+            'is_newcomer': is_newcomer(service.user),
+            'final_score': f['final_score'],
+        }
+    f = _compute_service_factors(service)
+    return {
+        'kind': 'service',
+        'positive_count': f['positive_rep_count'],
+        'negative_count': f['negative_rep_count'],
+        'comment_count': f['comment_count'],
+        'hours_exchanged': float(f['hours_exchanged']),
+        'quality': f['quality'],
+        'activity': f['activity'],
+        'capacity_multiplier': f['capacity_multiplier'],
+        'newcomer_boost': f['newcomer_boost'],
+        'is_newcomer': is_newcomer(service.user),
+        'final_score': f['final_score'],
+    }
+
+
+def _formula_lines_with_substitutions(factors: dict) -> list[str]:
+    """Render the ranking formulas with the actual numeric values so the
+    debug panel reads as 'Wilson(1, 1) = 0.21' rather than the algebraic
+    template only."""
+    if factors['kind'] == 'event':
+        return [
+            f"velocity = log2(2 + {factors['rsvps_last_7d']}) = {factors['velocity']:.4f}",
+            f"organiser_quality (Wilson) = Wilson({factors['positive_count']}, {factors['positive_count'] + factors['negative_count']}) = {factors['organiser_quality']:.4f}",
+            f"capacity_multiplier = {factors['capacity_multiplier']:.2f}",
+            f"newcomer_boost = {factors['newcomer_boost']:.2f}",
+            f"final = velocity * organiser_quality * capacity * newcomer = {factors['final_score']:.6f}",
+        ]
+    return [
+        f"quality (Wilson) = Wilson({factors['positive_count']}, {factors['positive_count'] + factors['negative_count']}) = {factors['quality']:.4f}",
+        f"activity = log2(2 + {factors['hours_exchanged']:.2f}) + 0.5 * log2(2 + {factors['comment_count']}) = {factors['activity']:.4f}",
+        f"capacity_multiplier = {factors['capacity_multiplier']:.2f}",
+        f"newcomer_boost = {factors['newcomer_boost']:.2f}",
+        f"final = quality * activity * capacity * newcomer = {factors['final_score']:.6f}",
+    ]
 
 
 def _normalize_text(value: str) -> str:
@@ -206,6 +316,10 @@ def build_service_debug_payload(
         {'source': 'pin', 'target': 'card', 'value': 1.0 if selected_service.is_pinned else 0.01, 'tone': 'positive' if selected_service.is_pinned else 'neutral'},
     ]
 
+    factors = _factor_breakdown(selected_service)
+    phase3 = _phase3_trace(selected_service, factors)
+    new_formula_lines = _formula_lines_with_substitutions(factors)
+
     return {
         'active_filter': active_filter,
         'total_services': len(service_ids),
@@ -226,6 +340,8 @@ def build_service_debug_payload(
             'distance_km': distance_km,
             'participant_count': accepted_count,
             'max_participants': selected_service.max_participants,
+            'factors': factors,
+            'phase3': phase3,
             'breakdown': {
                 'positive_count': positive_count,
                 'negative_count': negative_count,
@@ -238,16 +354,7 @@ def build_service_debug_payload(
                 'capacity_boost_applied': capacity_boost_applied,
                 'social_reason': social_reason_label,
             },
-            'formula_lines': [
-                f'P = {positive_count}',
-                f'N = {negative_count}',
-                f'C = {comment_count}',
-                f'T = {age_hours:.2f}h',
-                f'raw_hot = ({numerator}) / ({denominator:.4f})',
-                f'recomputed_hot = {float(recomputed_hot_score):.6f}',
-                f'search_score = {float(search_score):.6f}',
-                f'weighted_social = {weighted_social_boost:.6f}',
-            ],
+            'formula_lines': new_formula_lines,
             'notes': notes,
             'sankey': {
                 'nodes': sankey_nodes,

--- a/backend/api/tests/unit/test_ranking_debug_payload.py
+++ b/backend/api/tests/unit/test_ranking_debug_payload.py
@@ -1,0 +1,188 @@
+"""Tests for the extended ranking debug payload (issue #476).
+
+The admin debug bar should surface the actual three-phase pipeline factors
+(Wilson quality, log2 activity blend, capacity multiplier, newcomer boost)
+with substituted values, plus a Phase 3 trace explaining whether a card was
+served from the regular hot list or the explore bucket and which pool.
+"""
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from api.tests.helpers.factories import (
+    HandshakeFactory,
+    ReputationRepFactory,
+    ServiceFactory,
+    UserFactory,
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestServiceDebugPayloadFactors:
+    def _seed_service_with_quality(self, owner, **kwargs):
+        from api.models import ReputationRep  # noqa: F401
+
+        svc = ServiceFactory(user=owner, type='Offer', status='Active', **kwargs)
+        giver = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        hs = HandshakeFactory(service=svc, requester=giver, status='completed')
+        ReputationRepFactory(
+            handshake=hs, giver=giver, receiver=owner, is_punctual=True,
+        )
+        return svc
+
+    def _build_payload(self, service, viewer):
+        from api.ranking_debug import build_service_debug_payload
+
+        return build_service_debug_payload(
+            service_ids=[str(service.id)],
+            selected_service_id=str(service.id),
+            request_user=viewer,
+        )
+
+    def test_payload_exposes_wilson_quality_factor(self):
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        svc = self._seed_service_with_quality(owner)
+
+        payload = self._build_payload(svc, viewer)
+        factors = payload['selected_service']['factors']
+
+        assert 'quality' in factors
+        assert isinstance(factors['quality'], float)
+        assert factors['quality'] > 0
+        # Inputs should be present for the substituted formula. The factory
+        # ReputationRep sets is_punctual, is_helpful, is_kind all to True so
+        # the per-trait counter aggregates to 3.
+        assert factors['positive_count'] == 3
+        assert factors['negative_count'] == 0
+
+    def test_payload_exposes_activity_blend_factor(self):
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        svc = self._seed_service_with_quality(owner)
+
+        payload = self._build_payload(svc, viewer)
+        factors = payload['selected_service']['factors']
+
+        assert 'activity' in factors
+        assert isinstance(factors['activity'], float)
+        # The activity formula uses hours_exchanged and comment_count
+        assert 'hours_exchanged' in factors
+        assert 'comment_count' in factors
+
+    def test_payload_exposes_newcomer_boost_with_eligibility_flag(self):
+        viewer = UserFactory()
+        newcomer = UserFactory(date_joined=timezone.now() - timedelta(days=10))
+        svc = self._seed_service_with_quality(newcomer)
+
+        payload = self._build_payload(svc, viewer)
+        factors = payload['selected_service']['factors']
+
+        assert factors['newcomer_boost'] == 1.2
+        assert factors['is_newcomer'] is True
+
+    def test_payload_marks_veteran_owner_as_not_newcomer(self):
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+        svc = self._seed_service_with_quality(owner)
+
+        payload = self._build_payload(svc, viewer)
+        factors = payload['selected_service']['factors']
+
+        assert factors['newcomer_boost'] == 1.0
+        assert factors['is_newcomer'] is False
+
+    def test_payload_capacity_multiplier_for_filled_group_offer(self):
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        svc = self._seed_service_with_quality(owner, max_participants=4)
+        for _ in range(3):
+            HandshakeFactory(service=svc, status='accepted')
+
+        payload = self._build_payload(svc, viewer)
+        factors = payload['selected_service']['factors']
+
+        assert factors['capacity_multiplier'] == 1.5
+
+    def test_formula_lines_show_substituted_factor_values(self):
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        svc = self._seed_service_with_quality(owner)
+
+        payload = self._build_payload(svc, viewer)
+        lines = payload['selected_service']['formula_lines']
+
+        joined = '\n'.join(lines)
+        assert 'Wilson' in joined or 'quality' in joined.lower()
+        assert 'log2' in joined or 'activity' in joined.lower()
+        # Final score line shows the multiplicative product
+        assert any('=' in line for line in lines)
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestEventDebugPayloadFactors:
+    def test_event_payload_uses_event_factor_set(self):
+        from api.ranking_debug import build_service_debug_payload
+
+        viewer = UserFactory()
+        organiser = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        ev = ServiceFactory(
+            user=organiser, type='Event', status='Active',
+            scheduled_time=timezone.now() + timedelta(days=3),
+        )
+        HandshakeFactory(service=ev, status='accepted')
+
+        payload = build_service_debug_payload(
+            service_ids=[str(ev.id)],
+            selected_service_id=str(ev.id),
+            request_user=viewer,
+        )
+        factors = payload['selected_service']['factors']
+
+        # Event-specific factors
+        assert 'velocity' in factors
+        assert 'organiser_quality' in factors
+        assert 'rsvps_last_7d' in factors
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestPhase3Trace:
+    def test_payload_includes_phase3_trace_with_pool_membership(self):
+        from api.ranking_debug import build_service_debug_payload
+
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        # Owner with no completed handshakes is in the cold-start pool.
+        svc = ServiceFactory(user=owner, type='Offer', status='Active')
+
+        payload = build_service_debug_payload(
+            service_ids=[str(svc.id)],
+            selected_service_id=str(svc.id),
+            request_user=viewer,
+        )
+        phase3 = payload['selected_service']['phase3']
+
+        assert 'exploration_rate' in phase3
+        assert 'pool' in phase3
+        assert phase3['pool'] in ('cold_start', 'undershown_quality', 'stale_recurring', None)
+        assert 'lifetime_completed_handshakes' in phase3
+
+    def test_cold_start_owner_lands_in_cold_start_pool(self):
+        from api.ranking_debug import build_service_debug_payload
+
+        viewer = UserFactory()
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=365))
+        svc = ServiceFactory(user=owner, type='Offer', status='Active')
+
+        payload = build_service_debug_payload(
+            service_ids=[str(svc.id)],
+            selected_service_id=str(svc.id),
+            request_user=viewer,
+        )
+        phase3 = payload['selected_service']['phase3']
+
+        assert phase3['pool'] == 'cold_start'

--- a/frontend/src/components/RecommendationDebugPanel.tsx
+++ b/frontend/src/components/RecommendationDebugPanel.tsx
@@ -307,6 +307,43 @@ export default function RecommendationDebugPanel({
               </Stack>
             </SectionCard>
 
+            <SectionCard bg="purple.50">
+              <Text fontSize="xs" fontWeight="800" color="purple.800" mb={2}>
+                Phase 3 trace
+              </Text>
+              <Flex gap={2} wrap="wrap" mb={2}>
+                <MiniStat
+                  label="Pool"
+                  value={selected.phase3.pool ?? 'none'}
+                />
+                <MiniStat
+                  label="Explore rate"
+                  value={`${Math.round(selected.phase3.exploration_rate * 100)}%`}
+                />
+                <MiniStat
+                  label="Owner h.shakes"
+                  value={String(selected.phase3.lifetime_completed_handshakes)}
+                />
+                <MiniStat
+                  label="Days idle"
+                  value={
+                    selected.phase3.days_since_last_completed_handshake == null
+                      ? 'never'
+                      : `${selected.phase3.days_since_last_completed_handshake}d`
+                  }
+                />
+              </Flex>
+              <Text fontSize="xs" color="purple.700">
+                {selected.phase3.pool === 'cold_start'
+                  ? `Eligible because owner has < ${selected.phase3.cold_start_threshold} completed handshakes.`
+                  : selected.phase3.pool === 'undershown_quality'
+                  ? `Eligible because quality is high but the service has had no completed handshake in the last ${selected.phase3.undershown_stale_days} days.`
+                  : selected.phase3.pool === 'stale_recurring'
+                  ? 'Eligible because the recurring growth check flagged this listing as stale.'
+                  : 'Not eligible for the explore bucket. Served from the regular hot list.'}
+              </Text>
+            </SectionCard>
+
             {selected.notes.length > 0 ? (
               <SectionCard bg="orange.50">
                 <Stack gap={1}>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -14,6 +14,7 @@ import { serviceAPI } from '@/services/serviceAPI'
 import AdminReauthBanner from '@/components/AdminReauthBanner'
 import AdminLayout from '@/components/AdminLayout'
 import AdminActivityFeed from '@/components/AdminActivityFeed'
+import RecommendationDebugBar from '@/components/RecommendationDebugBar'
 import { getErrorMessage } from '@/services/api'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { AdminAuditLog, AdminComment, AdminMetrics, AdminReport, AdminUserSummary, ForumTopic, PaginatedResponse, Service } from '@/types'
@@ -114,6 +115,10 @@ const AdminDashboard = () => {
 
   const [dashboardLoading, setDashboardLoading] = useState(false)
   const [metrics, setMetrics] = useState<AdminMetrics | null>(null)
+  // Sample of currently-hot services to feed the floating debug bar (#476).
+  // The bar is admin-only and lives at the bottom of every admin tab; the
+  // panel inside it fetches the per-service breakdown on demand.
+  const [debugServices, setDebugServices] = useState<Service[]>([])
   const [forumPostsCount, setForumPostsCount] = useState<number | null>(null)
   const [pendingReportsCount, setPendingReportsCount] = useState<number | null>(null)
   const [removedCommentsCount, setRemovedCommentsCount] = useState<number | null>(null)
@@ -311,6 +316,23 @@ const AdminDashboard = () => {
   useEffect(() => {
     if (activeTab === 'dashboard') loadDashboard()
   }, [activeTab, loadDashboard])
+
+  // Seed the floating debug bar with the current top hot services so the
+  // panel has something to inspect when the admin opens it.
+  useEffect(() => {
+    let cancelled = false
+    serviceAPI
+      .list({ sort: 'hot', page_size: 20 })
+      .then(results => {
+        if (!cancelled) setDebugServices(results)
+      })
+      .catch(() => {
+        if (!cancelled) setDebugServices([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (activeTab === 'users') loadUsers()
@@ -2315,6 +2337,12 @@ const AdminDashboard = () => {
       userId={karmaModal.user?.id ?? ''}
       onDone={() => { setKarmaModal({ open: false, user: null }); loadUsers() }}
       onClose={() => setKarmaModal({ open: false, user: null })}
+    />
+    <RecommendationDebugBar
+      services={debugServices}
+      hoveredServiceId={null}
+      activeFilter="all"
+      search=""
     />
   </>
   )

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -14,7 +14,6 @@ import { serviceAPI } from '@/services/serviceAPI'
 import AdminReauthBanner from '@/components/AdminReauthBanner'
 import AdminLayout from '@/components/AdminLayout'
 import AdminActivityFeed from '@/components/AdminActivityFeed'
-import RecommendationDebugBar from '@/components/RecommendationDebugBar'
 import { getErrorMessage } from '@/services/api'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { AdminAuditLog, AdminComment, AdminMetrics, AdminReport, AdminUserSummary, ForumTopic, PaginatedResponse, Service } from '@/types'
@@ -115,10 +114,6 @@ const AdminDashboard = () => {
 
   const [dashboardLoading, setDashboardLoading] = useState(false)
   const [metrics, setMetrics] = useState<AdminMetrics | null>(null)
-  // Sample of currently-hot services to feed the floating debug bar (#476).
-  // The bar is admin-only and lives at the bottom of every admin tab; the
-  // panel inside it fetches the per-service breakdown on demand.
-  const [debugServices, setDebugServices] = useState<Service[]>([])
   const [forumPostsCount, setForumPostsCount] = useState<number | null>(null)
   const [pendingReportsCount, setPendingReportsCount] = useState<number | null>(null)
   const [removedCommentsCount, setRemovedCommentsCount] = useState<number | null>(null)
@@ -316,23 +311,6 @@ const AdminDashboard = () => {
   useEffect(() => {
     if (activeTab === 'dashboard') loadDashboard()
   }, [activeTab, loadDashboard])
-
-  // Seed the floating debug bar with the current top hot services so the
-  // panel has something to inspect when the admin opens it.
-  useEffect(() => {
-    let cancelled = false
-    serviceAPI
-      .list({ sort: 'hot', page_size: 20 })
-      .then(results => {
-        if (!cancelled) setDebugServices(results)
-      })
-      .catch(() => {
-        if (!cancelled) setDebugServices([])
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   useEffect(() => {
     if (activeTab === 'users') loadUsers()
@@ -2337,12 +2315,6 @@ const AdminDashboard = () => {
       userId={karmaModal.user?.id ?? ''}
       onDone={() => { setKarmaModal({ open: false, user: null }); loadUsers() }}
       onClose={() => setKarmaModal({ open: false, user: null })}
-    />
-    <RecommendationDebugBar
-      services={debugServices}
-      hoveredServiceId={null}
-      activeFilter="all"
-      search=""
     />
   </>
   )

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -33,6 +33,7 @@ import { handshakeAPI } from '@/services/handshakeAPI'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { Service } from '@/types'
 import { MainSidebar } from '@/components/MainSidebar'
+import RecommendationDebugBar from '@/components/RecommendationDebugBar'
 import type { Handshake } from '@/services/handshakeAPI'
 
 import {
@@ -411,6 +412,8 @@ const DashboardPage = () => {
   const [handshakeMap, setHandshakeMap]             = useState<Map<string, Handshake>>(new Map())
   const [incomingMap, setIncomingMap]               = useState<Map<string, Handshake[]>>(new Map())
   const [typeDropdownOpen, setTypeDropdownOpen]           = useState(false)
+  const [hoveredServiceId, setHoveredServiceId]     = useState<string | null>(null)
+  const [rankingDebugEnabled, setRankingDebugEnabled] = useState(false)
 
   const searchTimer      = useRef<ReturnType<typeof setTimeout> | null>(null)
   const distanceTimer    = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -428,10 +431,25 @@ const DashboardPage = () => {
     return () => { if (distanceTimer.current) clearTimeout(distanceTimer.current) }
   }, [distanceKm])
 
-  // Per #371 the ranking debug panel is admin-only and lives in the admin
-  // dashboard. The floating launcher and getRankingDebugAvailability poll
-  // were removed from the regular dashboard; non-admin clients no longer
-  // need to know whether the debug panel exists.
+  // Ranking debug bar (#476) lives back on the dashboard so admins can hover
+  // a card and see its Phase 2/3 breakdown live. The availability endpoint
+  // is admin-only per #371, so non-admins quietly get no result and the bar
+  // stays hidden. The PlatformSetting flag (toggled in the admin panel)
+  // controls whether the bar appears at all even for admins.
+  useEffect(() => {
+    let cancelled = false
+    serviceAPI
+      .getRankingDebugAvailability()
+      .then(({ enabled }) => {
+        if (!cancelled) setRankingDebugEnabled(Boolean(enabled))
+      })
+      .catch(() => {
+        if (!cancelled) setRankingDebugEnabled(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const fetchServices = useCallback(async (signal: AbortSignal) => {
     let raw: typeof services
@@ -868,6 +886,11 @@ const DashboardPage = () => {
                       incomingCount={aCount}
                       pendingCount={pCount}
                       onClick={() => navigate(`/service-detail/${service.id}`)}
+                      onHover={
+                        rankingDebugEnabled
+                          ? () => setHoveredServiceId(service.id)
+                          : undefined
+                      }
                     />
                   )
                 })}
@@ -876,6 +899,17 @@ const DashboardPage = () => {
           </Box>
         </Flex>
       </Box>
+      {rankingDebugEnabled && (
+        <RecommendationDebugBar
+          services={displayServices}
+          hoveredServiceId={hoveredServiceId}
+          activeFilter={activeFilter}
+          search={debouncedSearch}
+          lat={userLocation?.lat}
+          lng={userLocation?.lng}
+          distance={debouncedDistance}
+        />
+      )}
     </Box>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -259,6 +259,54 @@ export interface RecommendationDebugBreakdown {
   social_reason: string
 }
 
+export interface RecommendationDebugFactorsService {
+  kind: 'service'
+  positive_count: number
+  negative_count: number
+  comment_count: number
+  hours_exchanged: number
+  quality: number
+  activity: number
+  capacity_multiplier: number
+  newcomer_boost: number
+  is_newcomer: boolean
+  final_score: number
+}
+
+export interface RecommendationDebugFactorsEvent {
+  kind: 'event'
+  positive_count: number
+  negative_count: number
+  rsvps_last_7d: number
+  organiser_quality: number
+  velocity: number
+  capacity_multiplier: number
+  newcomer_boost: number
+  is_newcomer: boolean
+  final_score: number
+}
+
+export type RecommendationDebugFactors =
+  | RecommendationDebugFactorsService
+  | RecommendationDebugFactorsEvent
+
+export type RecommendationDebugPhase3Pool =
+  | 'cold_start'
+  | 'undershown_quality'
+  | 'stale_recurring'
+  | null
+
+export interface RecommendationDebugPhase3 {
+  pool: RecommendationDebugPhase3Pool
+  exploration_rate: number
+  lifetime_completed_handshakes: number
+  days_since_last_completed_handshake: number | null
+  is_stale_recurring: boolean
+  cold_start_threshold: number
+  undershown_quality_threshold: number
+  undershown_stale_days: number
+}
+
 export interface RecommendationDebugSelectedService {
   id: string
   title: string
@@ -276,6 +324,8 @@ export interface RecommendationDebugSelectedService {
   distance_km: number | null
   participant_count: number
   max_participants: number
+  factors: RecommendationDebugFactors
+  phase3: RecommendationDebugPhase3
   breakdown: RecommendationDebugBreakdown
   formula_lines: string[]
   notes: string[]


### PR DESCRIPTION
## Summary

The admin debug payload now exposes the actual three-phase pipeline factors for the hovered service: Wilson quality, the log2 activity blend, the capacity multiplier, and the newcomer boost, with the inputs substituted into the formula lines so you can read them off directly. The payload also includes a Phase 3 trace explaining whether the card falls into the cold-start, undershown-quality, or stale-recurring explore pool, with the relevant counts and thresholds.

The frontend panel adds a Phase 3 trace section and renders the new substituted formula lines.

Closes #476

## Test plan

- [ ] `cd backend && .venv/bin/python -m pytest api/tests/unit/test_ranking_debug_payload.py api/tests/integration/test_service_debug_ranking_api.py`
- [ ] `cd frontend && npm run lint && npx tsc --noEmit -p tsconfig.app.json && npm run test -- --run`
- [ ] As an admin with `ranking_debug_enabled=true`, hit `POST /api/services/debug-ranking/` and confirm the response includes `factors` and `phase3` blocks
