### PR TITLE
fix(tests): unbreak security hardening assertions

### DIFF
--- a/backend/api/tests/conftest.py
+++ b/backend/api/tests/conftest.py
@@ -23,6 +23,22 @@ def clear_django_cache():
 
 
 @pytest.fixture(autouse=True)
+def _propagate_api_security_logs():
+    """Production has propagate=False on the api / api.security loggers so
+    Docker log scraping does not see duplicates. pytest's caplog only attaches
+    a handler to root, so without propagation the security-signal tests cannot
+    observe the records they emit. Restore propagation for the test only."""
+    import logging
+    loggers = [logging.getLogger(name) for name in ('api', 'api.security')]
+    originals = [logger.propagate for logger in loggers]
+    for logger in loggers:
+        logger.propagate = True
+    yield
+    for logger, original in zip(loggers, originals):
+        logger.propagate = original
+
+
+@pytest.fixture(autouse=True)
 def disable_drf_throttling(settings):
     """Disable DRF throttling for test stability.
 

--- a/backend/api/tests/integration/test_security_hardening_api.py
+++ b/backend/api/tests/integration/test_security_hardening_api.py
@@ -52,7 +52,8 @@ class TestDisposableEmailBlacklist:
         response = client.post(REGISTER_URL, _payload(f'spammer@{domain}'))
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         # Error must come back attached to the email field, not as a server error.
-        assert 'email' in response.data
+        # The custom exception handler nests DRF field errors under field_errors.
+        assert 'email' in response.data.get('field_errors', response.data)
 
     def test_real_provider_accepted(self):
         client = APIClient()


### PR DESCRIPTION
Tests added in #469 were failing on dev because the assertions did not match the runtime response shape and the api.security logger does not propagate to root, so caplog never saw the records.

- test_disposable_domain_rejected now looks under `field_errors` (the custom DRF exception handler nests validation errors there).
- New autouse fixture re-enables propagation on `api` / `api.security` for tests only, so caplog can pick up `auth.login.success` / `auth.login.failed` records emitted by the signals.

This unblocks every open feature PR. Their CI was going red on these same three tests after #469 merged.