### PR TITLE
chore(ci): add EAS preview build to mobile CI

### DIFF
--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -57,3 +57,42 @@ jobs:
       - name: Run unit tests
         working-directory: mobile-client
         run: npm test -- --ci --forceExit --coverage
+
+  build:
+    name: EAS Preview Build (Android)
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: ${{ vars.ENABLE_MOBILE_BUILD == 'true' && github.event_name == 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: mobile-client/node_modules
+          key: mobile-node-${{ hashFiles('mobile-client/package-lock.json') }}
+          restore-keys: mobile-node-
+
+      - name: Clear npm cache tmp
+        run: rm -rf ~/.npm/_cacache/tmp
+
+      - name: Install dependencies
+        working-directory: mobile-client
+        run: npm ci --prefer-offline --no-audit
+
+      - name: EAS preview build (Android)
+        working-directory: mobile-client
+        run: eas build --profile preview --platform android --non-interactive


### PR DESCRIPTION
## Summary

Adds an EAS preview build job to the mobile CI workflow so native build regressions are caught on PR instead of at someone's desk.

- New `build` job runs after the existing `test` job (lint/tsc/Jest), only when the trigger is a `pull_request` and `vars.ENABLE_MOBILE_BUILD == 'true'`.
- Builds Android only via `eas build --profile preview --platform android --non-interactive`. iOS can follow once Apple credentials are wired in EAS.
- Job stays skipped until the setup below is done — does not block any current PRs.

## Why

Today's mobile CI runs only TypeScript + Jest. Any failure that lives between "TS compiles" and "the app actually runs" — Pod install regressions, Gradle plugin drift, Metro `assetExts` gaps, native plugin breakage — is invisible until someone pulls and tries to build locally. Recent example: the `leaflet.html` Metro asset bug shipped silently because nothing in CI exercises a real native bundle.

A real native build on PR is the highest-ROI feedback-loop fix because it changes nothing in the app — only when we find out it's broken.

## One-time setup (required before flipping the switch)

1. Add an Expo access token as repo secret `EXPO_TOKEN` (expo.dev → Account Settings → Access Tokens).
2. Upload Firebase credentials to EAS as project-scoped file secrets so the remote build can read them (the workflow doesn't handle credentials directly):

   ```
   eas secret:create --scope project --name EXPO_GOOGLE_SERVICES_JSON --type file --value ./google-services.json
   eas secret:create --scope project --name EXPO_GOOGLE_SERVICES_PLIST --type file --value ./GoogleService-Info.plist
   ```

   (`mobile-client/app.config.ts` already reads those env vars at build time.)
3. Set repo variable `ENABLE_MOBILE_BUILD=true` to enable the job.

Until step 3, the `build` job is skipped on every PR.

## Test plan

- [ ] On this PR, confirm the existing `test` job runs as before and the new `build` job is reported as *skipped* (because `ENABLE_MOBILE_BUILD` isn't set yet).
- [ ] After the one-time setup, open a small no-op PR that touches `mobile-client/` and confirm: `build` runs, `eas build` is dispatched, and a deliberately broken native config (e.g. removing a required plugin) fails the PR check.
- [ ] Confirm the job does not fire on direct pushes to feature branches — only on PRs to `dev`.

## Follow-ups

- Add iOS to the same job once Apple credentials are in EAS.
- Consider a fingerprint-based skip so the build only runs when native deps actually change.