### PR TITLE
test: finish #461 — sweep, migrate, fix flakes, mutmut bootstrap

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -226,3 +226,30 @@ jobs:
       - name: Stop MinIO
         if: always()
         run: docker rm -f ci_minio || true
+
+  assert-sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    name: assert-sweep guardrail
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install libcst
+        run: pip install "libcst>=1.4"
+
+      - name: Run codemod in --check mode
+        working-directory: backend
+        run: python -m scripts.codemods.sweep_status_assertions --check api/tests/integration/
+
+      - name: Forbid TestCase subclasses in unit tests
+        working-directory: backend
+        run: |
+          set -e
+          if grep -rEn 'class \w+\((TestCase|APITestCase|TransactionTestCase|HypothesisTestCase)\)' api/tests/unit/ --include='*.py' 2>/dev/null; then
+            echo "::error::TestCase subclasses found in api/tests/unit/."
+            exit 1
+          fi

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -27,7 +27,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Backend mutmut runs on a nightly schedule + manual dispatch only — NOT
+  # on every PR. The CI scope (currently just badge_utils.py to fit the
+  # 45-min job timeout) doesn't earn its ~10 min of runner time per PR
+  # when the rest of the hot-module list isn't actually being gated. Keep
+  # the wiring so the bootstrap stays exercised by the nightly run, and
+  # so anyone debugging mutation testing can trigger it on demand from
+  # the Actions tab. To temporarily run it on a PR, dispatch this
+  # workflow against the PR's branch from the GitHub UI.
   backend-mutmut:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     services:

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -75,6 +75,36 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends gdal-bin libgdal-dev libgeos-dev
 
+      - name: Start MinIO
+        run: |
+          docker run -d --name ci_minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin123 \
+            --health-cmd "curl -f http://localhost:9000/minio/health/live || exit 1" \
+            --health-interval 5s \
+            --health-timeout 3s \
+            --health-retries 20 \
+            minio/minio:latest server /data --console-address ":9001"
+
+      - name: Wait for MinIO
+        run: |
+          for i in $(seq 1 30); do
+            STATUS=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' ci_minio)
+            if [ "$STATUS" = "healthy" ]; then
+              echo "MinIO is healthy."
+              break
+            fi
+            if [ "$STATUS" = "unhealthy" ]; then
+              echo "::error::MinIO became unhealthy"
+              docker logs ci_minio
+              exit 1
+            fi
+            echo "Waiting for MinIO... status=$STATUS ($i/30)"
+            sleep 2
+          done
+
+
       - name: Cache pip
         uses: actions/cache@v4
         with:
@@ -97,7 +127,6 @@ jobs:
         run: |
           .venv/bin/mutmut run || true
           .venv/bin/mutmut results > mutmut-results.txt
-          .venv/bin/mutmut html || true
 
       - name: Upload mutmut report
         if: always()
@@ -106,7 +135,6 @@ jobs:
           name: backend-mutation
           path: |
             backend/mutmut-results.txt
-            backend/html/
 
       # Only post a PR comment if mutmut produced at least one scored
       # mutant. With the current Django app-registry issue, every line in

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -127,6 +127,11 @@ jobs:
         run: |
           .venv/bin/mutmut run || true
           .venv/bin/mutmut results > mutmut-results.txt
+          # `mutmut results` only prints SURVIVED/timeout/suspicious mutants,
+          # not the killed ones — counting it would always read killed=0.
+          # `export-cicd-stats` writes a JSON tally with the actual totals,
+          # which is what the PR comment script reads.
+          .venv/bin/mutmut export-cicd-stats || true
 
       - name: Upload mutmut report
         if: always()
@@ -135,51 +140,51 @@ jobs:
           name: backend-mutation
           path: |
             backend/mutmut-results.txt
+            backend/mutants/mutmut-cicd-stats.json
 
-      # Only post a PR comment if mutmut produced at least one scored
-      # mutant. With the current Django app-registry issue, every line in
-      # results.txt is "not checked" — pasting that wall is noise. When a
-      # scored mutant appears, the comment summarises killed / survived /
-      # not-checked counts in a tight code block.
+      # Read the cicd-stats JSON so killed/survived/total are accurate.
+      # Only post when mutmut actually scored a mutant — when the bootstrap
+      # is broken everything ends up in `segfault` / `not_checked` and the
+      # comment would just be noise.
       - name: Comment mutation summary on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const path = 'backend/mutmut-results.txt';
+            const path = 'backend/mutants/mutmut-cicd-stats.json';
             if (!fs.existsSync(path)) {
-              core.info('No mutmut results file produced; skipping PR comment.');
+              core.info('No mutmut cicd-stats file produced; skipping PR comment.');
               return;
             }
-            const text = fs.readFileSync(path, 'utf8');
-            const lines = text.split('\n').filter(Boolean);
-            const tally = { killed: 0, survived: 0, suspicious: 0, timeout: 0, skipped: 0, not_checked: 0 };
-            for (const line of lines) {
-              const m = line.match(/:\s*([a-z_]+)\s*$/);
-              if (!m) continue;
-              const status = m[1];
-              if (tally[status] !== undefined) tally[status] += 1;
-              else if (status === 'ok_killed') tally.killed += 1;
-              else if (status === 'bad_survived') tally.survived += 1;
-            }
-            const scored = tally.killed + tally.survived + tally.timeout + tally.suspicious;
+            const stats = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const killed = stats.killed ?? 0;
+            const survived = stats.survived ?? 0;
+            const timeout = stats.timeout ?? 0;
+            const suspicious = stats.suspicious ?? 0;
+            const skipped = stats.skipped ?? 0;
+            const segfault = stats.segfault ?? 0;
+            const noTests = stats.no_tests ?? 0;
+            const total = stats.total ?? (killed + survived + timeout + suspicious + skipped + segfault + noTests);
+            const scored = killed + survived;
             if (scored === 0) {
               core.info('mutmut produced no scored mutants this run; skipping PR comment.');
               return;
             }
-            const score = tally.killed / (tally.killed + tally.survived);
-            const pct = isFinite(score) ? (score * 100).toFixed(1) : 'n/a';
+            const pct = ((killed / scored) * 100).toFixed(1);
             const body = [
               '### Backend mutation testing (mutmut)',
               '',
               '```',
               'mutation score : ' + pct + '%',
-              'killed         : ' + tally.killed,
-              'survived       : ' + tally.survived,
-              'timeout        : ' + tally.timeout,
-              'suspicious     : ' + tally.suspicious,
-              'not checked    : ' + tally.not_checked,
+              'killed         : ' + killed,
+              'survived       : ' + survived,
+              'timeout        : ' + timeout,
+              'suspicious     : ' + suspicious,
+              'skipped        : ' + skipped,
+              'segfault       : ' + segfault,
+              'no_tests       : ' + noTests,
+              'total          : ' + total,
               '```',
             ].join('\n');
             await github.rest.issues.createComment({

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -219,9 +219,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-mutation
-          path: |
-            frontend/reports/
-            frontend/tests/reports/mutation/
+          path: frontend/tests/reports/mutation/
 
       # Stryker's JSON schema (1.0) does not carry an aggregate score field,
       # so compute it from the per-file mutant tallies. The clear-text
@@ -233,7 +231,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = 'frontend/reports/mutation/mutation.json';
+            const path = 'frontend/tests/reports/mutation/mutation.json';
             if (!fs.existsSync(path)) {
               core.warning('No Stryker report produced.');
               return;

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@
         prod-up prod-down prod-logs prod-build prod-reset prod-demo \
         shell-backend shell-db shell-redis \
         test test-unit test-integration test-docker coverage coverage-backend coverage-frontend coverage-report \
-        test-mutation test-mutation-html test-perf test-mobile-unit
+        test-mutation test-mutation-html test-perf test-mobile-unit \
+        test-assert-sweep
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -441,6 +442,17 @@ test-perf: ## Run k6 perf gates against the running stack
 
 test-mobile-unit: ## Run mobile-client Jest test suite
 	@cd mobile-client && npm test -- --watchAll=false
+
+test-assert-sweep: ## Lint guardrail: forbid raw status_code asserts and TestCase subclasses
+	$(call _log,"Checking for raw status_code asserts under api/tests/integration/...")
+	@cd backend && $(PYEXEC) -m scripts.codemods.sweep_status_assertions --check api/tests/integration/
+	$(call _log,"Checking no TestCase subclasses survive in api/tests/unit/...")
+	@if grep -rEn "class \w+\((TestCase|APITestCase|TransactionTestCase|HypothesisTestCase)\)" \
+	     backend/api/tests/unit/ --include="*.py" 2>/dev/null; then \
+	   printf '\033[1;31mERROR: TestCase subclasses found in unit tests:\033[0m\n'; \
+	   exit 1; \
+	 fi
+	$(call _ok,"Assertion sweep guardrail clean.")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/api/cache_utils.py
+++ b/backend/api/cache_utils.py
@@ -323,7 +323,14 @@ def register_calendar_cache_key(user_id: str, cache_key: str) -> None:
         new_set.add(cache_key)
         # Use the same TTL as the item so the tracking set expires with it.
         cache.set(tracking_key, new_set, timeout=_CALENDAR_CACHE_TTL)
-        return
+        # Verify the write actually stuck. A racing writer between our get
+        # and set could clobber our value with a stale set; we re-read and
+        # retry up to 3 times to re-add our key.
+        confirmed = cache.get(tracking_key, set())
+        if cache_key in confirmed:
+            return
+    # Final attempt failed — give up silently. The TTL bounds staleness;
+    # the next request will re-register the key.
 
 
 def invalidate_user_calendar(user_id: str) -> None:

--- a/backend/api/tests/conftest.py
+++ b/backend/api/tests/conftest.py
@@ -25,14 +25,16 @@ def pytest_collection_modifyitems(config, items):
 
 @pytest.fixture(autouse=True)
 def _assert_in_memory_channels(request, settings):
-    """Unit tests must use the in-memory channel layer.
+    """Unit and websocket-marked tests must use the in-memory channel layer.
 
-    Hitting Redis from unit tests is a leak — slow, flaky, and silently
-    coupled to whatever else is in the layer. Reset to in-memory at the
-    start of every unit test so a misconfigured CI environment cannot sneak
+    Hitting Redis from tests is a leak — slow, flaky, and silently coupled
+    across xdist workers (each worker shares Redis but uses its own DB
+    transaction, so channel groups created by one worker can bleed into
+    another). Reset to in-memory at the start of every unit and
+    websocket-marked test so a misconfigured CI environment cannot sneak
     by.
     """
-    if 'unit' not in request.keywords:
+    if 'unit' not in request.keywords and 'websocket' not in request.keywords:
         return
     settings.CHANNEL_LAYERS = {
         'default': {'BACKEND': 'channels.layers.InMemoryChannelLayer'},

--- a/backend/api/tests/integration/test_activity_feed.py
+++ b/backend/api/tests/integration/test_activity_feed.py
@@ -16,6 +16,7 @@ from api.tests.helpers.factories import (
     ServiceFactory,
     UserFactory,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -138,7 +139,7 @@ class TestActivityFeedEndpoint:
     def test_anonymous_returns_401(self):
         client = APIClient()
         resp = client.get('/api/activity/feed/')
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
     def test_returns_events_from_followed_users(self):
         from api.models import UserFollow
@@ -157,7 +158,7 @@ class TestActivityFeedEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/activity/feed/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         data = resp.json()
         actors = {row['actor']['id'] for row in data['results']}
         assert str(followed.id) in actors
@@ -184,7 +185,7 @@ class TestActivityFeedEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/activity/feed/?lat=0.0&lng=0.0')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         actors = {row['actor']['id'] for row in resp.json()['results']}
         assert str(nearby_owner.id) in actors
         assert str(far_owner.id) not in actors
@@ -220,7 +221,7 @@ class TestActivityFeedEndpoint:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get('/api/activity/feed/?lat=0.0&lng=0.0&sort=nearby')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         results = resp.json()['results']
         assert len(results) <= 12
         # Distances should be monotonically increasing.
@@ -246,7 +247,7 @@ class TestActivityFeedEndpoint:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get('/api/activity/feed/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         rows = [
             r for r in resp.json()['results']
             if r['verb'] == ActivityEvent.EVENT_FILLING_UP
@@ -293,7 +294,7 @@ class TestActivityFeedEndpoint:
         client = APIClient()
         client.force_authenticate(user=b)
         resp = client.get('/api/activity/feed/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         follow_rows = [
             r for r in resp.json()['results']
             if r['verb'] == ActivityEvent.USER_FOLLOWED

--- a/backend/api/tests/integration/test_admin_comment_api.py
+++ b/backend/api/tests/integration/test_admin_comment_api.py
@@ -5,6 +5,7 @@ from rest_framework.test import APIClient
 from api.models import Comment
 from api.tests.helpers.factories import AdminUserFactory, CommentFactory, ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -12,14 +13,14 @@ from api.tests.helpers.test_client import AuthenticatedAPIClient
 class TestAdminCommentApi:
     def test_list_requires_authentication(self):
         response = APIClient().get('/api/admin/comments/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_non_admin_cannot_list_comments(self):
         member = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(member)
 
         response = client.get('/api/admin/comments/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_admin_lists_active_comments_by_default(self):
         admin = AdminUserFactory()
@@ -30,7 +31,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get('/api/admin/comments/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {item['id'] for item in response.data['results']}
         assert str(active_comment.id) in ids
         assert all(item['status'] == 'active' for item in response.data['results'])
@@ -44,7 +45,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get('/api/admin/comments/?status=removed')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {item['id'] for item in response.data['results']}
         assert str(removed_comment.id) in ids
         assert all(item['status'] == 'removed' for item in response.data['results'])
@@ -58,7 +59,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get('/api/admin/comments/?search=helpful')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {item['id'] for item in response.data['results']}
         assert str(matching.id) in ids
 
@@ -69,7 +70,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.post(f'/api/admin/comments/{comment.id}/remove/', {}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         comment.refresh_from_db()
         assert comment.is_deleted is True
         assert response.data['status'] == 'removed'
@@ -81,7 +82,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.post(f'/api/admin/comments/{comment.id}/restore/', {}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         comment.refresh_from_db()
         assert comment.is_deleted is False
         assert response.data['status'] == 'active'
@@ -93,7 +94,7 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_user(member)
         response = client.post(f'/api/admin/comments/{comment.id}/remove/', {}, format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         comment.refresh_from_db()
         assert comment.is_deleted is False
 
@@ -104,6 +105,4 @@ class TestAdminCommentApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get(f'/api/admin/comments/{comment.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(comment.id)
-        assert response.data['body'] == 'Moderation detail body'
+        assert_api_response(response, 200, schema={'id': str(comment.id), 'body': 'Moderation detail body'})

--- a/backend/api/tests/integration/test_admin_management_api.py
+++ b/backend/api/tests/integration/test_admin_management_api.py
@@ -15,6 +15,7 @@ from api.exceptions import AuditLogImmutabilityError
 from api.models import AdminAuditLog, Report
 from api.tests.helpers.factories import AdminUserFactory, ForumTopicFactory, HandshakeFactory, ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 def _payload_items(data):
@@ -30,14 +31,14 @@ def _payload_items(data):
 class TestAdminManagementApi:
     def test_metrics_requires_authentication(self):
         response = APIClient().get('/api/metrics/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_non_admin_cannot_access_metrics(self):
         member = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(member)
 
         response = client.get('/api/metrics/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_admin_can_access_metrics(self):
         admin = AdminUserFactory()
@@ -45,7 +46,7 @@ class TestAdminManagementApi:
 
         response = client.get('/api/metrics/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         payload = response.json()
         assert 'users' in payload
         assert 'services' in payload
@@ -54,14 +55,14 @@ class TestAdminManagementApi:
 
     def test_admin_users_list_requires_authentication(self):
         response = APIClient().get('/api/admin/users/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_non_admin_cannot_list_admin_users(self):
         member = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(member)
 
         response = client.get('/api/admin/users/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_admin_can_list_users(self):
         admin = AdminUserFactory()
@@ -70,7 +71,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get('/api/admin/users/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         items = _payload_items(response.data)
         ids = {item['id'] for item in items}
         assert str(listed_user.id) in ids
@@ -86,15 +87,15 @@ class TestAdminManagementApi:
             {'message': 'Please follow guidelines.'},
             format='json',
         )
-        assert warn_response.status_code == status.HTTP_200_OK
+        assert_api_response(warn_response, 200)
 
         ban_response = client.post(f'/api/admin/users/{target_user.id}/ban/', {}, format='json')
-        assert ban_response.status_code == status.HTTP_200_OK
+        assert_api_response(ban_response, 200)
         target_user.refresh_from_db()
         assert target_user.is_active is False
 
         unban_response = client.post(f'/api/admin/users/{target_user.id}/unban/', {}, format='json')
-        assert unban_response.status_code == status.HTTP_200_OK
+        assert_api_response(unban_response, 200)
         target_user.refresh_from_db()
         assert target_user.is_active is True
 
@@ -103,13 +104,13 @@ class TestAdminManagementApi:
             {'adjustment': -3},
             format='json',
         )
-        assert karma_response.status_code == status.HTTP_200_OK
+        assert_api_response(karma_response, 200)
         target_user.refresh_from_db()
         assert target_user.karma_score == 7
 
     def test_admin_audit_logs_requires_authentication(self):
         response = APIClient().get('/api/admin/audit-logs/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_non_admin_gets_empty_admin_audit_logs(self):
         member = UserFactory()
@@ -126,7 +127,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_user(member)
         response = client.get('/api/admin/audit-logs/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         items = _payload_items(response.data)
         assert len(items) == 0
 
@@ -161,12 +162,12 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
 
         all_response = client.get('/api/admin/audit-logs/')
-        assert all_response.status_code == status.HTTP_200_OK
+        assert_api_response(all_response, 200)
         all_items = _payload_items(all_response.data)
         assert len(all_items) >= 2
 
         filtered_response = client.get('/api/admin/audit-logs/?action_type=resolve_report&target_entity=report')
-        assert filtered_response.status_code == status.HTTP_200_OK
+        assert_api_response(filtered_response, 200)
         filtered_items = _payload_items(filtered_response.data)
         assert len(filtered_items) >= 1
         assert all(item['action_type'] == 'resolve_report' for item in filtered_items)
@@ -179,7 +180,7 @@ class TestAdminManagementApi:
 
         response = client.post(f'/api/admin/users/{admin.id}/ban/', {}, format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         admin.refresh_from_db()
         assert admin.is_active is True  # account must remain active
 
@@ -194,7 +195,7 @@ class TestAdminManagementApi:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_admin_can_still_suspend_other_users(self):
         """Regression: the self-suspend guard must not break normal ban flow."""
@@ -204,7 +205,7 @@ class TestAdminManagementApi:
 
         response = client.post(f'/api/admin/users/{target.id}/ban/', {}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         target.refresh_from_db()
         assert target.is_active is False
 
@@ -218,7 +219,7 @@ class TestAdminManagementApi:
 
         response = client.post(f'/api/admin/users/{admin.id}/ban/', {}, format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         admin.refresh_from_db()
         assert admin.is_active is True
 
@@ -234,7 +235,7 @@ class TestAdminManagementApi:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_moderator_can_warn_another_moderator(self):
         """Moderators may warn peers at the same tier."""
@@ -248,7 +249,7 @@ class TestAdminManagementApi:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_moderator_cannot_ban_another_moderator(self):
         """Moderators must not be able to ban peers at the same tier."""
@@ -258,7 +259,7 @@ class TestAdminManagementApi:
 
         response = client.post(f'/api/admin/users/{peer.id}/ban/', {}, format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         peer.refresh_from_db()
         assert peer.is_active is True
 
@@ -275,7 +276,7 @@ class TestAdminManagementApi:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         admin.refresh_from_db()
         assert admin.karma_score == original_karma
 
@@ -289,7 +290,7 @@ class TestAdminManagementApi:
 
         response = client.get('/api/admin/users/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {item['id'] for item in _payload_items(response.data)}
         assert str(super_admin.id) not in ids
 
@@ -301,7 +302,7 @@ class TestAdminManagementApi:
 
         response = client.get(f'/api/admin/users/{super_admin.id}/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_super_admin_can_see_other_super_admins(self):
         """A super_admin should be able to view another super_admin's detail."""
@@ -311,8 +312,7 @@ class TestAdminManagementApi:
 
         response = client.get(f'/api/admin/users/{peer.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(peer.id)
+        assert_api_response(response, 200, schema={'id': str(peer.id)})
 
     def test_resolved_report_is_retrievable_via_detail_endpoint(self):
         """Resolved reports must return 200 on the detail endpoint (not 404)."""
@@ -330,9 +330,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get(f'/api/admin/reports/{report.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(report.id)
-        assert response.data['status'] == 'resolved'
+        assert_api_response(response, 200, schema={'id': str(report.id), 'status': 'resolved'})
 
     def test_dismissed_report_is_retrievable_via_detail_endpoint(self):
         """Dismissed reports must also return 200 on the detail endpoint."""
@@ -350,8 +348,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get(f'/api/admin/reports/{report.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'dismissed'
+        assert_api_response(response, 200, schema={'status': 'dismissed'})
 
     def test_admin_can_list_retrieve_and_pause_reports(self):
         admin = AdminUserFactory()
@@ -372,17 +369,16 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
 
         list_response = client.get('/api/admin/reports/?status=pending')
-        assert list_response.status_code == status.HTTP_200_OK
+        assert_api_response(list_response, 200)
         list_items = _payload_items(list_response.data)
         report_ids = {item['id'] for item in list_items}
         assert str(report.id) in report_ids
 
         retrieve_response = client.get(f'/api/admin/reports/{report.id}/')
-        assert retrieve_response.status_code == status.HTTP_200_OK
-        assert retrieve_response.data['id'] == str(report.id)
+        assert_api_response(retrieve_response, 200, schema={'id': str(report.id)})
 
         pause_response = client.post(f'/api/admin/reports/{report.id}/pause/', {}, format='json')
-        assert pause_response.status_code == status.HTTP_200_OK
+        assert_api_response(pause_response, 200)
         handshake.refresh_from_db()
         assert handshake.status == 'paused'
 
@@ -391,14 +387,14 @@ class TestAdminManagementApi:
     def test_admin_user_detail_requires_authentication(self):
         target = UserFactory()
         response = APIClient().get(f'/api/admin/users/{target.id}/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_non_admin_cannot_retrieve_user_detail(self):
         member = UserFactory()
         target = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(member)
         response = client.get(f'/api/admin/users/{target.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_admin_can_retrieve_user_detail(self):
         admin = AdminUserFactory()
@@ -410,7 +406,7 @@ class TestAdminManagementApi:
 
         response = client.get(f'/api/admin/users/{target.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         data = response.data
         assert data['id'] == str(target.id)
         assert data['email'] == target.email
@@ -450,7 +446,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get(f'/api/admin/users/{target.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         data = response.data
         assert data['offers_count'] == 2
         assert data['requests_count'] == 1
@@ -472,7 +468,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
         response = client.get(f'/api/admin/users/{target.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         actions = response.data['recent_admin_actions']
         assert len(actions) == 1
         assert actions[0]['action_type'] == 'warn_user'
@@ -484,7 +480,7 @@ class TestAdminManagementApi:
         client = AuthenticatedAPIClient().authenticate_admin(admin)
 
         response = client.get(f'/api/admin/users/{uuid.uuid4()}/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     # ── Role-aware handshake counts ───────────────────────────────────────────
 
@@ -658,7 +654,7 @@ class TestAdminRoleAssignment:
         """Endpoint requires a valid session."""
         target = UserFactory()
         response = APIClient().post(self._url(target.id), {'role': 'moderator'}, format='json')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_member_cannot_assign_roles(self):
         """A standard member must not access admin endpoints."""
@@ -668,7 +664,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'moderator')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         target.refresh_from_db()
         assert target.role == 'member'
 
@@ -681,7 +677,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, admin.id, 'member')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         admin.refresh_from_db()
         assert admin.role == 'admin'  # unchanged
 
@@ -695,7 +691,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, peer_admin.id, 'member')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         peer_admin.refresh_from_db()
         assert peer_admin.role == 'admin'  # unchanged
 
@@ -707,7 +703,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'admin')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         target.refresh_from_db()
         assert target.role == 'member'  # unchanged
 
@@ -721,7 +717,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'moderator')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         payload = response.json()
         assert payload['status'] == 'success'
         assert payload['previous_role'] == 'member'
@@ -737,7 +733,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'member')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         target.refresh_from_db()
         assert target.role == 'member'
 
@@ -749,7 +745,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'moderator')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         target.refresh_from_db()
         assert target.role == 'member'
 
@@ -763,7 +759,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'admin')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         target.refresh_from_db()
         assert target.role == 'admin'
 
@@ -775,7 +771,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, peer.id, 'admin')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         peer.refresh_from_db()
         assert peer.role == 'super_admin'
 
@@ -789,7 +785,7 @@ class TestAdminRoleAssignment:
 
         initial_log_count = AdminAuditLog.objects.filter(action_type='assign_role').count()
         response = self._post(client, target.id, 'moderator')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         logs = AdminAuditLog.objects.filter(action_type='assign_role')
         assert logs.count() == initial_log_count + 1
@@ -822,7 +818,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, target.id, 'superuser')  # not a valid role
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         target.refresh_from_db()
         assert target.role == 'member'
 
@@ -834,7 +830,7 @@ class TestAdminRoleAssignment:
 
         response = client.post(self._url(target.id), {}, format='json')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_unknown_user_id_returns_404(self):
         """A non-existent target user must return 404."""
@@ -844,7 +840,7 @@ class TestAdminRoleAssignment:
 
         response = self._post(client, uuid.uuid4(), 'member')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 @pytest.mark.django_db
@@ -869,7 +865,7 @@ class TestAdminForumTopicLockPin:
         initial_count = AdminAuditLog.objects.filter(action_type='lock_topic').count()
         response = client.post(self._lock_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         topic.refresh_from_db()
         assert topic.is_locked is True
 
@@ -890,7 +886,7 @@ class TestAdminForumTopicLockPin:
         initial_count = AdminAuditLog.objects.filter(action_type='lock_topic').count()
         response = client.post(self._lock_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         topic.refresh_from_db()
         assert topic.is_locked is False
 
@@ -907,7 +903,7 @@ class TestAdminForumTopicLockPin:
 
         response = client.post(self._lock_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         topic.refresh_from_db()
         assert topic.is_locked is False
 
@@ -917,7 +913,7 @@ class TestAdminForumTopicLockPin:
 
         response = APIClient().post(self._lock_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     # ── pin ───────────────────────────────────────────────────────────────────
 
@@ -930,7 +926,7 @@ class TestAdminForumTopicLockPin:
         initial_count = AdminAuditLog.objects.filter(action_type='pin_topic').count()
         response = client.post(self._pin_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         topic.refresh_from_db()
         assert topic.is_pinned is True
 
@@ -951,7 +947,7 @@ class TestAdminForumTopicLockPin:
         initial_count = AdminAuditLog.objects.filter(action_type='pin_topic').count()
         response = client.post(self._pin_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         topic.refresh_from_db()
         assert topic.is_pinned is False
 
@@ -968,7 +964,7 @@ class TestAdminForumTopicLockPin:
 
         response = client.post(self._pin_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         topic.refresh_from_db()
         assert topic.is_pinned is False
 
@@ -978,7 +974,7 @@ class TestAdminForumTopicLockPin:
 
         response = APIClient().post(self._pin_url(topic.id), format='json')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     # ── idempotency / multiple toggles ────────────────────────────────────────
 
@@ -991,14 +987,14 @@ class TestAdminForumTopicLockPin:
         # Lock → unlocked → locked: three round-trips
         for expected in [True, False, True]:
             response = client.post(self._lock_url(topic.id), format='json')
-            assert response.status_code == status.HTTP_200_OK
+            assert_api_response(response, 200)
             topic.refresh_from_db()
             assert topic.is_locked is expected
 
         # Pin → unpinned → pinned: three round-trips
         for expected in [True, False, True]:
             response = client.post(self._pin_url(topic.id), format='json')
-            assert response.status_code == status.HTTP_200_OK
+            assert_api_response(response, 200)
             topic.refresh_from_db()
             assert topic.is_pinned is expected
 

--- a/backend/api/tests/integration/test_auth_api.py
+++ b/backend/api/tests/integration/test_auth_api.py
@@ -142,8 +142,7 @@ class TestTokenRefresh:
         response = client.post('/api/auth/refresh/', {
             'refresh': str(refresh)
         })
-        assert response.status_code == status.HTTP_200_OK
-        assert 'access' in response.data
+        assert_api_response(response, 200, contains={'access'})
     
     def test_token_refresh_invalid_token(self):
         """Test token refresh with invalid token"""
@@ -151,7 +150,7 @@ class TestTokenRefresh:
         response = client.post('/api/auth/refresh/', {
             'refresh': 'invalid-token'
         })
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 @pytest.mark.django_db
@@ -166,14 +165,13 @@ class TestAuthenticatedEndpoints:
         client.authenticate_user(user)
         
         response = client.get('/api/users/me/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['email'] == user.email
+        assert_api_response(response, 200, schema={'email': user.email})
     
     def test_unauthenticated_access(self):
         """Test accessing protected endpoint without token"""
         client = APIClient()
         response = client.get('/api/users/me/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 @pytest.mark.django_db
@@ -187,7 +185,7 @@ class TestLogout:
         user.set_password(password)
         user.save()
         resp = client.post('/api/auth/login/', {'email': email, 'password': password})
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         return user, resp.data['refresh']
 
     def test_logout_returns_200(self):
@@ -195,8 +193,7 @@ class TestLogout:
         client = APIClient()
         self._login(client)
         response = client.post('/api/auth/logout/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'detail' in response.data
+        assert_api_response(response, 200, contains={'detail'})
 
     def test_logout_clears_auth_cookies(self):
         """Logout response includes cookie-deletion directives for both tokens."""
@@ -207,7 +204,7 @@ class TestLogout:
         client.cookies['refresh_token'] = refresh_token
 
         response = client.post('/api/auth/logout/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         # Django sets max-age=0 when deleting a cookie
         assert 'access_token' in response.cookies
@@ -223,16 +220,15 @@ class TestLogout:
         # Attach refresh cookie so logout can blacklist it
         client.cookies['refresh_token'] = refresh_token
         logout_resp = client.post('/api/auth/logout/')
-        assert logout_resp.status_code == status.HTTP_200_OK
+        assert_api_response(logout_resp, 200)
 
         # Attempt to use the blacklisted token on a fresh client (sent in body)
         fresh_client = APIClient()
         refresh_resp = fresh_client.post('/api/auth/refresh/', {'refresh': refresh_token})
-        assert refresh_resp.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(refresh_resp, 401)
 
     def test_logout_without_cookies_is_safe(self):
         """Logout is idempotent / safe when no refresh cookie is present."""
         client = APIClient()
         response = client.post('/api/auth/logout/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'detail' in response.data
+        assert_api_response(response, 200, contains={'detail'})

--- a/backend/api/tests/integration/test_calendar_api.py
+++ b/backend/api/tests/integration/test_calendar_api.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from api.models import Handshake, Service
 from api.tests.helpers.factories import UserFactory, ServiceFactory, HandshakeFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 CALENDAR_URL = '/api/users/me/calendar/'
@@ -23,13 +24,13 @@ class TestMeCalendarAuth:
     def test_requires_auth_returns_401(self):
         client = AuthenticatedAPIClient()
         response = client.get(CALENDAR_URL)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_authenticated_user_gets_200(self):
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(CALENDAR_URL)
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
 
 @pytest.mark.django_db
@@ -39,7 +40,7 @@ class TestMeCalendarResponseShape:
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(CALENDAR_URL)
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         data = response.json()
         assert 'items' in data
         assert 'conflicts' in data
@@ -73,7 +74,7 @@ class TestMeCalendarQueryParams:
         from_dt = '2026-06-01'
         to_dt = '2026-07-01'
         response = client.get(CALENDAR_URL, {'from': from_dt, 'to': to_dt})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         r = response.json()['range']
         assert r['from'] == from_dt
         assert r['to'] == to_dt
@@ -84,7 +85,7 @@ class TestMeCalendarQueryParams:
         from_dt = '2020-01-01'
         to_dt = '2048-01-01'  # > max window
         response = client.get(CALENDAR_URL, {'from': from_dt, 'to': to_dt})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         data = response.json()
         assert 'max_days' in data
         assert data['max_days'] == 3650
@@ -93,13 +94,13 @@ class TestMeCalendarQueryParams:
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(CALENDAR_URL, {'from': 'not-a-date'})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_invalid_to_date_returns_400(self):
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(CALENDAR_URL, {'to': 'not-a-date'})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
 
 @pytest.mark.django_db
@@ -138,7 +139,7 @@ class TestMeCalendarItems:
         )
         client = AuthenticatedAPIClient().authenticate_user(provider)
         resp = client.get(CALENDAR_URL)
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         items = resp.json()['items']
         assert len(items) >= 1
         item = items[0]
@@ -177,7 +178,7 @@ class TestMeCalendarItems:
         client = AuthenticatedAPIClient().authenticate_user(owner)
         resp = client.get(CALENDAR_URL)
 
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         matching = [item for item in resp.json()['items'] if item['service_id'] == str(svc.id)]
         assert len(matching) == 1
         assert matching[0]['link'] == {'type': 'service', 'id': str(svc.id)}
@@ -208,7 +209,7 @@ class TestMeCalendarItems:
         client = AuthenticatedAPIClient().authenticate_user(owner)
         resp = client.get(CALENDAR_URL)
 
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         matching = [item for item in resp.json()['items'] if item['service_id'] == str(svc.id)]
         assert len(matching) == 1
         assert matching[0]['link'] == {'type': 'service', 'id': str(svc.id)}
@@ -272,7 +273,7 @@ class TestMeCalendarItems:
             },
         )
 
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         matching = [item for item in resp.json()['items'] if item['service_id'] == str(svc.id)]
         assert len(matching) == 1
         assert matching[0]['id'] == str(svc.id)
@@ -348,12 +349,12 @@ class TestMeCalendarCaching:
         )
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp1 = client.get(CALENDAR_URL)
-        assert resp1.status_code == status.HTTP_200_OK
+        assert_api_response(resp1, 200)
         data1 = resp1.json()
 
         # Second call — no mutations, cache still valid
         resp2 = client.get(CALENDAR_URL)
-        assert resp2.status_code == status.HTTP_200_OK
+        assert_api_response(resp2, 200)
         data2 = resp2.json()
         # Same data: same item count and same item IDs
         assert len(data2['items']) == len(data1['items'])
@@ -380,7 +381,7 @@ class TestMeCalendarCacheInvalidation:
 
         # First call: populates cache, handshake is visible
         resp1 = client.get(CALENDAR_URL)
-        assert resp1.status_code == status.HTTP_200_OK
+        assert_api_response(resp1, 200)
         assert len(resp1.json()['items']) >= 1
 
         # Transition handshake to cancelled (triggers post_save signal → invalidation)
@@ -389,7 +390,7 @@ class TestMeCalendarCacheInvalidation:
 
         # Second call: cache was invalidated, so fresh DB read — item gone
         resp2 = client.get(CALENDAR_URL)
-        assert resp2.status_code == status.HTTP_200_OK
+        assert_api_response(resp2, 200)
         item_ids = [item['id'] for item in resp2.json()['items']]
         assert str(hs.id) not in item_ids, (
             "Cancelled handshake still in calendar — cache was not invalidated"
@@ -409,7 +410,7 @@ class TestMeCalendarCacheInvalidation:
 
         # First call: pending handshake is NOT in calendar (only accepted statuses appear)
         resp1 = client.get(CALENDAR_URL)
-        assert resp1.status_code == status.HTTP_200_OK
+        assert_api_response(resp1, 200)
         item_ids_before = [item['id'] for item in resp1.json()['items']]
         assert str(hs.id) not in item_ids_before
 
@@ -419,7 +420,7 @@ class TestMeCalendarCacheInvalidation:
 
         # Second call: cache invalidated, new accepted handshake is now visible
         resp2 = client.get(CALENDAR_URL)
-        assert resp2.status_code == status.HTTP_200_OK
+        assert_api_response(resp2, 200)
         item_ids_after = [item['id'] for item in resp2.json()['items']]
         assert str(hs.id) in item_ids_after, (
             "Newly accepted handshake not in calendar — cache was not invalidated"
@@ -437,7 +438,7 @@ class TestMeCalendarCacheInvalidation:
 
         # First call: event is visible for organiser
         resp1 = client.get(CALENDAR_URL)
-        assert resp1.status_code == status.HTTP_200_OK
+        assert_api_response(resp1, 200)
         assert len(resp1.json()['items']) >= 1
 
         # Cancel the event (triggers post_save signal → invalidation via invalidate_on_service_change)
@@ -446,7 +447,7 @@ class TestMeCalendarCacheInvalidation:
 
         # Second call: cache invalidated, cancelled event no longer in calendar
         resp2 = client.get(CALENDAR_URL)
-        assert resp2.status_code == status.HTTP_200_OK
+        assert_api_response(resp2, 200)
         item_ids = [item['id'] for item in resp2.json()['items']]
         assert str(svc.id) not in item_ids, (
             "Cancelled event still in organiser's calendar — cache was not invalidated"
@@ -483,11 +484,11 @@ class TestMeCalendarCacheTrackingSet:
 
         # Fetch window 1 — populates cache and registers key
         resp1 = client.get(CALENDAR_URL, {'from': from_w1, 'to': to_w1})
-        assert resp1.status_code == status.HTTP_200_OK
+        assert_api_response(resp1, 200)
 
         # Fetch window 2 — populates cache and registers a different key
         resp2 = client.get(CALENDAR_URL, {'from': from_w2, 'to': to_w2})
-        assert resp2.status_code == status.HTTP_200_OK
+        assert_api_response(resp2, 200)
 
         # Both keys should be in the tracking set
         tracking_key = f"user_calendar_keys:{user.id}"
@@ -507,7 +508,7 @@ class TestMeCalendarCacheTrackingSet:
 
         # Verify fresh responses reflect the cancellation (handshake no longer in calendar)
         resp3 = client.get(CALENDAR_URL, {'from': from_w1, 'to': to_w1})
-        assert resp3.status_code == status.HTTP_200_OK
+        assert_api_response(resp3, 200)
         item_ids_w1 = [item['id'] for item in resp3.json()['items']]
         assert str(hs.id) not in item_ids_w1, (
             "Cancelled handshake still visible in window-1 after invalidation"

--- a/backend/api/tests/integration/test_chat_api.py
+++ b/backend/api/tests/integration/test_chat_api.py
@@ -146,13 +146,11 @@ class TestChatViewSet:
 
         client.authenticate_user(owner)
         owner_response = client.get(f'/api/chats/{handshake.id}/')
-        assert owner_response.status_code == status.HTTP_200_OK
-        assert owner_response.data['count'] == 1
+        assert_api_response(owner_response, 200, schema={'count': 1})
 
         client.authenticate_user(requester)
         requester_response = client.get(f'/api/chats/{handshake.id}/')
-        assert requester_response.status_code == status.HTTP_200_OK
-        assert requester_response.data['count'] == 1
+        assert_api_response(requester_response, 200, schema={'count': 1})
 
     def test_cancelled_handshake_messages_accessible_to_both_parties(self):
         """FR-10c: private chat remains accessible after handshake is cancelled."""
@@ -166,13 +164,11 @@ class TestChatViewSet:
 
         client.authenticate_user(owner)
         owner_response = client.get(f'/api/chats/{handshake.id}/')
-        assert owner_response.status_code == status.HTTP_200_OK
-        assert owner_response.data['count'] == 1
+        assert_api_response(owner_response, 200, schema={'count': 1})
 
         client.authenticate_user(requester)
         requester_response = client.get(f'/api/chats/{handshake.id}/')
-        assert requester_response.status_code == status.HTTP_200_OK
-        assert requester_response.data['count'] == 1
+        assert_api_response(requester_response, 200, schema={'count': 1})
 
     def test_group_offer_participant_cannot_read_other_private_thread(self):
         """FR-10e: participant cannot access another participant's private thread."""

--- a/backend/api/tests/integration/test_consumers_ws.py
+++ b/backend/api/tests/integration/test_consumers_ws.py
@@ -122,7 +122,11 @@ class TestGroupChatConsumer:
 
     async def test_owner_can_connect(self, db):
         owner = await async_user()
-        service = await async_service(user=owner, max_participants=4)
+        # Pin schedule_type to 'One-Time' because ServiceFactory's iterator
+        # otherwise alternates between 'One-Time' and 'Recurrent' between
+        # consecutive test runs, and Recurrent group chat requires a
+        # session_id query parameter that this test does not provide.
+        service = await async_service(user=owner, max_participants=4, schedule_type='One-Time')
         async with consumer_for(
             f'/ws/group-chat/{service.id}/', user=owner, auth='cookie',
         ) as comm:
@@ -132,7 +136,7 @@ class TestGroupChatConsumer:
     async def test_outsider_without_handshake_rejected(self, db):
         owner = await async_user()
         outsider = await async_user()
-        service = await async_service(user=owner, max_participants=4)
+        service = await async_service(user=owner, max_participants=4, schedule_type='One-Time')
         comm, connected, _ = await connect_consumer(
             f'/ws/group-chat/{service.id}/', user=outsider, auth='cookie',
         )

--- a/backend/api/tests/integration/test_discovery_api.py
+++ b/backend/api/tests/integration/test_discovery_api.py
@@ -21,6 +21,7 @@ from api.tests.helpers.factories import (
     ServiceFactory,
     HandshakeFactory,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +49,7 @@ class TestAdminPinEvent:
 
         resp = client.post(f'/api/services/{event.id}/pin-event/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         event.refresh_from_db()
         assert event.is_pinned is True
 
@@ -59,7 +60,7 @@ class TestAdminPinEvent:
 
         resp = client.post(f'/api/services/{event.id}/pin-event/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         event.refresh_from_db()
         assert event.is_pinned is False
 
@@ -72,7 +73,7 @@ class TestAdminPinEvent:
 
         resp = client.post(f'/api/services/{event.id}/pin-event/')
 
-        assert resp.status_code == 403
+        assert_problem_detail(resp, 403)
 
     def test_pin_endpoint_rejects_non_event_service(self):
         """Offer and Need services cannot be pinned via the event pin endpoint."""
@@ -90,7 +91,7 @@ class TestAdminPinEvent:
 
         client = APIClient()
         resp = client.get('/api/services/?type=Event')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
 
         results = resp.data.get('results', [])
         pinned_idx = next(
@@ -134,7 +135,7 @@ class TestAdminShowcaseFeatured:
 
         resp = client.post(f'/api/services/{event.id}/feature/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         event.refresh_from_db()
         assert getattr(event, 'is_featured', False) is True
 
@@ -150,7 +151,7 @@ class TestAdminShowcaseFeatured:
 
         # Fetch the featured feed
         resp = client.get('/api/services/featured/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         result_ids = [s['id'] for s in resp.data.get('results', [])]
         assert str(featured_event.id) in result_ids
 
@@ -167,7 +168,7 @@ class TestAdminShowcaseFeatured:
             data={'expires_at': expiry},
             format='json',
         )
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +256,7 @@ class TestFollowSystem:
         client.post(f'/api/users/{followed_provider.id}/follow/')
 
         resp = client.get('/api/services/?type=Offer')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         results = resp.data.get('results', [])
         ids = [str(s['id']) for s in results]
 
@@ -272,7 +273,7 @@ class TestFollowSystem:
 
         resp = client.post(f'/api/users/{followed.id}/follow/')
 
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +307,7 @@ class TestDiscoveryFeedPerformance:
         resp = client.get('/api/services/')
         elapsed = time.monotonic() - start
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert elapsed < self.FEED_SLA_SECONDS, (
             f"Discovery feed took {elapsed:.3f}s — exceeds the {self.FEED_SLA_SECONDS}s NFR-19a SLA."
         )
@@ -328,7 +329,7 @@ class TestDiscoveryFeedPerformance:
         resp = client.get('/api/services/?lat=41.012345&lng=28.974321&distance=10')
         elapsed = time.monotonic() - start
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert elapsed < self.FEED_SLA_SECONDS, (
             f"Location-filtered feed took {elapsed:.3f}s — exceeds the NFR-19a SLA."
         )

--- a/backend/api/tests/integration/test_e2e_utils_api.py
+++ b/backend/api/tests/integration/test_e2e_utils_api.py
@@ -11,6 +11,7 @@ from django.test import override_settings
 
 from api.tests.helpers.factories import UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -28,10 +29,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': 10.5}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['balance'] == 10.5
-        assert response.data['email'] == user.email
-        assert response.data['id'] == str(user.id)
+        assert_api_response(response, 200, schema={'balance': 10.5, 'email': user.email, 'id': str(user.id)})
 
         user.refresh_from_db()
         assert user.timebank_balance == Decimal('10.50')
@@ -44,8 +42,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': 0}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['balance'] == 0.0
+        assert_api_response(response, 200, schema={'balance': 0.0})
 
         user.refresh_from_db()
         assert user.timebank_balance == Decimal('0.00')
@@ -58,7 +55,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': -5.0}, format='json')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         user.refresh_from_db()
         assert user.timebank_balance == Decimal('-5.00')
 
@@ -70,7 +67,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': 100}, format='json')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert 'E2E mode' in response.data['detail']
 
     @override_settings(DJANGO_E2E=True)
@@ -78,7 +75,7 @@ class TestE2ESetBalance:
         client = APIClient()
         response = client.post(self.URL, {'balance': 10}, format='json')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     @override_settings(DJANGO_E2E=True)
     def test_missing_balance_field(self):
@@ -88,7 +85,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {}, format='json')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'balance' in response.data['detail'].lower()
 
     @override_settings(DJANGO_E2E=True)
@@ -99,7 +96,7 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': 'not-a-number'}, format='json')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     @override_settings(DJANGO_E2E=True)
     def test_balance_below_minimum_rejected(self):
@@ -109,5 +106,5 @@ class TestE2ESetBalance:
 
         response = client.post(self.URL, {'balance': -11.0}, format='json')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'range' in response.data['detail'].lower()

--- a/backend/api/tests/integration/test_evaluation_window_close.py
+++ b/backend/api/tests/integration/test_evaluation_window_close.py
@@ -24,6 +24,7 @@ from rest_framework import status
 from api.models import Handshake, EventEvaluationSummary, Service
 from api.tests.helpers.factories import HandshakeFactory, ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -152,9 +153,7 @@ class TestServiceHotScoreAtWindowClose:
             'helpful': False,
             'kindness': False,
         })
-        assert response.status_code == status.HTTP_410_GONE, (
-            "Reputation submission after window close must return 410 Gone."
-        )
+        assert_problem_detail(response, 410)
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +202,7 @@ class TestEventHotScoreAtWindowClose:
             'engaging': True,
             'welcoming': False,
         })
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
         # Expire the window so process_feedback_windows picks it up.
         now = timezone.now()
@@ -306,7 +305,7 @@ class TestEventHotScoreAtWindowClose:
             'engaging': True,
             'welcoming': True,
         })
-        assert r1.status_code == status.HTTP_201_CREATED
+        assert_api_response(r1, 201)
 
         # participant_b submits purely negative evaluation.
         client_b = AuthenticatedAPIClient().authenticate_user(participant_b)
@@ -316,7 +315,7 @@ class TestEventHotScoreAtWindowClose:
             'boring': True,
             'unwelcoming': True,
         })
-        assert r2.status_code == status.HTTP_201_CREATED
+        assert_api_response(r2, 201)
 
         # Expire both windows so process_feedback_windows picks them up.
         now = timezone.now()
@@ -374,6 +373,4 @@ class TestEventHotScoreAtWindowClose:
             'engaging': False,
             'welcoming': True,
         })
-        assert response.status_code == status.HTTP_410_GONE, (
-            "Event evaluation after window close must return 410 Gone."
-        )
+        assert_problem_detail(response, 410)

--- a/backend/api/tests/integration/test_event_browse_api.py
+++ b/backend/api/tests/integration/test_event_browse_api.py
@@ -21,6 +21,7 @@ from rest_framework.test import APIClient
 from api.tests.helpers.factories import UserFactory, ServiceFactory, HandshakeFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Service
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -59,8 +60,7 @@ class TestEventFeedAnonymousAccess:
 
         response = client.get('/api/services/?type=Event')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'results' in response.data
+        assert_api_response(response, 200, contains={'results'})
 
     def test_anonymous_user_sees_active_events(self):
         """FR-12a: anonymous feed includes Active events."""
@@ -81,7 +81,7 @@ class TestEventFeedAnonymousAccess:
 
         response = client.get('/api/services/?type=Event')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'Auth User Event' in titles
 
@@ -107,7 +107,7 @@ class TestEventDateRangeFilter:
 
         response = client.get(f'/api/services/?type=Event&date_from={date_from}')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'Future Event' in titles
         assert 'Past Event' not in titles
@@ -122,7 +122,7 @@ class TestEventDateRangeFilter:
 
         response = client.get(f'/api/services/?type=Event&date_to={date_to}')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'Near Event' in titles
         assert 'Far Event' not in titles
@@ -141,7 +141,7 @@ class TestEventDateRangeFilter:
             f'/api/services/?type=Event&date_from={date_from}&date_to={date_to}'
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'In Window' in titles
         assert 'Before Window' not in titles
@@ -153,7 +153,7 @@ class TestEventDateRangeFilter:
 
         response = client.get('/api/services/?type=Event&date_from=not-a-date')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_invalid_date_to_returns_400(self):
         """FR-12c: invalid date_to value should return 400, not silently ignored."""
@@ -161,7 +161,7 @@ class TestEventDateRangeFilter:
 
         response = client.get('/api/services/?type=Event&date_to=not-a-date')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_date_filter_does_not_affect_non_event_services(self):
         """FR-12c: date_from/date_to only applies when type=Event; other services unaffected."""
@@ -172,7 +172,7 @@ class TestEventDateRangeFilter:
         # Query without type=Event — the date filter should not silently drop regular services
         response = client.get(f'/api/services/?type=Offer&date_from={date_from}')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'Regular Offer' in titles
 
@@ -193,7 +193,7 @@ class TestEventQuotaDisplay:
 
         response = client.get('/api/services/?type=Event')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         event_data = next(
             (s for s in response.data['results'] if s['title'] == 'Quota Event'), None
         )
@@ -247,7 +247,7 @@ class TestEventJoinAuthGuard:
 
         response = client.post(f'/api/handshakes/services/{event.id}/join-event/')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_unauthenticated_user_can_still_view_event_detail(self):
         """FR-12f: read-only access to event detail is allowed anonymously."""
@@ -256,7 +256,7 @@ class TestEventJoinAuthGuard:
 
         response = client.get(f'/api/services/{event.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +276,7 @@ class TestCancelledEventVisibility:
 
         response = client.get('/api/services/?type=Event')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         titles = [s['title'] for s in response.data['results']]
         assert 'Active Event' in titles
         assert 'Cancelled Event' not in titles
@@ -293,8 +293,7 @@ class TestCancelledEventVisibility:
         response = client.get(f'/api/services/{cancelled.id}/')
 
         # Object should be retrievable so the frontend can show cancellation state
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'Cancelled'
+        assert_api_response(response, 200, schema={'status': 'Cancelled'})
 
     def test_cancelled_event_detail_exposes_cancelled_status_field(self):
         """
@@ -329,7 +328,7 @@ class TestCancelEventReasonValidation:
 
         response = client.post(f'/api/services/{event.id}/cancel-event/', data={})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_cancel_event_with_blank_reason_returns_400(self):
         organizer = UserFactory()
@@ -341,7 +340,7 @@ class TestCancelEventReasonValidation:
             data={'reason': '   '},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_cancel_event_with_reason_succeeds(self):
         organizer = UserFactory()
@@ -353,6 +352,6 @@ class TestCancelEventReasonValidation:
             data={'reason': 'Venue unavailable'},
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         event.refresh_from_db()
         assert event.status == 'Cancelled'

--- a/backend/api/tests/integration/test_event_chat.py
+++ b/backend/api/tests/integration/test_event_chat.py
@@ -18,6 +18,7 @@ from api.tests.helpers.factories import (
     UserFactory, ServiceFactory, HandshakeFactory, ChatMessageFactory,
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -78,7 +79,7 @@ class TestChatViewSetExcludesEvents:
         client.authenticate_user(user)
 
         response = client.get('/api/chats/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         results = response.data['results']
         handshake_ids = {item['handshake_id'] for item in results}
@@ -99,7 +100,7 @@ class TestChatViewSetExcludesEvents:
         client.authenticate_user(user)
 
         response = client.get('/api/chats/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data['results']) == 0
 
     def test_requester_side_event_excluded(self):
@@ -115,7 +116,7 @@ class TestChatViewSetExcludesEvents:
         client.authenticate_user(requester)
 
         response = client.get('/api/chats/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data['results']) == 0
 
 
@@ -143,9 +144,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(organizer)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'room' in response.data
-        assert 'messages' in response.data
+        assert_api_response(response, 200, contains={'room', 'messages'})
 
     def test_accepted_participant_can_access_event_chat(self):
         """A participant with 'accepted' status can access the event chat."""
@@ -158,7 +157,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_checked_in_participant_can_access_event_chat(self):
         """A participant with 'checked_in' status can access the event chat."""
@@ -171,7 +170,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_attended_participant_can_access_event_chat(self):
         """A participant with 'attended' status can access the event chat."""
@@ -184,7 +183,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_non_participant_denied_event_chat(self):
         """A user with no handshake cannot access the event chat."""
@@ -195,7 +194,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(outsider)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_pending_participant_denied_event_chat(self):
         """A user with only a pending handshake cannot access the event chat."""
@@ -208,7 +207,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(user)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_cancelled_participant_denied_event_chat(self):
         """A user with a cancelled handshake cannot access the event chat."""
@@ -221,7 +220,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(user)
 
         response = client.get(f'/api/public-chat/{event.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     # ── POST (create message) ─────────────────────────────────────────────────
 
@@ -234,7 +233,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(organizer)
 
         response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Hello from organizer!'})
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert PublicChatMessage.objects.filter(
             room=event.chat_room,
             body='Hello from organizer!'
@@ -251,7 +250,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Participant message'})
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
     def test_non_participant_cannot_send_event_chat_message(self):
         """A non-participant cannot send a message to event chat."""
@@ -262,7 +261,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(outsider)
 
         response = client.post(f'/api/public-chat/{event.id}/', {'body': 'Sneaky msg'})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert not PublicChatMessage.objects.filter(
             room=event.chat_room,
             body='Sneaky msg'
@@ -279,7 +278,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(random_user)
 
         response = client.get(f'/api/public-chat/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_non_event_public_chat_send_open_to_all(self):
         """For non-event services, any authenticated user can send messages."""
@@ -290,7 +289,7 @@ class TestPublicChatEventAccess:
         client.authenticate_user(random_user)
 
         response = client.post(f'/api/public-chat/{service.id}/', {'body': 'Public question'})
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
 
 # ─── GroupChatViewSet: events rejected ────────────────────────────────────────
@@ -309,7 +308,7 @@ class TestGroupChatEventAccess:
         client.authenticate_user(organizer)
 
         response = client.get(f'/api/group-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_event_organizer_can_post_group_chat(self):
         """POST /api/group-chat/{event_id}/ returns 201 for organizer."""
@@ -324,7 +323,7 @@ class TestGroupChatEventAccess:
             {'body': 'Hello from organizer'},
             format='json',
         )
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
     def test_event_checked_in_participant_can_access(self):
         """A checked-in event participant can access group chat."""
@@ -336,7 +335,7 @@ class TestGroupChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.get(f'/api/group-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_event_participant_list_includes_checked_in_and_attended(self):
         """Event group chat participants include all active event statuses."""
@@ -353,7 +352,7 @@ class TestGroupChatEventAccess:
         client.authenticate_user(organizer)
 
         response = client.get(f'/api/group-chat/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         participant_ids = {participant['id'] for participant in response.data['participants']}
         assert participant_ids == {
             str(organizer.id),
@@ -372,7 +371,7 @@ class TestGroupChatEventAccess:
         client.authenticate_user(participant)
 
         response = client.get(f'/api/group-chat/{event.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_non_event_group_chat_still_works(self):
         """Regular group services still work with group chat."""
@@ -383,4 +382,4 @@ class TestGroupChatEventAccess:
         client.authenticate_user(owner)
 
         response = client.get(f'/api/group-chat/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)

--- a/backend/api/tests/integration/test_events_feature_api.py
+++ b/backend/api/tests/integration/test_events_feature_api.py
@@ -14,6 +14,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.tests.helpers.factories import ServiceFactory, UserFactory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 def _event(scheduled_time, **overrides):
@@ -48,7 +49,7 @@ class TestDateRangeStrategyAPI:
                 'date_to': (now + timedelta(days=5)).date().isoformat(),
             },
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results'] if isinstance(response.data, dict) else response.data
         ids = {r['id'] for r in results}
         assert str(in_range.id) in ids
@@ -71,7 +72,7 @@ class TestDateRangeStrategyAPI:
                 'date_from': (now + timedelta(days=1)).date().isoformat(),
             },
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results'] if isinstance(response.data, dict) else response.data
         ids = {r['id'] for r in results}
         assert str(with_time.id) in ids
@@ -83,7 +84,7 @@ class TestDateRangeStrategyAPI:
             '/api/services/',
             {'type': 'Event', 'date_from': 'not-a-real-date'},
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         # Field-level error so the frontend can attach it to the right input.
         assert 'date_from' in response.data.get('field_errors', {})
 
@@ -96,7 +97,7 @@ class TestDateRangeStrategyAPI:
             '/api/services/',
             {'type': 'Offer', 'date_from': '2026-01-01', 'date_to': '2026-12-31'},
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
 
 @pytest.mark.django_db
@@ -108,7 +109,7 @@ class TestEditLockSerializer:
         event = _event(timezone.now() + timedelta(days=10))
         client = APIClient()
         response = client.get(f'/api/services/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['edit_locked'] is False
         assert response.data['edit_lock_reason'] is None
 
@@ -116,7 +117,7 @@ class TestEditLockSerializer:
         event = _event(timezone.now() + timedelta(hours=12))
         client = APIClient()
         response = client.get(f'/api/services/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['edit_locked'] is True
         assert 'lockdown' in (response.data['edit_lock_reason'] or '').lower()
 
@@ -124,7 +125,7 @@ class TestEditLockSerializer:
         event = _event(timezone.now() - timedelta(hours=1))
         client = APIClient()
         response = client.get(f'/api/services/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['edit_locked'] is True
 
     def test_terminal_status_service_is_locked(self):
@@ -135,7 +136,7 @@ class TestEditLockSerializer:
         )
         client = APIClient()
         response = client.get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['edit_locked'] is True
 
 
@@ -152,5 +153,4 @@ class TestCancelledEventDetail:
         )
         client = APIClient()
         response = client.get(f'/api/services/{event.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'Cancelled'
+        assert_api_response(response, 200, schema={'status': 'Cancelled'})

--- a/backend/api/tests/integration/test_explore_only_endpoint.py
+++ b/backend/api/tests/integration/test_explore_only_endpoint.py
@@ -21,6 +21,7 @@ from api.tests.helpers.factories import (
     ServiceFactory,
     UserFactory,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -35,7 +36,7 @@ class TestNewcomerOwnerSerializerField:
         client.force_authenticate(user=viewer)
         resp = client.get(f'/api/services/{svc.id}/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_newcomer_owner'] is True
 
     def test_newcomer_owner_field_false_for_veteran(self):
@@ -47,7 +48,7 @@ class TestNewcomerOwnerSerializerField:
         client.force_authenticate(user=viewer)
         resp = client.get(f'/api/services/{svc.id}/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_newcomer_owner'] is False
 
 
@@ -64,7 +65,7 @@ class TestExploreOnlyEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?explore_only=true')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         data = resp.json()
         assert data['count'] >= 1
         first = data['results'][0]
@@ -80,8 +81,7 @@ class TestExploreOnlyEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?explore_only=true')
 
-        assert resp.status_code == 200
-        assert resp.json()['count'] == 0
+        assert_api_response(resp, 200, schema={'count': 0})
 
     def test_explore_pool_field_is_none_on_regular_list(self):
         # Without ?explore_only the field exists but is None for every card.
@@ -93,7 +93,7 @@ class TestExploreOnlyEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         results = resp.json().get('results', resp.json())
         assert len(results) >= 1
         assert results[0]['explore_pool'] is None
@@ -123,7 +123,7 @@ class TestExploreOnlyQueryParam:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?explore_only=true')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         ids = {item['id'] for item in resp.json()['results']}
         assert str(cold_svc.id) in ids
         assert str(established_svc.id) not in ids
@@ -137,7 +137,7 @@ class TestExploreOnlyQueryParam:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         ids = {item['id'] for item in resp.json()['results']}
         assert str(a.id) in ids
         assert str(b.id) in ids

--- a/backend/api/tests/integration/test_for_you_endpoint.py
+++ b/backend/api/tests/integration/test_for_you_endpoint.py
@@ -10,6 +10,7 @@ from api.tests.helpers.factories import (
     ServiceFactory,
     UserFactory,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 def _make_tag(qid):
@@ -38,7 +39,7 @@ class TestForYouFeedEndpoint:
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?sort=for_you')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         data = resp.json()
         results = data['results']
         assert len(results) >= 1
@@ -53,8 +54,7 @@ class TestForYouFeedEndpoint:
         ServiceFactory(type='Offer', status='Active')
         client = APIClient()
         resp = client.get('/api/services/?sort=for_you')
-        assert resp.status_code == 200
-        assert resp.json()['results'] == []
+        assert_api_response(resp, 200, schema={'results': []})
 
     def test_not_onboarded_viewer_gets_empty_for_you(self):
         viewer = UserFactory(is_onboarded=False)
@@ -62,8 +62,7 @@ class TestForYouFeedEndpoint:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?sort=for_you')
-        assert resp.status_code == 200
-        assert resp.json()['results'] == []
+        assert_api_response(resp, 200, schema={'results': []})
 
     def test_onboarded_without_skills_gets_empty_for_you(self):
         viewer = UserFactory(is_onboarded=True)
@@ -71,8 +70,7 @@ class TestForYouFeedEndpoint:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/?sort=for_you')
-        assert resp.status_code == 200
-        assert resp.json()['results'] == []
+        assert_api_response(resp, 200, schema={'results': []})
 
     def test_impressions_logged_on_for_you_response(self):
         from api.models import ForYouEvent
@@ -103,7 +101,7 @@ class TestForYouClickAttribution:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get(f'/api/services/{svc.id}/?from=for_you')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert ForYouEvent.objects.filter(
             viewer=viewer, service=svc,
             kind=ForYouEvent.CLICK, source=ForYouEvent.SOURCE_FOR_YOU,
@@ -192,7 +190,7 @@ class TestForYouMetricsEndpoint:
         client = APIClient()
         client.force_authenticate(user=admin)
         resp = client.get('/api/services/for-you-metrics/?days=7')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         body = resp.json()
         assert body['days'] == 7
         # Top-level note documents what `count` actually represents so admins
@@ -215,4 +213,4 @@ class TestForYouMetricsEndpoint:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.get('/api/services/for-you-metrics/?days=7')
-        assert resp.status_code == 403
+        assert_problem_detail(resp, 403)

--- a/backend/api/tests/integration/test_forum_api.py
+++ b/backend/api/tests/integration/test_forum_api.py
@@ -12,6 +12,7 @@ from api.tests.helpers.factories import (
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import ForumCategory, ForumTopic, ForumPost, Report
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -26,7 +27,7 @@ class TestForumCategoryViewSet:
         
         client = APIClient()
         response = client.get('/api/forum/categories/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) == 3
     
     def test_retrieve_category_by_slug(self):
@@ -35,8 +36,7 @@ class TestForumCategoryViewSet:
         
         client = APIClient()
         response = client.get(f'/api/forum/categories/{category.slug}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['slug'] == 'general'
+        assert_api_response(response, 200, schema={'slug': 'general'})
     
     def test_create_category_admin_only(self):
         """Test only admins can create categories"""
@@ -53,7 +53,7 @@ class TestForumCategoryViewSet:
             'icon': 'message-square',
             'color': 'blue'
         })
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         
         client.authenticate_user(admin)
         response = client.post('/api/forum/categories/', {
@@ -63,7 +63,7 @@ class TestForumCategoryViewSet:
             'icon': 'message-square',
             'color': 'blue'
         })
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
 
 @pytest.mark.django_db
@@ -78,8 +78,7 @@ class TestForumTopicViewSet:
         
         client = APIClient()
         response = client.get('/api/forum/topics/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'results' in response.data
+        assert_api_response(response, 200, contains={'results'})
     
     def test_list_topics_by_category(self):
         """Test filtering topics by category"""
@@ -90,7 +89,7 @@ class TestForumTopicViewSet:
         
         client = APIClient()
         response = client.get('/api/forum/topics/?category=cat1')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data['results']) == 3
     
     def test_create_topic(self):
@@ -106,8 +105,7 @@ class TestForumTopicViewSet:
             'title': 'New Topic',
             'body': 'This is a new topic discussion'
         })
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['title'] == 'New Topic'
+        assert_api_response(response, 201, schema={'title': 'New Topic'})
         assert ForumTopic.objects.filter(title='New Topic').exists()
     
     def test_update_topic_author(self):
@@ -122,8 +120,7 @@ class TestForumTopicViewSet:
         response = client.patch(f'/api/forum/topics/{topic.id}/', {
             'title': 'Updated Title'
         })
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Updated Title'
+        assert_api_response(response, 200, schema={'title': 'Updated Title'})
     
     def test_update_topic_unauthorized(self):
         """Test non-author cannot update topic"""
@@ -138,7 +135,7 @@ class TestForumTopicViewSet:
         response = client.patch(f'/api/forum/topics/{topic.id}/', {
             'title': 'Hacked Title'
         })
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
 @pytest.mark.django_db
 @pytest.mark.integration
@@ -164,17 +161,14 @@ class TestForumActivityView:
 
         response = client.get('/api/forum/my-activity/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['my_topics'] == 2
-        assert response.data['my_replies'] == 3
-        assert response.data['open_topics'] == 1
+        assert_api_response(response, 200, schema={'my_topics': 2, 'my_replies': 3, 'open_topics': 1})
         assert len(response.data['open_topic_items']) == 1
         assert response.data['open_topic_items'][0]['id'] == str(open_topic.id)
         assert response.data['open_topic_items'][0]['is_locked'] is False
 
     def test_forum_activity_requires_authentication(self):
         response = APIClient().get('/api/forum/my-activity/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 @pytest.mark.django_db
@@ -189,8 +183,7 @@ class TestForumPostViewSet:
         
         client = APIClient()
         response = client.get(f'/api/forum/topics/{topic.id}/posts/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 5
+        assert_api_response(response, 200, schema={'count': 5})
         assert len(response.data['results']) == 5
     
     def test_create_post(self):
@@ -204,8 +197,7 @@ class TestForumPostViewSet:
         response = client.post(f'/api/forum/topics/{topic.id}/posts/', {
             'body': 'This is a reply to the topic'
         })
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['body'] == 'This is a reply to the topic'
+        assert_api_response(response, 201, schema={'body': 'This is a reply to the topic'})
         assert ForumPost.objects.filter(body='This is a reply to the topic').exists()
     
     def test_update_post_author(self):
@@ -220,8 +212,7 @@ class TestForumPostViewSet:
         response = client.patch(f'/api/forum/posts/{post.id}/', {
             'body': 'Updated post content'
         })
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['body'] == 'Updated post content'
+        assert_api_response(response, 200, schema={'body': 'Updated post content'})
     
     def test_delete_post_soft_delete(self):
         """Test post deletion is soft delete"""
@@ -233,7 +224,7 @@ class TestForumPostViewSet:
         client.authenticate_user(author)
 
         response = client.delete(f'/api/forum/posts/{post.id}/')
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert_api_response(response, 204)
 
         post.refresh_from_db()
         assert post.is_deleted is True
@@ -254,9 +245,7 @@ class TestForumTopicEdit:
 
         response = client.patch(f'/api/forum/topics/{topic.id}/', {'title': 'Updated Title'})
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Updated Title'
-        assert response.data['body'] == 'Original body text here.'
+        assert_api_response(response, 200, schema={'title': 'Updated Title', 'body': 'Original body text here.'})
         topic.refresh_from_db()
         assert topic.title == 'Updated Title'
 
@@ -270,9 +259,7 @@ class TestForumTopicEdit:
 
         response = client.patch(f'/api/forum/topics/{topic.id}/', {'body': 'Brand new body content here.'})
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Original Title'
-        assert response.data['body'] == 'Brand new body content here.'
+        assert_api_response(response, 200, schema={'title': 'Original Title', 'body': 'Brand new body content here.'})
         topic.refresh_from_db()
         assert topic.body == 'Brand new body content here.'
 
@@ -289,9 +276,7 @@ class TestForumTopicEdit:
             'body': 'New body content.',
         })
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'New Title'
-        assert response.data['body'] == 'New body content.'
+        assert_api_response(response, 200, schema={'title': 'New Title', 'body': 'New body content.'})
 
     def test_other_user_cannot_edit_topic(self):
         """A user who did not create the topic receives 403"""
@@ -304,7 +289,7 @@ class TestForumTopicEdit:
 
         response = client.patch(f'/api/forum/topics/{topic.id}/', {'title': 'Stolen Title'})
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         topic.refresh_from_db()
         assert topic.title == 'Original Title'
 
@@ -314,7 +299,7 @@ class TestForumTopicEdit:
 
         response = APIClient().patch(f'/api/forum/topics/{topic.id}/', {'title': 'No Auth Title'})
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
         topic.refresh_from_db()
         assert topic.title == 'Original Title'
 
@@ -332,8 +317,7 @@ class TestForumTopicEdit:
             'body': 'Admin edited body.',
         })
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Admin Edited Title'
+        assert_api_response(response, 200, schema={'title': 'Admin Edited Title'})
 
     def test_edit_ignores_non_editable_fields(self):
         """Patching category or is_pinned has no effect — only title/body are allowed"""
@@ -351,7 +335,7 @@ class TestForumTopicEdit:
             'is_pinned': True,
         })
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         topic.refresh_from_db()
         assert topic.category_id == category.id  # unchanged
         assert topic.is_pinned is False           # unchanged
@@ -366,7 +350,7 @@ class TestForumTopicEdit:
 
         response = client.patch(f'/api/forum/topics/{topic.id}/', {'title': 'Hi'})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_title_preserves_special_characters(self):
         """Special characters like & are stored and returned as-is (not HTML-encoded)"""
@@ -378,8 +362,7 @@ class TestForumTopicEdit:
 
         response = client.patch(f'/api/forum/topics/{topic.id}/', {'title': 'Cats & Dogs'})
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Cats & Dogs'
+        assert_api_response(response, 200, schema={'title': 'Cats & Dogs'})
         topic.refresh_from_db()
         assert topic.title == 'Cats & Dogs'
 
@@ -391,7 +374,7 @@ class TestForumTopicEdit:
 
         response = client.patch('/api/forum/topics/00000000-0000-0000-0000-000000000000/', {'title': 'Ghost'})
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 @pytest.mark.django_db
@@ -430,7 +413,7 @@ class TestForumTopicSorting:
         topic_old, topic_mid, topic_new = self._make_topics_with_ages(category)
 
         response = APIClient().get('/api/forum/topics/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = [t['id'] for t in response.data['results']]
         assert ids.index(str(topic_new.pk)) < ids.index(str(topic_mid.pk))
         assert ids.index(str(topic_mid.pk)) < ids.index(str(topic_old.pk))
@@ -441,7 +424,7 @@ class TestForumTopicSorting:
         topic_old, _mid, topic_new = self._make_topics_with_ages(category)
 
         response = APIClient().get('/api/forum/topics/?sort=newest')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = [t['id'] for t in response.data['results']]
         assert ids.index(str(topic_new.pk)) < ids.index(str(topic_old.pk))
 
@@ -451,7 +434,7 @@ class TestForumTopicSorting:
         topic_old, _mid, _new = self._make_topics_with_ages(category)
 
         response = APIClient().get('/api/forum/topics/?sort=most_active')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = [t['id'] for t in response.data['results']]
         assert ids[0] == str(topic_old.pk)
 
@@ -471,7 +454,7 @@ class TestForumTopicSorting:
         ForumPost.objects.filter(pk=deleted_post.pk).update(created_at=now - timedelta(minutes=5))
 
         response = APIClient().get('/api/forum/topics/?sort=most_active')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = [t['id'] for t in response.data['results']]
         # topic_b was created more recently; topic_a's only post is deleted
         assert ids[0] == str(topic_b.pk)
@@ -492,7 +475,7 @@ class TestForumTopicSorting:
         ForumPost.objects.filter(pk=post.pk).update(created_at=now - timedelta(hours=1))
 
         response = APIClient().get('/api/forum/topics/?category=sort-cat-a&sort=most_active')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         result_ids = {t['id'] for t in response.data['results']}
         assert str(topic_a.pk) in result_ids
         assert str(topic_b.pk) not in result_ids
@@ -513,7 +496,7 @@ class TestForumTopicSorting:
         ForumPost.objects.filter(pk=post.pk).update(created_at=now - timedelta(minutes=1))
 
         response = APIClient().get('/api/forum/topics/?sort=most_active')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = [t['id'] for t in response.data['results']]
         assert ids[0] == str(pinned.pk)
 
@@ -523,7 +506,7 @@ class TestForumTopicSorting:
         ForumTopicFactory.create_batch(3, category=category)
 
         response = APIClient().get('/api/forum/topics/?sort=garbage')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
 
 @pytest.mark.django_db
@@ -545,7 +528,7 @@ class TestForumTopicReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(topic.id), {'type': 'spam'})
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Report.objects.filter(
             reporter=reporter,
             reported_forum_topic=topic,
@@ -566,7 +549,7 @@ class TestForumTopicReport:
             'description': 'This topic contains offensive language.',
         })
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         report = Report.objects.get(reporter=reporter, reported_forum_topic=topic)
         assert report.description == 'This topic contains offensive language.'
 
@@ -595,7 +578,7 @@ class TestForumTopicReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(topic.id), {'type': 'harassment'})
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         data = response.data
         assert 'id' in data
         assert data['type'] == 'harassment'
@@ -613,7 +596,7 @@ class TestForumTopicReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(topic.id), {'type': 'not_a_valid_type'})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_self_report_on_own_topic_is_rejected(self):
         """A user cannot report a topic they authored."""
@@ -625,7 +608,7 @@ class TestForumTopicReport:
         client.authenticate_user(author)
         response = client.post(self._url(topic.id), {'type': 'spam'})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert not Report.objects.filter(reported_forum_topic=topic).exists()
 
     def test_unauthenticated_report_is_blocked(self):
@@ -648,7 +631,7 @@ class TestForumTopicReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(uuid.uuid4()), {'type': 'spam'})
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 @pytest.mark.django_db
@@ -671,7 +654,7 @@ class TestForumPostReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(post.id), {'type': 'harassment'})
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Report.objects.filter(
             reporter=reporter,
             reported_forum_post=post,
@@ -693,7 +676,7 @@ class TestForumPostReport:
             'description': 'This reply is promotional content.',
         })
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         report = Report.objects.get(reporter=reporter, reported_forum_post=post)
         assert report.description == 'This reply is promotional content.'
 
@@ -740,7 +723,7 @@ class TestForumPostReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(post.id), {'type': 'scam'})
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         data = response.data
         assert 'id' in data
         assert data['type'] == 'scam'
@@ -760,7 +743,7 @@ class TestForumPostReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(post.id), {'type': 'gibberish'})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_self_report_on_own_post_is_rejected(self):
         """A user cannot report a post they authored."""
@@ -773,7 +756,7 @@ class TestForumPostReport:
         client.authenticate_user(author)
         response = client.post(self._url(post.id), {'type': 'spam'})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert not Report.objects.filter(reported_forum_post=post).exists()
 
     def test_unauthenticated_post_report_is_blocked(self):
@@ -797,7 +780,7 @@ class TestForumPostReport:
         client.authenticate_user(reporter)
         response = client.post(self._url(uuid.uuid4()), {'type': 'spam'})
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 @pytest.mark.django_db
@@ -818,7 +801,7 @@ class TestForumTopicLockUnlock:
         client.authenticate_user(admin)
         response = client.post(self._url(topic.id))
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['is_locked'] is True
         topic.refresh_from_db()
         assert topic.is_locked is True
@@ -833,7 +816,7 @@ class TestForumTopicLockUnlock:
         client.authenticate_user(admin)
         response = client.post(self._url(topic.id))
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['is_locked'] is False
         topic.refresh_from_db()
         assert topic.is_locked is False
@@ -882,7 +865,7 @@ class TestForumTopicLockUnlock:
         client.authenticate_user(user)
         response = client.post(self._url(topic.id))
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         topic.refresh_from_db()
         assert topic.is_locked is False
 
@@ -906,7 +889,7 @@ class TestForumTopicLockUnlock:
         client.authenticate_user(admin)
         response = client.post(f'/api/forum/topics/{uuid.uuid4()}/lock/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 @pytest.mark.django_db
@@ -927,7 +910,7 @@ class TestPostingToLockedThread:
             {'body': 'This should not be allowed.'},
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert not ForumPost.objects.filter(topic=topic).exists()
 
     def test_posting_to_unlocked_topic_succeeds(self):
@@ -943,7 +926,7 @@ class TestPostingToLockedThread:
             {'body': 'A valid reply.'},
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert ForumPost.objects.filter(topic=topic).exists()
 
     def test_lock_then_post_is_rejected(self):
@@ -964,7 +947,7 @@ class TestPostingToLockedThread:
             {'body': 'Trying to post after lock.'},
         )
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
     def test_unlock_then_post_succeeds(self):
         """Admin unlocks a previously locked topic; reply is then accepted."""
@@ -984,7 +967,7 @@ class TestPostingToLockedThread:
             {'body': 'Now this should work.'},
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
 
 @pytest.mark.django_db
@@ -1010,7 +993,7 @@ class TestForumPostRestore:
         client.authenticate_user(admin)
         response = client.post(self._url(post.id))
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         post.refresh_from_db()
         assert post.is_deleted is False
 
@@ -1025,7 +1008,7 @@ class TestForumPostRestore:
         client.authenticate_user(admin)
         response = client.post(self._url(post.id))
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         data = response.data
         assert str(post.id) == str(data['id'])
         assert data['is_deleted'] is False
@@ -1045,7 +1028,7 @@ class TestForumPostRestore:
         assert post.is_deleted is True
 
         response = admin_client.post(self._url(post.id))
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         post.refresh_from_db()
         assert post.is_deleted is False
 
@@ -1060,7 +1043,7 @@ class TestForumPostRestore:
         client.authenticate_user(user)
         response = client.post(self._url(post.id))
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         post.refresh_from_db()
         assert post.is_deleted is True
 
@@ -1087,7 +1070,7 @@ class TestForumPostRestore:
         client.authenticate_user(admin)
         response = client.post(self._url(post.id))
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_restore_nonexistent_post_returns_404(self):
         """Restoring a UUID that does not exist returns 404."""
@@ -1098,7 +1081,7 @@ class TestForumPostRestore:
         client.authenticate_user(admin)
         response = client.post(self._url(uuid.uuid4()))
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 # ---------------------------------------------------------------------------
@@ -1189,7 +1172,7 @@ class TestDeletedAuthorTraceability:
         author.delete()
 
         response = APIClient().get('/api/forum/topics/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         result = next(t for t in response.data['results'] if t['id'] == topic_id)
         assert result['author_name'] == '[Deleted User]'
@@ -1205,8 +1188,7 @@ class TestDeletedAuthorTraceability:
         author.delete()
 
         response = APIClient().get(f'/api/forum/topics/{topic.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['author_name'] == '[Deleted User]'
+        assert_api_response(response, 200, schema={'author_name': '[Deleted User]'})
         assert response.data['author_id'] is None
         assert response.data['author_avatar_url'] is None
 
@@ -1220,7 +1202,7 @@ class TestDeletedAuthorTraceability:
         author.delete()
 
         response = APIClient().get(f'/api/forum/topics/{topic.id}/posts/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         result = next(p for p in response.data['results'] if str(p['id']) == str(post.id))
         assert result['author_name'] == '[Deleted User]'
@@ -1237,7 +1219,7 @@ class TestDeletedAuthorTraceability:
         post_author.delete()
 
         response = APIClient().get(f'/api/forum/topics/{topic.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         inline_post = next(p for p in response.data['posts'] if str(p['id']) == str(post.id))
         assert inline_post['author_name'] == '[Deleted User]'
@@ -1252,7 +1234,7 @@ class TestDeletedAuthorTraceability:
         ForumTopicFactory(category=category, author=author)
 
         response = APIClient().get('/api/forum/topics/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         result = next(t for t in response.data['results'] if t['author_id'] == str(author.id))
         assert result['author_name'] == 'Alice Smith'
@@ -1266,7 +1248,7 @@ class TestDeletedAuthorTraceability:
         post = ForumPostFactory(topic=topic, author=author)
 
         response = APIClient().get(f'/api/forum/topics/{topic.id}/posts/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         result = next(p for p in response.data['results'] if str(p['id']) == str(post.id))
         assert result['author_name'] == 'Bob Jones'
@@ -1285,7 +1267,7 @@ class TestDeletedAuthorTraceability:
         deleted_author.delete()
 
         response = APIClient().get('/api/forum/topics/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         results = {t['id']: t for t in response.data['results']}
 

--- a/backend/api/tests/integration/test_handshake_api.py
+++ b/backend/api/tests/integration/test_handshake_api.py
@@ -14,6 +14,7 @@ from api.tests.helpers.factories import (
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Handshake, ChatMessage, TransactionHistory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -31,7 +32,7 @@ class TestExpressInterestView:
         client.authenticate_user(requester)
         
         response = client.post(f'/api/services/{service.id}/interest/')
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Handshake.objects.filter(
             service=service,
             requester=requester,
@@ -55,7 +56,7 @@ class TestExpressInterestView:
 
         response = client.post(f'/api/services/{service.id}/interest/')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Handshake.objects.filter(
             service=service, requester=requester
@@ -74,7 +75,7 @@ class TestExpressInterestView:
 
         response = client.post(f'/api/services/{need.id}/interest/')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Handshake.objects.filter(
             service=need, requester=requester
@@ -94,7 +95,7 @@ class TestExpressInterestView:
 
         response = client.post(f'/api/handshakes/services/{service.id}/interest/')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
     
     def test_express_interest_insufficient_balance(self):
@@ -107,7 +108,7 @@ class TestExpressInterestView:
         client.authenticate_user(requester)
         
         response = client.post(f'/api/services/{service.id}/interest/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
     
     def test_express_interest_own_service(self):
         """Test cannot express interest in own service"""
@@ -118,7 +119,7 @@ class TestExpressInterestView:
         client.authenticate_user(user)
         
         response = client.post(f'/api/services/{service.id}/interest/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
     
     def test_express_interest_max_participants(self):
         """Test cannot express interest when max participants reached"""
@@ -133,7 +134,7 @@ class TestExpressInterestView:
         client.authenticate_user(requester2)
         
         response = client.post(f'/api/services/{service.id}/interest/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_express_interest_creates_chat_thread_with_opening_message(self):
         """FR-10a/10b: expressing interest creates private thread and opening message."""
@@ -145,20 +146,20 @@ class TestExpressInterestView:
         client.authenticate_user(requester)
 
         interest_response = client.post(f'/api/services/{service.id}/interest/')
-        assert interest_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(interest_response, 201)
 
         handshake_id = interest_response.data['id']
         assert str(interest_response.data['status']).lower() == 'pending'
 
         # Requester can see the conversation in chat list.
         requester_list = client.get('/api/chats/')
-        assert requester_list.status_code == status.HTTP_200_OK
+        assert_api_response(requester_list, 200)
         requester_rows = requester_list.data.get('results', requester_list.data)
         assert any(row['handshake_id'] == str(handshake_id) for row in requester_rows)
 
         # Requester can fetch messages and sees the auto opening text.
         requester_thread = client.get(f'/api/chats/{handshake_id}/')
-        assert requester_thread.status_code == status.HTTP_200_OK
+        assert_api_response(requester_thread, 200)
         requester_messages = requester_thread.data.get('results', [])
         assert len(requester_messages) >= 1
         assert any(
@@ -169,7 +170,7 @@ class TestExpressInterestView:
         # Provider can also fetch the same thread.
         client.authenticate_user(provider)
         provider_thread = client.get(f'/api/chats/{handshake_id}/')
-        assert provider_thread.status_code == status.HTTP_200_OK
+        assert_api_response(provider_thread, 200)
         provider_messages = provider_thread.data.get('results', [])
         assert any(
             'interested in your service' in message['body']
@@ -194,7 +195,7 @@ class TestExpressInterestView:
         ):
             response = client.post(f'/api/services/{service.id}/interest/')
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert fake_channel_layer.group_send.await_count >= 1
         chat_group_name = f"chat_{response.data['id']}"
         chat_events = [
@@ -223,7 +224,7 @@ class TestHandshakeViewSet:
         client.authenticate_user(user)
         
         response = client.get('/api/handshakes/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert isinstance(response.data, list)
         assert len(response.data) == 3
 
@@ -245,7 +246,7 @@ class TestHandshakeViewSet:
         client.authenticate_user(requester)
 
         response = client.get('/api/handshakes/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) >= 1
         h = next((x for x in response.data if str(x['id']) == str(handshake.id)), None)
         assert h is not None
@@ -259,7 +260,7 @@ class TestHandshakeViewSet:
             'kindness': True,
         })
         response2 = client.get('/api/handshakes/')
-        assert response2.status_code == status.HTTP_200_OK
+        assert_api_response(response2, 200)
         h2 = next((x for x in response2.data if str(x['id']) == str(handshake.id)), None)
         assert h2 is not None
         assert h2['user_has_reviewed'] is True
@@ -279,7 +280,7 @@ class TestHandshakeViewSet:
             'exact_duration': 2.0,
             'scheduled_time': '2027-12-20T10:00:00Z'
         })
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
@@ -324,7 +325,7 @@ class TestHandshakeViewSet:
             'exact_duration': 9,
             'scheduled_time': '2099-01-01T10:00:00Z',
         })
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
@@ -359,7 +360,7 @@ class TestHandshakeViewSet:
             'exact_duration': 2,
             'scheduled_time': '2027-12-20T10:00:00Z',
         })
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
@@ -392,7 +393,7 @@ class TestHandshakeViewSet:
         client.authenticate_user(requester)
         
         response = client.post(f'/api/handshakes/{handshake.id}/approve/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
@@ -424,14 +425,14 @@ class TestHandshakeViewSet:
         client.authenticate_user(provider)
         
         response = client.post(f'/api/handshakes/{handshake.id}/confirm/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         
         handshake.refresh_from_db()
         assert handshake.provider_confirmed_complete is True
         
         client.authenticate_user(requester)
         response = client.post(f'/api/handshakes/{handshake.id}/confirm/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         
         handshake.refresh_from_db()
         assert handshake.status == 'completed'
@@ -458,7 +459,7 @@ class TestHandshakeViewSet:
         request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/', {
             'reason': 'Unexpected conflict',
         })
-        assert request_response.status_code == status.HTTP_200_OK
+        assert_api_response(request_response, 200)
 
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
@@ -467,7 +468,7 @@ class TestHandshakeViewSet:
 
         client.authenticate_user(requester)
         response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/approve/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         
         handshake.refresh_from_db()
         assert handshake.status == 'cancelled'
@@ -498,11 +499,11 @@ class TestHandshakeViewSet:
         request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/', {
             'reason': 'Cannot help anymore',
         })
-        assert request_response.status_code == status.HTTP_200_OK
+        assert_api_response(request_response, 200)
 
         client.authenticate_user(owner)
         response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/approve/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         owner.refresh_from_db()
         service.refresh_from_db()
@@ -534,11 +535,11 @@ class TestHandshakeViewSet:
         request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/', {
             'reason': 'Need to reschedule instead',
         })
-        assert request_response.status_code == status.HTTP_200_OK
+        assert_api_response(request_response, 200)
 
         client.authenticate_user(requester)
         reject_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/reject/')
-        assert reject_response.status_code == status.HTTP_200_OK
+        assert_api_response(reject_response, 200)
 
         handshake.refresh_from_db()
         requester.refresh_from_db()
@@ -562,10 +563,10 @@ class TestHandshakeViewSet:
         client = AuthenticatedAPIClient()
         client.authenticate_user(requester)
         request_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/')
-        assert request_response.status_code == status.HTTP_200_OK
+        assert_api_response(request_response, 200)
 
         approve_response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/approve/')
-        assert approve_response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(approve_response, 403)
 
     def test_event_handshake_cannot_use_cancellation_request(self):
         organizer = UserFactory()
@@ -581,7 +582,7 @@ class TestHandshakeViewSet:
         client = AuthenticatedAPIClient()
         client.authenticate_user(organizer)
         response = client.post(f'/api/handshakes/{handshake.id}/cancel-request/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
 
 # ── Tests: initiate/approve permission changes (service-owner-first model) ────
@@ -615,7 +616,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(service_owner)
         resp = client.post(f'/api/handshakes/{handshake.id}/initiate/', self.INITIATE_PAYLOAD)
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
 
@@ -634,7 +635,7 @@ class TestInitiateApproveServiceOwnerModel:
             'scheduled_time': (timezone.now() + timedelta(days=5)).isoformat(),
         })
 
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert resp.data['detail'] == 'Duration must be a whole number of hours'
 
     def test_offer_requester_cannot_initiate(self):
@@ -647,7 +648,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(requester)
         resp = client.post(f'/api/handshakes/{handshake.id}/initiate/', self.INITIATE_PAYLOAD)
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(resp, 403)
 
     def test_offer_requester_can_approve(self):
         """Requester (interest expresser) can approve an Offer handshake."""
@@ -665,7 +666,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(requester)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
 
@@ -697,7 +698,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(requester)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
 
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
@@ -728,7 +729,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(requester)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert resp.data['detail'] == 'Provider must provide exact location, duration, and scheduled time before approval'
         assert resp.data['requires_details'] is True
 
@@ -748,7 +749,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(service_owner)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(resp, 403)
 
     # ── Need/Want service ─────────────────────────────────────────────────────
 
@@ -765,7 +766,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(service_owner)
         resp = client.post(f'/api/handshakes/{handshake.id}/initiate/', self.INITIATE_PAYLOAD)
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         handshake.refresh_from_db()
         assert handshake.provider_initiated is True
         assert handshake.exact_location == 'Test Cafe, Beşiktaş'
@@ -783,7 +784,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(helper)
         resp = client.post(f'/api/handshakes/{handshake.id}/initiate/', self.INITIATE_PAYLOAD)
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(resp, 403)
 
     def test_need_helper_can_approve(self):
         """
@@ -804,7 +805,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(helper)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
 
@@ -832,7 +833,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(helper)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
 
         service_owner.refresh_from_db()
         service.refresh_from_db()
@@ -859,7 +860,7 @@ class TestInitiateApproveServiceOwnerModel:
         client.authenticate_user(provider)
         resp = client.post(f'/api/handshakes/{handshake.id}/confirm/', {'hours': 1.5})
 
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert resp.data['detail'] == 'Hours must be a whole number'
 
     def test_need_service_owner_cannot_approve_own_handshake(self):
@@ -878,7 +879,7 @@ class TestInitiateApproveServiceOwnerModel:
         client = AuthenticatedAPIClient()
         client.authenticate_user(service_owner)
         resp = client.post(f'/api/handshakes/{handshake.id}/approve/', {})
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(resp, 403)
 
     def test_third_party_cannot_initiate_or_approve(self):
         """
@@ -934,9 +935,7 @@ class TestPendingCapacityIntegration:
         for user in (u1, u2, u3):
             client.authenticate_user(user)
             resp = client.post(f'/api/services/{svc.id}/interest/')
-            assert resp.status_code == status.HTTP_201_CREATED, (
-                f"User {user.email} should be able to express interest: {resp.data}"
-            )
+            assert_api_response(resp, 201)
 
         assert Handshake.objects.filter(service=svc, status='pending').count() == 3
 
@@ -1001,7 +1000,7 @@ class TestAcceptAutoDenyIntegration:
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
         resp = client.post(f'/api/handshakes/{h_accept.id}/accept/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
 
         for h in handshakes[1:]:
             h.refresh_from_db()
@@ -1048,7 +1047,7 @@ class TestAgreedStatusIntegration:
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
         resp = client.post(f'/api/handshakes/{handshake.id}/accept/')
-        assert resp.status_code == status.HTTP_200_OK, resp.data
+        assert_api_response(resp, 200)
 
     def test_one_time_service_becomes_agreed_on_full_accept(self):
         provider = UserFactory(timebank_balance=Decimal('20'))
@@ -1079,7 +1078,7 @@ class TestAgreedStatusIntegration:
         client = AuthenticatedAPIClient()
         client.authenticate_user(viewer)
         resp = client.get('/api/services/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         data = resp.data
         results = data['results'] if isinstance(data, dict) and 'results' in data else data
         ids = [str(s['id']) for s in results]
@@ -1101,10 +1100,10 @@ class TestAgreedStatusIntegration:
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
         request_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/')
-        assert request_resp.status_code == status.HTTP_200_OK
+        assert_api_response(request_resp, 200)
         client.authenticate_user(requester)
         resp = client.post(f'/api/handshakes/{h.id}/cancel-request/approve/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
 
         svc.refresh_from_db()
         assert svc.status == 'Active'
@@ -1123,10 +1122,10 @@ class TestAgreedStatusIntegration:
         client = AuthenticatedAPIClient()
         client.authenticate_user(provider)
         request_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/')
-        assert request_resp.status_code == status.HTTP_200_OK
+        assert_api_response(request_resp, 200)
         client.authenticate_user(requester)
         approve_resp = client.post(f'/api/handshakes/{h.id}/cancel-request/approve/')
-        assert approve_resp.status_code == status.HTTP_200_OK
+        assert_api_response(approve_resp, 200)
 
         viewer = UserFactory()
         client.authenticate_user(viewer)
@@ -1190,7 +1189,7 @@ class TestEventHandshakeEndpoints:
         client = AuthenticatedAPIClient()
         client.authenticate_user(participant)
         response = client.post(f'/api/handshakes/services/{service.id}/join-event/')
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
         handshake = Handshake.objects.get(id=response.data['id'])
         assert handshake.status == 'accepted'
@@ -1212,7 +1211,7 @@ class TestEventHandshakeEndpoints:
         client = AuthenticatedAPIClient().authenticate_user(participant)
         response = client.post(f'/api/handshakes/services/{service.id}/join-event/')
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Handshake.objects.filter(
             service=service, requester=participant
@@ -1238,7 +1237,7 @@ class TestEventHandshakeEndpoints:
         client = AuthenticatedAPIClient()
         client.authenticate_user(participant)
         response = client.post(f'/api/handshakes/{handshake.id}/checkin/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'no longer available' in str(response.data).lower()
 
     def test_mark_attended_requires_authentication(self):
@@ -1303,7 +1302,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
         response = client.post(f'/api/handshakes/{handshake.id}/mark-attended/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         handshake.refresh_from_db()
         assert handshake.status == 'attended'
 
@@ -1387,7 +1386,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
         response = client.post(f'/api/handshakes/{handshake.id}/mark-attended/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         handshake.refresh_from_db()
         assert handshake.status == 'accepted'
 
@@ -1413,7 +1412,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
         response = client.post(f'/api/handshakes/{handshake.id}/mark-attended/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         handshake.refresh_from_db()
         assert handshake.status == 'attended'
 
@@ -1456,7 +1455,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
         response = client.post(f'/api/services/{event.id}/complete-event/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         h_accepted.refresh_from_db()
         h_checked_in.refresh_from_db()
@@ -1488,7 +1487,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
         response = client.post(f'/api/services/{event.id}/complete-event/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         handshake.refresh_from_db()
         assert handshake.status == 'attended'
 
@@ -1535,7 +1534,7 @@ class TestMarkAttendedAndCompleteEvent:
         client.authenticate_user(organizer)
 
         first = client.post(f'/api/services/{event.id}/complete-event/')
-        assert first.status_code == status.HTTP_200_OK
+        assert_api_response(first, 200)
 
         second = client.post(f'/api/services/{event.id}/complete-event/')
         assert second.status_code in (
@@ -1562,7 +1561,7 @@ class TestHandshakeInterestsPanelRequesterDetail:
 
         client = AuthenticatedAPIClient().authenticate_user(owner)
         resp = client.get('/api/handshakes/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         results = resp.json()
         # Find our handshake in the list
         hs_data = next(
@@ -1595,7 +1594,7 @@ class TestHandshakeInterestsPanelRequesterDetail:
 
         client = AuthenticatedAPIClient().authenticate_user(requester)
         resp = client.get('/api/handshakes/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         results = resp.json()
         hs_data = next(
             (h for h in results if str(h.get('service_id')) == str(service.id)),
@@ -1620,7 +1619,7 @@ class TestHandshakeInterestsPanelRequesterDetail:
 
         client = AuthenticatedAPIClient().authenticate_user(owner)
         resp = client.get('/api/handshakes/')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         results = resp.json()
         hs_data = next(
             (h for h in results if str(h.get('service_id')) == str(service.id)),

--- a/backend/api/tests/integration/test_notification_api.py
+++ b/backend/api/tests/integration/test_notification_api.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from api.tests.helpers.factories import UserFactory, NotificationFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Notification
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -24,14 +25,13 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.get('/api/notifications/?page=1')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert_api_response(response, 200, schema={'count': 3})
         assert len(response.data['results']) == 3
 
     def test_list_requires_auth(self):
         client = AuthenticatedAPIClient()
         response = client.get('/api/notifications/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_retrieve_own_notification(self):
         user = UserFactory()
@@ -41,8 +41,7 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.get(f'/api/notifications/{notification.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(notification.id)
+        assert_api_response(response, 200, schema={'id': str(notification.id)})
 
     def test_cannot_retrieve_other_users_notification(self):
         user = UserFactory()
@@ -53,7 +52,7 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.get(f'/api/notifications/{notification.id}/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_unread_count(self):
         user = UserFactory()
@@ -64,8 +63,7 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.get('/api/notifications/unread-count/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 2
+        assert_api_response(response, 200, schema={'count': 2})
 
     def test_mark_single_as_read(self):
         user = UserFactory()
@@ -75,7 +73,7 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.patch(f'/api/notifications/{notification.id}/read/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['is_read'] is True
 
         notification.refresh_from_db()
@@ -89,7 +87,7 @@ class TestNotificationViewSet:
         client.authenticate_user(user)
 
         response = client.post('/api/notifications/read/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         assert Notification.objects.filter(user=user, is_read=False).count() == 0
 

--- a/backend/api/tests/integration/test_notification_preferences_api.py
+++ b/backend/api/tests/integration/test_notification_preferences_api.py
@@ -15,6 +15,7 @@ from api.models import DevicePushToken, Notification
 from api.tests.helpers.factories import UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.utils import _send_push_notification, user_wants_push
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -26,7 +27,7 @@ class TestNotificationPreferencesPersistence:
             {'notification_preferences': {'push': False}},
             format='json',
         )
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_patch_round_trips(self):
         user = UserFactory()
@@ -37,10 +38,10 @@ class TestNotificationPreferencesPersistence:
             {'notification_preferences': {'push': True, 'chat': False, 'system': True}},
             format='json',
         )
-        assert patch_response.status_code == status.HTTP_200_OK
+        assert_api_response(patch_response, 200)
 
         get_response = client.get('/api/users/me/')
-        assert get_response.status_code == status.HTTP_200_OK
+        assert_api_response(get_response, 200)
         prefs = get_response.data.get('notification_preferences') or {}
         assert prefs.get('push') is True
         assert prefs.get('chat') is False

--- a/backend/api/tests/integration/test_ranking_api.py
+++ b/backend/api/tests/integration/test_ranking_api.py
@@ -26,6 +26,7 @@ from api.tests.helpers.factories import (
 # ---------------------------------------------------------------------------
 
 from django.conf import settings as django_settings
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -45,7 +46,7 @@ class TestRankingQueryPerformance:
         response = client.get('/api/services/?ordering=-hot_score')
         elapsed = time.monotonic() - start
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         assert elapsed < django_settings.RANKING_FEED_SLA_SECONDS, (
             f"Hot-sort query took {elapsed:.3f}s -- exceeds the "
             f"{django_settings.RANKING_FEED_SLA_SECONDS}s NFR-17a SLA. "
@@ -64,7 +65,7 @@ class TestRankingQueryPerformance:
         response = client.get('/api/services/?ordering=-hot_score')
         elapsed = time.monotonic() - start
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         assert elapsed < django_settings.RANKING_FEED_SLA_SECONDS, (
             f"Mixed-type hot-sort took {elapsed:.3f}s -- exceeds NFR-17a SLA."
         )
@@ -87,7 +88,7 @@ class TestFeedEndToEndPerformance:
         response = client.get('/api/services/?ordering=-hot_score&page=1')
         elapsed = time.monotonic() - start
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         assert elapsed < django_settings.RANKING_FEED_E2E_SLA_SECONDS, (
             f"Anonymous feed took {elapsed:.3f}s -- exceeds the "
             f"{django_settings.RANKING_FEED_E2E_SLA_SECONDS}s NFR-19a SLA."

--- a/backend/api/tests/integration/test_ranking_privacy_achievements_api.py
+++ b/backend/api/tests/integration/test_ranking_privacy_achievements_api.py
@@ -19,6 +19,7 @@ from api.tests.helpers.factories import (
     UserFactory,
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -93,7 +94,7 @@ class TestLocationBlur:
             '/api/services/',
             {'lat': '41.0500', 'lng': '28.9700', 'distance': '50'},
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results'] if isinstance(response.data, dict) else response.data
         rows = [r for r in results if r['id'] == str(service.id)]
         assert rows, 'service should be in the location-filtered feed'
@@ -113,7 +114,7 @@ class TestLocationBlur:
 
         client = AuthenticatedAPIClient().authenticate_user(partner)
         response = client.get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         # Real coordinates should round-trip exactly because the partner has an
         # accepted handshake — no fuzzing is applied.
         assert float(response.data['location_lat']) == pytest.approx(41.0250, abs=1e-4)
@@ -126,7 +127,7 @@ class TestLocationBlur:
 
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         # Fuzz applies a deterministic ~1km offset; absolute equality is fine
         # because the offset is non-zero and bounded.
         lat = float(response.data['location_lat'])
@@ -157,7 +158,7 @@ class TestAchievementProgressEndpoint:
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(f'/api/users/{user.id}/badge-progress/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         # Response should be a dict-by-id with both earned and unearned entries.
         body = response.data
         assert isinstance(body, dict)

--- a/backend/api/tests/integration/test_report_lifecycle_api.py
+++ b/backend/api/tests/integration/test_report_lifecycle_api.py
@@ -14,6 +14,7 @@ from rest_framework.test import APIClient
 from api.models import Notification, Report
 from api.tests.helpers.factories import AdminUserFactory, ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -33,7 +34,7 @@ class TestReportReceivedNotification:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         received = Notification.objects.filter(
             user=reporter, type='report_received',
         )
@@ -69,7 +70,7 @@ class TestReportResolveLifecycleNotifications:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         report.refresh_from_db()
         assert report.status == 'resolved'
         assert report.resolved_by_id == admin.id
@@ -87,7 +88,7 @@ class TestReportResolveLifecycleNotifications:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         report.refresh_from_db()
         assert report.status == 'dismissed'
         assert Notification.objects.filter(
@@ -106,7 +107,7 @@ class TestReportResolveLifecycleNotifications:
             format='json',
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
 
 @pytest.mark.django_db
@@ -116,7 +117,7 @@ class TestMyReportsEndpoint:
 
     def test_unauthenticated_request_is_rejected(self):
         response = APIClient().get('/api/users/me/reports/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_returns_only_current_users_reports(self):
         alice = UserFactory()
@@ -136,7 +137,7 @@ class TestMyReportsEndpoint:
         client = AuthenticatedAPIClient().authenticate_user(alice)
         response = client.get('/api/users/me/reports/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results'] if isinstance(response.data, dict) else response.data
         assert len(results) == 1
         assert results[0]['description'] == 'alice report'
@@ -161,7 +162,7 @@ class TestMyReportsEndpoint:
         client = AuthenticatedAPIClient().authenticate_user(reporter)
         response = client.get('/api/users/me/reports/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results'] if isinstance(response.data, dict) else response.data
         assert len(results) == 1
         payload = results[0]

--- a/backend/api/tests/integration/test_reporting_api.py
+++ b/backend/api/tests/integration/test_reporting_api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from api.models import Report
 from api.tests.helpers.factories import HandshakeFactory, ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -24,8 +25,7 @@ class TestReportingAPI:
             {"issue_type": "spam", "description": "Report after status change."},
             format="json",
         )
-        assert response.status_code == status.HTTP_201_CREATED
-        assert "report_id" in response.data
+        assert_api_response(response, 201, contains={'report_id'})
 
     def test_user_can_only_report_a_listing_once(self):
         reporter = UserFactory()
@@ -38,15 +38,14 @@ class TestReportingAPI:
             {"issue_type": "spam", "description": "This listing looks like spam."},
             format="json",
         )
-        assert first.status_code == status.HTTP_201_CREATED
-        assert "report_id" in first.data
+        assert_api_response(first, 201, contains={'report_id'})
 
         second = client.post(
             f"/api/services/{service.id}/report/",
             {"issue_type": "spam", "description": "Duplicate report attempt."},
             format="json",
         )
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(second, 400)
         assert "already reported" in (second.data.get("detail", "") or "").lower()
 
     @pytest.mark.parametrize("final_status", ["resolved", "dismissed"])
@@ -61,7 +60,7 @@ class TestReportingAPI:
             {"issue_type": "spam", "description": "Initial report."},
             format="json",
         )
-        assert first.status_code == status.HTTP_201_CREATED
+        assert_api_response(first, 201)
 
         report = Report.objects.get(id=first.data["report_id"])
         report.status = final_status
@@ -72,7 +71,7 @@ class TestReportingAPI:
             {"issue_type": "spam", "description": "Attempt after moderation action."},
             format="json",
         )
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(second, 400)
         assert "already reported" in (second.data.get("detail", "") or "").lower()
 
     def test_handshake_report_is_not_blocked_by_existing_listing_report(self):
@@ -87,7 +86,7 @@ class TestReportingAPI:
             {"issue_type": "spam", "description": "Spam listing."},
             format="json",
         )
-        assert listing_report.status_code == status.HTTP_201_CREATED
+        assert_api_response(listing_report, 201)
 
         handshake = HandshakeFactory(service=service, requester=reporter, status="accepted")
 
@@ -96,8 +95,7 @@ class TestReportingAPI:
             {"issue_type": "no_show", "description": "No-show dispute for this handshake."},
             format="json",
         )
-        assert handshake_report.status_code == status.HTTP_201_CREATED
-        assert "report_id" in handshake_report.data
+        assert_api_response(handshake_report, 201, contains={'report_id'})
 
     def test_non_event_handshake_report_keeps_active_status(self):
         provider = UserFactory()
@@ -112,7 +110,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         handshake.refresh_from_db()
         assert handshake.status == "accepted"
 
@@ -133,7 +131,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         report = Report.objects.get(id=response.data["report_id"])
         assert report.type == "harassment"
         assert report.description == payload["description"]
@@ -156,7 +154,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         report = Report.objects.get(id=response.data["report_id"])
         assert report.type == "harassment"
         assert report.reported_user_id == organizer.id
@@ -179,7 +177,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
     def test_event_handshake_rejects_no_show_reports_before_event_start(self):
         organizer = UserFactory()
@@ -199,7 +197,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert "no-show reports are allowed" in (response.data.get("detail", "") or "").lower()
 
     def test_event_handshake_rejects_no_show_reports_after_24h_window(self):
@@ -220,7 +218,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert "no-show reports are allowed" in (response.data.get("detail", "") or "").lower()
 
     def test_event_handshake_allows_behavior_reports_after_24h_window(self):
@@ -241,7 +239,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
     def test_event_participant_can_report_another_participant_with_reported_user_id(self):
         organizer = UserFactory()
@@ -267,7 +265,7 @@ class TestReportingAPI:
             format="json",
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         report = Report.objects.get(id=response.data["report_id"])
         assert report.reported_user_id == target_participant.id
         assert report.type == "spam"
@@ -293,14 +291,14 @@ class TestReportingAPI:
             {"issue_type": "harassment", "description": "First harassment report."},
             format="json",
         )
-        assert first.status_code == status.HTTP_201_CREATED
+        assert_api_response(first, 201)
 
         second = participant_client.post(
             f"/api/handshakes/{handshake.id}/report/",
             {"issue_type": "harassment", "description": "Duplicate open report."},
             format="json",
         )
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(second, 400)
         assert "open report" in (second.data.get("detail", "") or "").lower()
 
         open_report = Report.objects.get(id=first.data["report_id"])
@@ -312,4 +310,4 @@ class TestReportingAPI:
             {"issue_type": "harassment", "description": "Re-report after moderation."},
             format="json",
         )
-        assert third.status_code == status.HTTP_201_CREATED
+        assert_api_response(third, 201)

--- a/backend/api/tests/integration/test_reputation_api.py
+++ b/backend/api/tests/integration/test_reputation_api.py
@@ -140,7 +140,7 @@ class TestReputationViewSet:
             'helpful': False,
             'kindness': False,
         })
-        assert eval_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(eval_response, 201)
         assert not Comment.objects.filter(
             related_handshake=handshake,
             user=requester,
@@ -152,7 +152,7 @@ class TestReputationViewSet:
             'handshake_id': str(handshake.id),
             'comment': 'Adding my review later inside the evaluation window.',
         })
-        assert review_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(review_response, 201)
         assert Comment.objects.filter(
             related_handshake=handshake,
             user=requester,
@@ -243,12 +243,11 @@ class TestReputationViewSet:
             'kindness': False,
             'comment': 'Private until both sides evaluate.',
         })
-        assert create_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(create_response, 201)
 
         provider_client = AuthenticatedAPIClient().authenticate_user(provider)
         hidden_response = provider_client.get(f'/api/services/{service.id}/comments/')
-        assert hidden_response.status_code == status.HTTP_200_OK
-        assert hidden_response.data['count'] == 0
+        assert_api_response(hidden_response, 200, schema={'count': 0})
 
         reciprocal_response = provider_client.post('/api/reputation/', {
             'handshake_id': str(handshake.id),
@@ -256,11 +255,10 @@ class TestReputationViewSet:
             'helpful': True,
             'kindness': True,
         })
-        assert reciprocal_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(reciprocal_response, 201)
 
         revealed_response = provider_client.get(f'/api/services/{service.id}/comments/')
-        assert revealed_response.status_code == status.HTTP_200_OK
-        assert revealed_response.data['count'] == 1
+        assert_api_response(revealed_response, 200, schema={'count': 1})
 
     def test_blind_review_revealed_after_window_expires_without_reciprocal(self):
         provider = UserFactory()
@@ -283,7 +281,7 @@ class TestReputationViewSet:
             'kindness': False,
             'comment': 'Visible after feedback window expiry.',
         })
-        assert create_response.status_code == status.HTTP_410_GONE
+        assert_problem_detail(create_response, 410)
 
         # Create legacy-style verified review directly to validate display gating on read path.
         Comment.objects.create(
@@ -707,7 +705,7 @@ class TestNegativeRepViewSet:
 
         organizer_client = AuthenticatedAPIClient().authenticate_user(organizer)
         service_response = organizer_client.get(f'/api/services/{event.id}/')
-        assert service_response.status_code == status.HTTP_200_OK
+        assert_api_response(service_response, 200)
         payload = service_response.data.get('event_evaluation_summary')
         assert payload is not None
         assert payload['positive_feedback_count'] == 1
@@ -740,7 +738,7 @@ class TestNegativeRepViewSet:
             'engaging': False,
             'welcoming': True,
         })
-        assert positive.status_code == status.HTTP_201_CREATED
+        assert_api_response(positive, 201)
 
         negative = participant_client.post('/api/reputation/negative/', {
             'handshake_id': str(handshake.id),
@@ -748,7 +746,7 @@ class TestNegativeRepViewSet:
             'boring': False,
             'unwelcoming': True,
         })
-        assert negative.status_code == status.HTTP_201_CREATED
+        assert_api_response(negative, 201)
 
         summary = EventEvaluationSummary.objects.get(service=event)
         assert summary.positive_feedback_count == 1
@@ -883,7 +881,7 @@ class TestEventEvaluationHotScoreIsolation:
             'boring': True,
             'unwelcoming': False,
         })
-        assert negative_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(negative_response, 201)
 
         organizer.refresh_from_db()
         event.refresh_from_db()
@@ -952,8 +950,8 @@ class TestEventNoShowAppeals:
         first = client.post(f'/api/handshakes/{handshake.id}/appeal-no-show/', {'description': 'first'})
         second = client.post(f'/api/handshakes/{handshake.id}/appeal-no-show/', {'description': 'second'})
 
-        assert first.status_code == status.HTTP_201_CREATED
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert_api_response(first, 201)
+        assert_problem_detail(second, 400)
         assert second.data['code'] == 'ALREADY_EXISTS'
 
     def test_admin_can_overturn_no_show_appeal(self):
@@ -1278,7 +1276,7 @@ class TestEventEvaluationCommentHistory:
             'welcoming': False,
             'comment': review_text,
         })
-        assert rep_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(rep_response, 201)
 
         # Comment created in the DB.
         assert Comment.objects.filter(
@@ -1295,7 +1293,7 @@ class TestEventEvaluationCommentHistory:
         organizer_client = AuthenticatedAPIClient()
         organizer_client.authenticate_user(organizer)
         profile_response = organizer_client.get('/api/users/me/')
-        assert profile_response.status_code == status.HTTP_200_OK
+        assert_api_response(profile_response, 200)
 
         history = profile_response.data.get('event_comments_history', [])
         assert isinstance(history, list), 'event_comments_history must be a list'
@@ -1335,7 +1333,7 @@ class TestEventEvaluationCommentHistory:
             'welcoming': False,
             # No 'comment' key supplied.
         })
-        assert rep_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(rep_response, 201)
 
         # No verified review comment should exist for this handshake.
         assert not Comment.objects.filter(
@@ -1350,7 +1348,7 @@ class TestEventEvaluationCommentHistory:
         organizer_client = AuthenticatedAPIClient()
         organizer_client.authenticate_user(organizer)
         profile_response = organizer_client.get('/api/users/me/')
-        assert profile_response.status_code == status.HTTP_200_OK
+        assert_api_response(profile_response, 200)
 
         history = profile_response.data.get('event_comments_history', [])
         event_entry = next(
@@ -1379,7 +1377,7 @@ class TestEventEvaluationCommentHistory:
             'welcoming': True,
             'comment': review_text,
         })
-        assert rep_response.status_code == status.HTTP_201_CREATED
+        assert_api_response(rep_response, 201)
 
         # Expire the window before fetching profile.
         self._expire_window(handshake)
@@ -1387,7 +1385,7 @@ class TestEventEvaluationCommentHistory:
         organizer_client = AuthenticatedAPIClient()
         organizer_client.authenticate_user(organizer)
         profile_response = organizer_client.get('/api/users/me/')
-        assert profile_response.status_code == status.HTTP_200_OK
+        assert_api_response(profile_response, 200)
 
         history = profile_response.data.get('event_comments_history', [])
         event_entry = next(
@@ -1648,13 +1646,13 @@ class TestFR16cEvaluationScoping:
             'handshake_id': str(handshake.id),
             'well_organized': True,
         })
-        assert first.status_code == status.HTTP_201_CREATED
+        assert_api_response(first, 201)
 
         second = client.post('/api/reputation/', {
             'handshake_id': str(handshake.id),
             'well_organized': True,
         })
-        assert second.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(second, 400)
 
         # Summary must not double-count.
         summary = EventEvaluationSummary.objects.get(service=handshake.service)

--- a/backend/api/tests/integration/test_review_photos_api.py
+++ b/backend/api/tests/integration/test_review_photos_api.py
@@ -20,6 +20,7 @@ from api.tests.helpers.factories import (
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Comment, CommentMedia
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +118,7 @@ class TestReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert CommentMedia.objects.filter(
             comment__related_handshake=handshake,
             comment__user=requester,
@@ -141,7 +142,7 @@ class TestReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert CommentMedia.objects.filter(
             comment__related_handshake=handshake,
         ).count() == 3
@@ -161,7 +162,7 @@ class TestReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'Maximum 3 images' in (response.data.get('detail') or '')
 
     def test_unsupported_image_format_rejected(self):
@@ -179,7 +180,7 @@ class TestReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'Unsupported image format' in (response.data.get('detail') or '')
 
     def test_image_url_returned_in_comment_serializer(self):
@@ -216,7 +217,7 @@ class TestReviewPhotoAttachment:
         client.authenticate_user(requester)
         response = client.get(f'/api/services/{service.id}/comments/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data.get('results', response.data)
         comment_data = next((c for c in results if str(c['id']) == str(comment.id)), None)
         assert comment_data is not None, 'Comment not found in response'
@@ -249,7 +250,7 @@ class TestReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         # Image must be attached to the existing comment, not a new one
         assert Comment.objects.filter(
             related_handshake=handshake, user=requester, is_verified_review=True,
@@ -297,7 +298,7 @@ class TestEventReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert CommentMedia.objects.filter(
             comment__related_handshake=handshake,
             comment__user=participant,
@@ -325,7 +326,7 @@ class TestEventReviewPhotoAttachment:
         client.authenticate_user(participant)
         response = client.get(f'/api/services/{event.id}/comments/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data.get('results', response.data)
         comment_data = next((c for c in results if str(c['id']) == str(comment.id)), None)
         assert comment_data is not None
@@ -346,7 +347,7 @@ class TestEventReviewPhotoAttachment:
             format='multipart',
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +395,7 @@ class TestEventReviewImmediateVisibility:
         client.authenticate_user(participant)
         response = client.get(f'/api/services/{event.id}/comments/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data.get('results', response.data)
         assert len(results) == 1, (
             'Event review must be visible immediately — '
@@ -420,8 +421,7 @@ class TestEventReviewImmediateVisibility:
             {'role': 'organizer'},
         )
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
+        assert_api_response(response, 200, schema={'count': 1})
 
     def test_offer_review_still_suppressed_during_window(self):
         """
@@ -452,7 +452,7 @@ class TestEventReviewImmediateVisibility:
         client.authenticate_user(requester)
         response = client.get(f'/api/services/{service.id}/comments/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data.get('results', response.data)
         # Must be hidden — both flags False and window still open
         assert len(results) == 0, (
@@ -497,6 +497,5 @@ class TestEventReviewImmediateVisibility:
             {'role': 'organizer'},
         )
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
+        assert_api_response(response, 200, schema={'count': 1})
         assert response.data['results'][0]['body'] == 'Great event!'

--- a/backend/api/tests/integration/test_save_endorse.py
+++ b/backend/api/tests/integration/test_save_endorse.py
@@ -3,6 +3,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from api.tests.helpers.factories import ServiceFactory, UserFactory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -16,7 +17,7 @@ class TestSaveService:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.post(f'/api/services/{svc.id}/save/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_saved'] is True
         assert SavedService.objects.filter(user=viewer, service=svc).exists()
 
@@ -40,7 +41,7 @@ class TestSaveService:
         client.force_authenticate(user=viewer)
         client.post(f'/api/services/{svc.id}/save/')
         resp = client.delete(f'/api/services/{svc.id}/save/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_saved'] is False
         assert not SavedService.objects.filter(user=viewer, service=svc).exists()
 
@@ -48,7 +49,7 @@ class TestSaveService:
         svc = ServiceFactory(type='Offer', status='Active')
         client = APIClient()
         resp = client.post(f'/api/services/{svc.id}/save/')
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
     def test_saved_list_returns_only_my_saves(self):
         viewer = UserFactory()
@@ -65,7 +66,7 @@ class TestSaveService:
         other_client.post(f'/api/services/{not_mine.id}/save/')
 
         resp = client.get('/api/services/saved/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         body = resp.json()
         results = body.get('results', body) if isinstance(body, dict) else body
         ids = {row['id'] for row in results}
@@ -111,7 +112,7 @@ class TestSaveEndorseListPerformance:
         client.force_authenticate(user=viewer)
         with CaptureQueriesContext(connection) as ctx_5:
             resp = client.get('/api/services/')
-            assert resp.status_code == 200
+            assert_api_response(resp, 200)
         small = len(ctx_5)
 
         for _ in range(15):
@@ -119,7 +120,7 @@ class TestSaveEndorseListPerformance:
 
         with CaptureQueriesContext(connection) as ctx_20:
             resp = client.get('/api/services/')
-            assert resp.status_code == 200
+            assert_api_response(resp, 200)
         large = len(ctx_20)
 
         # Allow some growth from prefetch sub-queries that scale with row
@@ -144,7 +145,7 @@ class TestEndorseService:
         client = APIClient()
         client.force_authenticate(user=viewer)
         resp = client.post(f'/api/services/{svc.id}/endorse/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_endorsed'] is True
         assert resp.json()['endorsement_count'] == 1
         assert Endorsement.objects.filter(endorser=viewer, service=svc).exists()
@@ -155,7 +156,7 @@ class TestEndorseService:
         client = APIClient()
         client.force_authenticate(user=owner)
         resp = client.post(f'/api/services/{svc.id}/endorse/')
-        assert resp.status_code == 400
+        assert_problem_detail(resp, 400)
 
     def test_endorse_is_idempotent(self):
         from api.models import Endorsement
@@ -179,7 +180,7 @@ class TestEndorseService:
         client.force_authenticate(user=viewer)
         client.post(f'/api/services/{svc.id}/endorse/')
         resp = client.delete(f'/api/services/{svc.id}/endorse/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         assert resp.json()['is_endorsed'] is False
         assert resp.json()['endorsement_count'] == 0
         assert not Endorsement.objects.filter(endorser=viewer, service=svc).exists()
@@ -188,7 +189,7 @@ class TestEndorseService:
         svc = ServiceFactory(type='Offer', status='Active')
         client = APIClient()
         resp = client.post(f'/api/services/{svc.id}/endorse/')
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
     def test_endorsement_count_visible_to_anyone(self):
         endorser_a = UserFactory()

--- a/backend/api/tests/integration/test_security_hardening_api.py
+++ b/backend/api/tests/integration/test_security_hardening_api.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.tests.helpers.factories import UserFactory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 REGISTER_URL = '/api/auth/register/'
@@ -50,7 +51,7 @@ class TestDisposableEmailBlacklist:
     def test_disposable_domain_rejected(self, domain):
         client = APIClient()
         response = client.post(REGISTER_URL, _payload(f'spammer@{domain}'))
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         # Error must come back attached to the email field, not as a server error.
         # The custom exception handler nests DRF field errors under field_errors.
         assert 'email' in response.data.get('field_errors', response.data)
@@ -58,7 +59,7 @@ class TestDisposableEmailBlacklist:
     def test_real_provider_accepted(self):
         client = APIClient()
         response = client.post(REGISTER_URL, _payload('real.user@gmail.com'))
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
 
 @pytest.mark.django_db
@@ -90,5 +91,5 @@ class TestAuthSecurityLogging:
                 'email': 'success@example.com',
                 'password': 'GoodPass123!',
             })
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert any('auth.login.success' in rec.message for rec in caplog.records)

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -12,6 +12,7 @@ from api.tests.helpers.factories import UserFactory, ServiceFactory, TagFactory,
 from api.tests.helpers.factories import AdminUserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Service, Notification, TransactionHistory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -26,8 +27,7 @@ class TestServiceViewSet:
         
         client = APIClient()
         response = client.get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'results' in response.data
+        assert_api_response(response, 200, contains={'results'})
         assert len(response.data['results']) > 0
     
     def test_list_services_filtering(self):
@@ -37,7 +37,7 @@ class TestServiceViewSet:
         
         client = APIClient()
         response = client.get('/api/services/?type=Offer')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert all(s['type'] == 'Offer' for s in response.data['results'])
     
     def test_list_services_pagination(self):
@@ -46,7 +46,7 @@ class TestServiceViewSet:
         
         client = APIClient()
         response = client.get('/api/services/?page_size=10')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data['results']) == 10
         assert 'next' in response.data or response.data['count'] <= 10
     
@@ -72,8 +72,7 @@ class TestServiceViewSet:
             'status': 'Active',
             'tag_ids': [tag.id]
         })
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['title'] == 'New Service'
+        assert_api_response(response, 201, schema={'title': 'New Service'})
         assert Service.objects.filter(id=response.data['id']).exists()
 
     def test_create_need_reserves_timebank_and_updates_profile_payload(self):
@@ -83,7 +82,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         me_before = client.get('/api/users/me/')
-        assert me_before.status_code == status.HTTP_200_OK
+        assert_api_response(me_before, 200)
         assert Decimal(str(me_before.data['timebank_balance'])) == Decimal('3.00')
 
         response = client.post('/api/services/', {
@@ -96,7 +95,7 @@ class TestServiceViewSet:
             'schedule_type': 'One-Time',
         })
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
         service = Service.objects.get(id=response.data['id'])
         owner.refresh_from_db()
@@ -112,7 +111,7 @@ class TestServiceViewSet:
         ).exists()
 
         me_after = client.get('/api/users/me/')
-        assert me_after.status_code == status.HTTP_200_OK
+        assert_api_response(me_after, 200)
         assert Decimal(str(me_after.data['timebank_balance'])) == Decimal('1.00')
 
     def test_create_service_with_video_media(self):
@@ -138,9 +137,7 @@ class TestServiceViewSet:
             ]
         }, format='json')
 
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['title'] == 'Service With Video'
-        assert 'media' in response.data
+        assert_api_response(response, 201, contains={'media'}, schema={'title': 'Service With Video'})
         assert any(m.get('media_type') == 'video' for m in response.data.get('media', []))
     
     def test_create_service_validation(self):
@@ -153,7 +150,7 @@ class TestServiceViewSet:
             'title': 'ab',  # Too short
             'description': 'Test'
         })
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     # ── Email verification gate for service creation ────────────────────
     # Offers, Needs and Events all require a verified email address.
@@ -209,7 +206,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._offer_payload())
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Service.objects.filter(title='Verified Only Offer').exists()
 
@@ -219,7 +216,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._need_payload())
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Service.objects.filter(title='Help moving a sofa').exists()
 
@@ -229,7 +226,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._event_payload())
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert response.data.get('code') == 'EMAIL_NOT_VERIFIED'
         assert not Service.objects.filter(title='Community picnic').exists()
 
@@ -239,7 +236,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._offer_payload())
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Service.objects.filter(id=response.data['id'], type='Offer').exists()
 
     def test_verified_user_can_create_need(self):
@@ -248,7 +245,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._need_payload())
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Service.objects.filter(id=response.data['id'], type='Need').exists()
 
     def test_verified_user_can_create_event(self):
@@ -257,7 +254,7 @@ class TestServiceViewSet:
 
         response = client.post('/api/services/', self._event_payload())
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         assert Service.objects.filter(id=response.data['id'], type='Event').exists()
     
     def test_retrieve_service(self):
@@ -266,9 +263,7 @@ class TestServiceViewSet:
         client = APIClient()
         
         response = client.get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(service.id)
-        assert response.data['title'] == service.title
+        assert_api_response(response, 200, schema={'id': str(service.id), 'title': service.title})
     
     def test_update_service(self):
         """Test updating a service"""
@@ -280,8 +275,7 @@ class TestServiceViewSet:
         response = client.patch(f'/api/services/{service.id}/', {
             'title': 'Updated Title'
         })
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['title'] == 'Updated Title'
+        assert_api_response(response, 200, schema={'title': 'Updated Title'})
         
         service.refresh_from_db()
         assert service.title == 'Updated Title'
@@ -297,7 +291,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Updated title'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         service.refresh_from_db()
         assert service.title == 'Updated title'
@@ -318,7 +312,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Updated title'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         service.refresh_from_db()
         assert service.title == 'Updated title'
@@ -345,7 +339,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Completed Updated'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         service.refresh_from_db()
         assert service.title == 'Completed Updated'
@@ -365,7 +359,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Should Fail'})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
         service.refresh_from_db()
         assert service.title != 'Should Fail'
@@ -387,7 +381,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Recurring Updated'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         service.refresh_from_db()
         assert service.title == 'Recurring Updated'
@@ -413,7 +407,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Updated Event Title'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         joined_notification = Notification.objects.filter(
             user=joined_user,
@@ -459,7 +453,7 @@ class TestServiceViewSet:
                 'description': 'Updated event description',
             },
         )
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
         notification = Notification.objects.filter(
             user=participant,
@@ -485,7 +479,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Should Be Blocked'})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         service.refresh_from_db()
         assert service.title == 'Event In Lockdown'
 
@@ -504,7 +498,7 @@ class TestServiceViewSet:
         client.authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Should Also Be Blocked'})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         service.refresh_from_db()
         assert service.title == 'Past Event'
     
@@ -520,7 +514,7 @@ class TestServiceViewSet:
         response = client.patch(f'/api/services/{service.id}/', {
             'title': 'Hacked Title'
         })
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
     
     def test_delete_service(self):
         """Test soft-deleting a service (sets status to Cancelled)"""
@@ -530,7 +524,7 @@ class TestServiceViewSet:
         client.authenticate_user(user)
         
         response = client.delete(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert_api_response(response, 204)
         service.refresh_from_db()
         assert service.status == 'Cancelled'
 
@@ -547,7 +541,7 @@ class TestServiceViewSet:
         client.authenticate_user(user)
 
         response = client.delete(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert_api_response(response, 204)
 
         service.refresh_from_db()
         user.refresh_from_db()
@@ -574,7 +568,7 @@ class TestServiceViewSet:
 
         # Soft-delete the service
         resp = owner_client.delete(f'/api/services/{service.id}/')
-        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert_api_response(resp, 204)
 
         # Public service list should not include cancelled service
         response = APIClient().get('/api/services/')
@@ -605,7 +599,7 @@ class TestServiceViewSet:
         client.authenticate_user(user)
 
         response = client.delete(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert response.data.get('code') == 'INVALID_STATE'
         assert 'active handshakes' in response.data.get('detail', '').lower()
         assert Service.objects.filter(id=service.id).exists()
@@ -622,7 +616,7 @@ class TestServiceViewSet:
         client.authenticate_user(user)
 
         response = client.delete(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert_api_response(response, 204)
         service.refresh_from_db()
         assert service.status == 'Cancelled'
 
@@ -637,7 +631,7 @@ class TestServiceViewSet:
         client.authenticate_user(other_user)
 
         response = client.delete(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
         assert Service.objects.filter(id=service.id).exists()
     
     def test_search_services(self):
@@ -647,7 +641,7 @@ class TestServiceViewSet:
         
         client = APIClient()
         response = client.get('/api/services/?search=cooking')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert any('cooking' in s['title'].lower() for s in response.data['results'])
 
     def test_report_service_visible_in_admin_reports_queue(self):
@@ -666,15 +660,14 @@ class TestServiceViewSet:
             },
             format='json'
         )
-        assert report_resp.status_code == status.HTTP_201_CREATED
-        assert 'report_id' in report_resp.data
+        assert_api_response(report_resp, 201, contains={'report_id'})
 
         admin_user = AdminUserFactory()
         admin_client = AuthenticatedAPIClient()
         admin_client.authenticate_admin(admin_user)
 
         queue_resp = admin_client.get('/api/admin/reports/?status=pending')
-        assert queue_resp.status_code == status.HTTP_200_OK
+        assert_api_response(queue_resp, 200)
         # Not paginated: should be a list of reports.
         report_ids = {r['id'] for r in queue_resp.data}
         assert report_resp.data['report_id'] in report_ids
@@ -702,28 +695,25 @@ class TestServiceRetrieveStatusVisibility:
         """Agreed One-Time service is visible on the detail endpoint."""
         service = ServiceFactory(schedule_type='One-Time', status='Agreed')
         response = APIClient().get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'Agreed'
+        assert_api_response(response, 200, schema={'status': 'Agreed'})
 
     def test_retrieve_one_time_completed_returns_200(self):
         """Completed One-Time service is visible on the detail endpoint."""
         service = ServiceFactory(schedule_type='One-Time', status='Completed')
         response = APIClient().get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'Completed'
+        assert_api_response(response, 200, schema={'status': 'Completed'})
 
     def test_retrieve_one_time_cancelled_returns_200(self):
         """Cancelled One-Time service is visible on the detail endpoint."""
         service = ServiceFactory(schedule_type='One-Time', status='Cancelled')
         response = APIClient().get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['status'] == 'Cancelled'
+        assert_api_response(response, 200, schema={'status': 'Cancelled'})
 
     def test_retrieve_one_time_active_returns_200(self):
         """Active One-Time service is still reachable (regression guard)."""
         service = ServiceFactory(schedule_type='One-Time', status='Active')
         response = APIClient().get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     # ── retrieve: Recurrent services are always Active ───────────────────────
 
@@ -731,13 +721,13 @@ class TestServiceRetrieveStatusVisibility:
         """Active Recurrent service is visible on the detail endpoint."""
         service = ServiceFactory(schedule_type='Recurrent', status='Active')
         response = APIClient().get(f'/api/services/{service.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_retrieve_nonexistent_service_returns_404(self):
         """Unknown UUID must still return 404."""
         import uuid
         response = APIClient().get(f'/api/services/{uuid.uuid4()}/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     # ── list: only Active services are exposed ────────────────────────────────
 
@@ -746,7 +736,7 @@ class TestServiceRetrieveStatusVisibility:
         ServiceFactory(schedule_type='One-Time', status='Agreed')
         ServiceFactory(schedule_type='One-Time', status='Active')
         response = APIClient().get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         statuses = [s['status'] for s in response.data['results']]
         assert 'Agreed' not in statuses
 
@@ -755,7 +745,7 @@ class TestServiceRetrieveStatusVisibility:
         ServiceFactory(schedule_type='One-Time', status='Completed')
         ServiceFactory(schedule_type='One-Time', status='Active')
         response = APIClient().get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         statuses = [s['status'] for s in response.data['results']]
         assert 'Completed' not in statuses
 
@@ -764,7 +754,7 @@ class TestServiceRetrieveStatusVisibility:
         ServiceFactory(schedule_type='One-Time', status='Cancelled')
         ServiceFactory(schedule_type='One-Time', status='Active')
         response = APIClient().get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         statuses = [s['status'] for s in response.data['results']]
         assert 'Cancelled' not in statuses
 
@@ -775,7 +765,7 @@ class TestServiceRetrieveStatusVisibility:
         ServiceFactory(status='Completed')
         ServiceFactory(status='Cancelled')
         response = APIClient().get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert all(s['status'] == 'Active' for s in response.data['results'])
 
     def test_list_excludes_expired_group_offers_from_feed(self):
@@ -796,7 +786,7 @@ class TestServiceRetrieveStatusVisibility:
         )
 
         response = APIClient().get('/api/services/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {item['id'] for item in response.data['results']}
         assert str(expired.id) not in ids
         assert str(future.id) in ids
@@ -816,8 +806,7 @@ class TestServiceRetrieveStatusVisibility:
             'max_participants': 5,
             'schedule_type': 'One-Time',
         })
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['max_participants'] == 1
+        assert_api_response(response, 201, schema={'max_participants': 1})
         service = Service.objects.get(id=response.data['id'])
         assert service.max_participants == 1
 
@@ -837,8 +826,7 @@ class TestServiceRetrieveStatusVisibility:
             'max_participants': 5,
             'schedule_type': 'Recurrent',
         })
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['max_participants'] == 5
+        assert_api_response(response, 201, schema={'max_participants': 5})
         service = Service.objects.get(id=response.data['id'])
         assert service.max_participants == 5
 
@@ -857,7 +845,7 @@ class TestServiceRetrieveStatusVisibility:
             'max_participants': 3,
             'schedule_type': 'One-Time',
         })
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         field_errors = response.data.get('field_errors', {})
         assert 'location_area' in field_errors or 'scheduled_time' in field_errors
 
@@ -885,7 +873,7 @@ class TestServiceRetrieveStatusVisibility:
             'session_location_guide': 'Veterinerin olduğu bina',
         })
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
         service = Service.objects.get(id=response.data['id'])
         assert service.session_exact_location == 'Caferağa Mahallesi, Moda Caddesi No: 185, Kadıköy, İstanbul, Türkiye'
         assert service.session_exact_location_lat == Decimal('40.987654')

--- a/backend/api/tests/integration/test_service_debug_ranking_api.py
+++ b/backend/api/tests/integration/test_service_debug_ranking_api.py
@@ -3,6 +3,7 @@ from rest_framework.test import APIClient
 
 from api.models import PlatformSetting
 from api.tests.helpers.factories import AdminUserFactory, ServiceFactory, UserFactory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -20,12 +21,12 @@ class TestServiceDebugRankingApi:
             'ranking_debug_enabled': True,
         }, format='json')
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         assert response.json()['ranking_debug_enabled'] is True
 
         availability = client.get('/api/services/debug-ranking-availability/')
 
-        assert availability.status_code == 200
+        assert_api_response(availability, 200)
         assert availability.json() == {'enabled': True}
 
     def test_debug_ranking_returns_backend_breakdown_for_selected_service(self):
@@ -50,7 +51,7 @@ class TestServiceDebugRankingApi:
             'active_filter': 'all',
         }, format='json')
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         payload = response.json()
         assert payload['total_services'] == 1
         assert payload['selected_service']['id'] == str(service.id)
@@ -76,7 +77,7 @@ class TestServiceDebugRankingApi:
             'selected_service_id': str(service.id),
         }, format='json')
 
-        assert response.status_code == 403
+        assert_problem_detail(response, 403)
 
 
 @pytest.mark.django_db
@@ -89,14 +90,14 @@ class TestDebugPanelAdminOnly:
         client = APIClient()
         client.force_authenticate(user=member)
         resp = client.get('/api/services/debug-ranking-availability/')
-        assert resp.status_code == 403
+        assert_problem_detail(resp, 403)
 
     def test_non_admin_post_debug_ranking_is_forbidden(self):
         member = UserFactory()
         client = APIClient()
         client.force_authenticate(user=member)
         resp = client.post('/api/services/debug-ranking/', {'service_ids': []}, format='json')
-        assert resp.status_code == 403
+        assert_problem_detail(resp, 403)
 
     def test_admin_can_simulate_as_other_user(self):
         admin = AdminUserFactory()
@@ -114,7 +115,7 @@ class TestDebugPanelAdminOnly:
             'simulated_user_id': str(target.id),
         }, format='json')
 
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         # Payload should still describe the same service, just from `target`'s
         # perspective (different social_boost / proximity numbers).
         assert resp.json()['selected_service']['id'] == str(service.id)

--- a/backend/api/tests/integration/test_service_hot_social_boost.py
+++ b/backend/api/tests/integration/test_service_hot_social_boost.py
@@ -7,6 +7,7 @@ import pytest
 from api.models import Service, UserFollow
 from api.tests.helpers.factories import ServiceFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -54,7 +55,7 @@ class TestServiceHotSocialBoost:
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get('/api/services/?sort=hot&search=[SPB]')
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         ordered_ids = self._service_ids_in_order(response.data)
         assert str(connected_service.id) == ordered_ids[0]
         assert str(disconnected_service.id) == ordered_ids[1]
@@ -96,7 +97,7 @@ class TestServiceHotSocialBoost:
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get('/api/services/?sort=hot&search=[SPB]')
 
-        assert response.status_code == 200
+        assert_api_response(response, 200)
         ordered_ids = self._service_ids_in_order(response.data)
         assert str(second_degree_service.id) == ordered_ids[0]
         assert str(disconnected_service.id) == ordered_ids[1]

--- a/backend/api/tests/integration/test_suggested_users.py
+++ b/backend/api/tests/integration/test_suggested_users.py
@@ -5,6 +5,7 @@ import pytest
 from api.models import UserFollow
 from api.tests.helpers.factories import TagFactory, UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -13,14 +14,14 @@ class TestSuggestedUsersView:
     def test_unauthenticated_returns_401(self):
         client = AuthenticatedAPIClient()
         resp = client.get('/api/users/suggested/')
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
     def test_excludes_self(self):
         viewer = UserFactory()
         UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         resp = client.get('/api/users/suggested/')
-        assert resp.status_code == 200
+        assert_api_response(resp, 200)
         ids = {row['id'] for row in resp.data['results']}
         assert str(viewer.id) not in ids
 

--- a/backend/api/tests/integration/test_transaction_history_api.py
+++ b/backend/api/tests/integration/test_transaction_history_api.py
@@ -17,6 +17,7 @@ from api.tests.helpers.factories import (
 )
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import TransactionHistory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -45,14 +46,14 @@ class TestTransactionHistoryAuth:
     def test_list_requires_auth(self):
         client = AuthenticatedAPIClient()
         response = client.get('/api/transactions/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_retrieve_requires_auth(self):
         user = UserFactory()
         tx = _make_tx(user, 'provision', Decimal('-2.00'))
         client = AuthenticatedAPIClient()
         response = client.get(f'/api/transactions/{tx.id}/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +75,7 @@ class TestTransactionHistoryList:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/transactions/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {r['id'] for r in response.data['results']}
         other_txs = TransactionHistory.objects.filter(user=other).values_list('id', flat=True)
         for oid in other_txs:
@@ -87,9 +88,7 @@ class TestTransactionHistoryList:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/transactions/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'results' in response.data
-        assert 'summary' in response.data
+        assert_api_response(response, 200, contains={'results', 'summary'})
         result = response.data['results'][0]
         for field in ('id', 'transaction_type', 'transaction_type_display', 'amount',
                       'balance_after', 'description', 'created_at'):
@@ -127,8 +126,7 @@ class TestTransactionHistoryList:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/transactions/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['results'] == []
+        assert_api_response(response, 200, schema={'results': []})
         assert response.data['summary']['total_earned'] == pytest.approx(0.0)
         assert response.data['summary']['total_spent'] == pytest.approx(0.0)
 
@@ -152,14 +150,14 @@ class TestTransactionHistoryDirectionFilter:
 
     def test_filter_credit(self):
         response = self.client.get('/api/transactions/?direction=credit')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {r['id'] for r in response.data['results']}
         assert str(self.credit_tx.id) in ids
         assert str(self.debit_tx.id) not in ids
 
     def test_filter_debit(self):
         response = self.client.get('/api/transactions/?direction=debit')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {r['id'] for r in response.data['results']}
         assert str(self.debit_tx.id) in ids
         assert str(self.credit_tx.id) not in ids
@@ -171,7 +169,7 @@ class TestTransactionHistoryDirectionFilter:
 
     def test_filter_reservation(self):
         response = self.client.get('/api/transactions/?direction=reservation')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         ids = {r['id'] for r in response.data['results']}
         assert str(self.debit_tx.id) in ids
         assert str(self.refund_tx.id) in ids
@@ -180,7 +178,7 @@ class TestTransactionHistoryDirectionFilter:
 
     def test_invalid_direction_falls_back_to_all(self):
         response = self.client.get('/api/transactions/?direction=bogus')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         # Both transactions should be present
         ids = {r['id'] for r in response.data['results']}
         assert str(self.credit_tx.id) in ids
@@ -203,10 +201,7 @@ class TestTransactionHistoryPagination:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/transactions/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'count' in response.data
-        assert 'results' in response.data
-        assert response.data['count'] == 5
+        assert_api_response(response, 200, contains={'count', 'results'}, schema={'count': 5})
 
     def test_second_page_accessible(self):
         """If page size is smaller than total records, page=2 returns different results."""
@@ -218,8 +213,8 @@ class TestTransactionHistoryPagination:
         response_p1 = client.get('/api/transactions/?page=1')
         response_p2 = client.get('/api/transactions/?page=2')
 
-        assert response_p1.status_code == status.HTTP_200_OK
-        assert response_p2.status_code == status.HTTP_200_OK
+        assert_api_response(response_p1, 200)
+        assert_api_response(response_p2, 200)
         ids_p1 = {r['id'] for r in response_p1.data['results']}
         ids_p2 = {r['id'] for r in response_p2.data['results']}
         assert ids_p1.isdisjoint(ids_p2), "Pages should not overlap"
@@ -239,8 +234,8 @@ class TestTransactionHistoryPagination:
         response_default = client.get('/api/transactions/?page=1&page_size=20&direction=all')
         response_large = client.get('/api/transactions/?page=1&page_size=100&direction=all')
 
-        assert response_default.status_code == status.HTTP_200_OK
-        assert response_large.status_code == status.HTTP_200_OK
+        assert_api_response(response_default, 200)
+        assert_api_response(response_large, 200)
         assert len(response_default.data['results']) == 20
         assert len(response_large.data['results']) == 30
 
@@ -261,9 +256,7 @@ class TestTransactionHistoryRetrieve:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get(f'/api/transactions/{tx.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(tx.id)
-        assert response.data['transaction_type'] == 'transfer'
+        assert_api_response(response, 200, schema={'id': str(tx.id), 'transaction_type': 'transfer'})
 
     def test_cannot_retrieve_other_users_transaction(self):
         owner = UserFactory()
@@ -273,7 +266,7 @@ class TestTransactionHistoryRetrieve:
         client = AuthenticatedAPIClient().authenticate_user(other)
         response = client.get(f'/api/transactions/{tx.id}/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
 
 # ---------------------------------------------------------------------------
@@ -308,7 +301,7 @@ class TestTransactionHistorySideEffects:
 
         client = AuthenticatedAPIClient().authenticate_user(requester)
         tx_response = client.get('/api/transactions/?direction=debit')
-        assert tx_response.status_code == status.HTTP_200_OK
+        assert_api_response(tx_response, 200)
         types = [r['transaction_type'] for r in tx_response.data['results']]
         assert 'provision' in types
 

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -21,6 +21,7 @@ from api.models import (
     UserFollow,
     UserFollowEvent,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 @pytest.mark.django_db
@@ -40,10 +41,7 @@ class TestUserProfileView:
         client.authenticate_user(user)
         
         response = client.get('/api/users/me/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['email'] == user.email
-        assert response.data['first_name'] == user.first_name
-        assert response.data['last_name'] == user.last_name
+        assert_api_response(response, 200, schema={'email': user.email, 'first_name': user.first_name, 'last_name': user.last_name})
         assert response.data['bio'] == user.bio
         assert response.data['avatar_url'] == user.avatar_url
         assert response.data['date_joined'].startswith(user.date_joined.date().isoformat())
@@ -72,10 +70,7 @@ class TestUserProfileView:
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/users/me/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'created_events' in response.data
-        assert 'joined_events' in response.data
-        assert 'invited_events' in response.data
+        assert_api_response(response, 200, contains={'created_events', 'joined_events', 'invited_events'})
 
         created_ids = {event['id'] for event in response.data['created_events']}
         joined_ids = {event['id'] for event in response.data['joined_events']}
@@ -99,10 +94,7 @@ class TestUserProfileView:
             'show_history': False,
             'email': 'should-not-change@example.com',
         })
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['bio'] == 'Updated bio'
-        assert response.data['first_name'] == 'Updated'
-        assert response.data['last_name'] == 'Profile'
+        assert_api_response(response, 200, schema={'bio': 'Updated bio', 'first_name': 'Updated', 'last_name': 'Profile'})
         assert response.data['avatar_url'] == 'https://example.com/avatars/updated.jpg'
         assert response.data['show_history'] is False
         assert response.data['email'] == user.email
@@ -124,7 +116,7 @@ class TestUserProfileView:
         response = client.patch('/api/users/me/', {
             'bio': 'x' * 1001  # Exceeds limit
         })
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert 'field_errors' in response.data
         assert 'bio' in response.data['field_errors']
         user.refresh_from_db()
@@ -137,9 +129,7 @@ class TestUserProfileView:
         UserFollow.objects.create(follower=user, following=peer)
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.get('/api/users/me/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['followers_count'] == 1
-        assert response.data['following_count'] == 1
+        assert_api_response(response, 200, schema={'followers_count': 1, 'following_count': 1})
         assert response.data['is_following'] is False
 
     def test_other_user_profile_is_following_and_counts(self):
@@ -149,7 +139,7 @@ class TestUserProfileView:
         UserFollow.objects.create(follower=UserFactory(), following=target)
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get(f'/api/users/{target.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data['is_following'] is True
         assert response.data['followers_count'] == 2
         assert response.data['following_count'] == 0
@@ -175,7 +165,7 @@ class TestUserHistoryView:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{user.id}/history/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert isinstance(response.data, list)
     
     def test_user_history_empty(self):
@@ -185,7 +175,7 @@ class TestUserHistoryView:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{user.id}/history/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert response.data == []
 
     def test_get_user_history_includes_completed_event_attendance(self):
@@ -207,7 +197,7 @@ class TestUserHistoryView:
         client = AuthenticatedAPIClient().authenticate_user(participant)
         response = client.get(f'/api/users/{participant.id}/history/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) == 1
         assert response.data[0]['service_type'] == 'Event'
         assert Decimal(str(response.data[0]['duration'])) == Decimal('2.50')
@@ -231,7 +221,7 @@ class TestUserHistoryView:
         client = AuthenticatedAPIClient().authenticate_user(participant)
         response = client.get(f'/api/users/{participant.id}/history/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) == 1
         assert response.data[0]['service_type'] == 'Event'
 
@@ -254,7 +244,7 @@ class TestUserHistoryView:
         client = AuthenticatedAPIClient().authenticate_user(organizer)
         response = client.get(f'/api/users/{organizer.id}/history/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) == 1
         assert response.data[0]['service_type'] == 'Event'
         assert response.data[0]['was_provider'] is True
@@ -272,7 +262,7 @@ class TestUserHistoryView:
         client = AuthenticatedAPIClient().authenticate_user(organizer)
         response = client.get(f'/api/users/{organizer.id}/history/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data) == 1
         assert response.data[0]['service_type'] == 'Event'
         assert response.data[0]['was_provider'] is True
@@ -294,8 +284,7 @@ class TestUserBadgeProgressView:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{user.id}/badge-progress/')
-        assert response.status_code == status.HTTP_200_OK
-        assert 'first-service' in response.data
+        assert_api_response(response, 200, contains={'first-service'})
         assert 'achievement' in response.data['first-service']
     
     def test_get_achievement_progress_other_user(self):
@@ -307,7 +296,7 @@ class TestUserBadgeProgressView:
         client.authenticate_user(user1)
         
         response = client.get(f'/api/users/{user2.id}/badge-progress/')
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert_problem_detail(response, 403)
 
 
 @pytest.mark.django_db
@@ -339,7 +328,7 @@ class TestUserVerifiedReviewsView:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{user.id}/verified-reviews/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert isinstance(response.data, dict)
         assert 'results' in response.data
         if len(response.data['results']) > 0:
@@ -367,8 +356,7 @@ class TestUserVerifiedReviewsView:
 
         client = AuthenticatedAPIClient().authenticate_user(provider)
         hidden_response = client.get(f'/api/users/{provider.id}/verified-reviews/')
-        assert hidden_response.status_code == status.HTTP_200_OK
-        assert hidden_response.data['count'] == 0
+        assert_api_response(hidden_response, 200, schema={'count': 0})
 
         ReputationRep.objects.create(
             handshake=handshake,
@@ -380,8 +368,7 @@ class TestUserVerifiedReviewsView:
         )
 
         revealed_response = client.get(f'/api/users/{provider.id}/verified-reviews/')
-        assert revealed_response.status_code == status.HTTP_200_OK
-        assert revealed_response.data['count'] == 1
+        assert_api_response(revealed_response, 200, schema={'count': 1})
 
     def test_role_filter_offer_provider(self):
         """Offer: target user is provider; role=provider returns review, role=receiver returns none."""
@@ -404,8 +391,8 @@ class TestUserVerifiedReviewsView:
         client = AuthenticatedAPIClient().authenticate_user(provider)
         r_provider = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'provider'})
         r_receiver = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'receiver'})
-        assert r_provider.status_code == status.HTTP_200_OK
-        assert r_receiver.status_code == status.HTTP_200_OK
+        assert_api_response(r_provider, 200)
+        assert_api_response(r_receiver, 200)
         assert r_provider.data['count'] == 1
         assert r_receiver.data['count'] == 0
         assert r_provider.data['results'][0].get('reviewed_user_role') == 'provider'
@@ -431,8 +418,8 @@ class TestUserVerifiedReviewsView:
         client = AuthenticatedAPIClient().authenticate_user(requester)
         r_provider = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'provider'})
         r_receiver = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'receiver'})
-        assert r_provider.status_code == status.HTTP_200_OK
-        assert r_receiver.status_code == status.HTTP_200_OK
+        assert_api_response(r_provider, 200)
+        assert_api_response(r_receiver, 200)
         assert r_provider.data['count'] == 0
         assert r_receiver.data['count'] == 1
         assert r_receiver.data['results'][0].get('reviewed_user_role') == 'receiver'
@@ -458,8 +445,8 @@ class TestUserVerifiedReviewsView:
         client = AuthenticatedAPIClient().authenticate_user(requester)
         r_provider = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'provider'})
         r_receiver = client.get(f'/api/users/{requester.id}/verified-reviews/', {'role': 'receiver'})
-        assert r_provider.status_code == status.HTTP_200_OK
-        assert r_receiver.status_code == status.HTTP_200_OK
+        assert_api_response(r_provider, 200)
+        assert_api_response(r_receiver, 200)
         assert r_provider.data['count'] == 1
         assert r_receiver.data['count'] == 0
         assert r_provider.data['results'][0].get('reviewed_user_role') == 'provider'
@@ -485,8 +472,8 @@ class TestUserVerifiedReviewsView:
         client = AuthenticatedAPIClient().authenticate_user(need_owner)
         r_provider = client.get(f'/api/users/{need_owner.id}/verified-reviews/', {'role': 'provider'})
         r_receiver = client.get(f'/api/users/{need_owner.id}/verified-reviews/', {'role': 'receiver'})
-        assert r_provider.status_code == status.HTTP_200_OK
-        assert r_receiver.status_code == status.HTTP_200_OK
+        assert_api_response(r_provider, 200)
+        assert_api_response(r_receiver, 200)
         assert r_provider.data['count'] == 0
         assert r_receiver.data['count'] == 1
         assert r_receiver.data['results'][0].get('reviewed_user_role') == 'receiver'
@@ -521,8 +508,7 @@ class TestUserVerifiedReviewsView:
         )
         client = AuthenticatedAPIClient().authenticate_user(provider)
         r = client.get(f'/api/users/{provider.id}/verified-reviews/', {'role': 'provider'})
-        assert r.status_code == status.HTTP_200_OK
-        assert r.data['count'] == 1
+        assert_api_response(r, 200, schema={'count': 1})
 
 
 @pytest.mark.django_db
@@ -537,10 +523,7 @@ class TestPublicUserProfile:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{user.id}/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(user.id)
-        assert 'achievements' in response.data
-        assert 'services' in response.data
+        assert_api_response(response, 200, contains={'achievements', 'services'}, schema={'id': str(user.id)})
     
     def test_public_profile_excludes_sensitive_data(self):
         """Test public profile excludes sensitive information"""
@@ -551,7 +534,7 @@ class TestPublicUserProfile:
         client.authenticate_user(user)
         
         response = client.get(f'/api/users/{other_user.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert 'email' not in response.data
         assert 'role' not in response.data
         assert 'timebank_balance' not in response.data
@@ -580,9 +563,7 @@ class TestPublicUserProfile:
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get(f'/api/users/{profile_user.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'created_events' in response.data
-        assert 'joined_events' in response.data
+        assert_api_response(response, 200, contains={'created_events', 'joined_events'})
         assert 'invited_events' not in response.data
 
         created_ids = {event['id'] for event in response.data['created_events']}
@@ -656,8 +637,7 @@ class TestEventCommentsHistoryOnProfile:
         client = AuthenticatedAPIClient().authenticate_user(viewer)
         response = client.get(f'/api/users/{organizer.id}/')
 
-        assert response.status_code == status.HTTP_200_OK
-        assert 'event_comments_history' in response.data
+        assert_api_response(response, 200, contains={'event_comments_history'})
         history = response.data['event_comments_history']
         assert len(history) == 2
 
@@ -695,7 +675,7 @@ class TestEventCommentsHistoryOnProfile:
 
         # Comment must be visible even before the organizer submits any evaluation.
         response = client.get(f'/api/users/{organizer.id}/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert len(response.data['event_comments_history']) == 1, (
             'Event review must be visible immediately — blind-review suppression '
             'must not apply to Event handshakes.'
@@ -715,7 +695,7 @@ class TestEventCommentsHistoryOnProfile:
         )
 
         after_response = client.get(f'/api/users/{organizer.id}/')
-        assert after_response.status_code == status.HTTP_200_OK
+        assert_api_response(after_response, 200)
         assert len(after_response.data['event_comments_history']) == 1
 
 
@@ -729,8 +709,7 @@ class TestUserFollowView:
         target = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(follower)
         response = client.post(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['message'] == 'Successfully followed user.'
+        assert_api_response(response, 201, schema={'message': 'Successfully followed user.'})
         assert response.data['follow']['follower_id'] == str(follower.id)
         assert response.data['follow']['following_id'] == str(target.id)
         assert 'id' in response.data['follow']
@@ -745,14 +724,14 @@ class TestUserFollowView:
     def test_follow_target_not_found(self):
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.post(f'/api/users/{uuid.uuid4()}/follow/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
         assert response.data['code'] == 'NOT_FOUND'
 
     def test_follow_self_returns_400(self):
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.post(f'/api/users/{user.id}/follow/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert response.data['code'] == 'VALIDATION_ERROR'
 
     def test_follow_duplicate_returns_400(self):
@@ -761,7 +740,7 @@ class TestUserFollowView:
         UserFollow.objects.create(follower=follower, following=target)
         client = AuthenticatedAPIClient().authenticate_user(follower)
         response = client.post(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert response.data['code'] == 'ALREADY_EXISTS'
 
     def test_follow_requires_authentication(self):
@@ -770,7 +749,7 @@ class TestUserFollowView:
         target = UserFactory()
         client = APIClient()
         response = client.post(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_follow_invalidates_cached_me_profile(self):
         follower = UserFactory()
@@ -799,8 +778,7 @@ class TestUserFollowView:
         UserFollow.objects.create(follower=follower, following=target)
         client = AuthenticatedAPIClient().authenticate_user(follower)
         response = client.delete(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['message'] == 'Successfully unfollowed user.'
+        assert_api_response(response, 200, schema={'message': 'Successfully unfollowed user.'})
         assert not UserFollow.objects.filter(follower=follower, following=target).exists()
         assert UserFollowEvent.objects.filter(
             follower=follower,
@@ -811,14 +789,14 @@ class TestUserFollowView:
     def test_unfollow_target_not_found(self):
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.delete(f'/api/users/{uuid.uuid4()}/follow/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
         assert response.data['code'] == 'NOT_FOUND'
 
     def test_unfollow_self_returns_400(self):
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         response = client.delete(f'/api/users/{user.id}/follow/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert response.data['code'] == 'VALIDATION_ERROR'
 
     def test_unfollow_when_not_following_returns_400(self):
@@ -826,7 +804,7 @@ class TestUserFollowView:
         target = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(follower)
         response = client.delete(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
         assert response.data['code'] == 'INVALID_STATE'
 
     def test_unfollow_requires_authentication(self):
@@ -835,7 +813,7 @@ class TestUserFollowView:
         target = UserFactory()
         client = APIClient()
         response = client.delete(f'/api/users/{target.id}/follow/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 @pytest.mark.django_db
@@ -851,7 +829,7 @@ class TestUserFollowListViews:
         UserFollow.objects.create(follower=follower_b, following=target)
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.get(f'/api/users/{target.id}/followers/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results']
         assert len(results) == 2
         ids = {row['id'] for row in results}
@@ -868,7 +846,7 @@ class TestUserFollowListViews:
         UserFollow.objects.create(follower=source, following=u2)
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.get(f'/api/users/{source.id}/following/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results']
         assert len(results) == 2
         ids = {row['id'] for row in results}
@@ -878,7 +856,7 @@ class TestUserFollowListViews:
     def test_followers_list_user_not_found(self):
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.get(f'/api/users/{uuid.uuid4()}/followers/')
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
         assert response.data['code'] == 'NOT_FOUND'
 
     def test_followers_list_requires_authentication(self):
@@ -886,14 +864,14 @@ class TestUserFollowListViews:
 
         target = UserFactory()
         response = APIClient().get(f'/api/users/{target.id}/followers/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_following_list_requires_authentication(self):
         from rest_framework.test import APIClient
 
         source = UserFactory()
         response = APIClient().get(f'/api/users/{source.id}/following/')
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
     def test_inactive_follower_excluded_from_list_and_count(self):
         target = UserFactory()
@@ -903,7 +881,7 @@ class TestUserFollowListViews:
         UserFollow.objects.create(follower=inactive_follower, following=target)
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.get(f'/api/users/{target.id}/followers/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results']
         ids = {row['id'] for row in results}
         assert str(active_follower.id) in ids
@@ -917,7 +895,7 @@ class TestUserFollowListViews:
         UserFollow.objects.create(follower=source, following=inactive_target)
         client = AuthenticatedAPIClient().authenticate_user(UserFactory())
         response = client.get(f'/api/users/{source.id}/following/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         results = response.data['results']
         ids = {row['id'] for row in results}
         assert str(active_target.id) in ids

--- a/backend/api/tests/integration/test_user_follow_views.py
+++ b/backend/api/tests/integration/test_user_follow_views.py
@@ -15,6 +15,7 @@ from rest_framework import status
 from api.models import UserFollow, UserFollowEvent
 from api.tests.helpers.factories import UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +34,7 @@ class TestUserFollowViewPost:
 
         response = client.post(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert_api_response(response, 201)
 
     def test_follow_success_creates_userfollow_row(self):
         actor = UserFactory()
@@ -74,7 +75,7 @@ class TestUserFollowViewPost:
 
         response = client.post(f'/api/users/{actor.id}/follow/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_follow_self_creates_no_rows(self):
         actor = UserFactory()
@@ -93,7 +94,7 @@ class TestUserFollowViewPost:
 
         response = client.post(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_follow_already_following_creates_no_extra_row(self):
         actor = UserFactory()
@@ -111,7 +112,7 @@ class TestUserFollowViewPost:
 
         response = client.post(f'/api/users/{_uuid.uuid4()}/follow/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_follow_unauthenticated_returns_401(self):
         target = UserFactory()
@@ -119,7 +120,7 @@ class TestUserFollowViewPost:
 
         response = client.post(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +140,7 @@ class TestUserFollowViewDelete:
 
         response = client.delete(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_unfollow_success_deletes_userfollow_row(self):
         actor = UserFactory()
@@ -171,7 +172,7 @@ class TestUserFollowViewDelete:
 
         response = client.delete(f'/api/users/{actor.id}/follow/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_unfollow_not_following_returns_400(self):
         actor = UserFactory()
@@ -180,7 +181,7 @@ class TestUserFollowViewDelete:
 
         response = client.delete(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_unfollow_not_following_creates_no_event(self):
         actor = UserFactory()
@@ -197,7 +198,7 @@ class TestUserFollowViewDelete:
 
         response = client.delete(f'/api/users/{_uuid.uuid4()}/follow/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_unfollow_unauthenticated_returns_401(self):
         target = UserFactory()
@@ -205,7 +206,7 @@ class TestUserFollowViewDelete:
 
         response = client.delete(f'/api/users/{target.id}/follow/')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +225,7 @@ class TestUserFollowersListView:
 
         response = client.get(f'/api/users/{user.id}/followers/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_followers_returns_correct_users(self):
         user = UserFactory()
@@ -260,7 +261,7 @@ class TestUserFollowersListView:
 
         response = client.get(f'/api/users/{_uuid.uuid4()}/followers/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_followers_unauthenticated_returns_401(self):
         user = UserFactory()
@@ -268,7 +269,7 @@ class TestUserFollowersListView:
 
         response = client.get(f'/api/users/{user.id}/followers/')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +288,7 @@ class TestUserFollowingListView:
 
         response = client.get(f'/api/users/{user.id}/following/')
 
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
 
     def test_following_returns_correct_users(self):
         user = UserFactory()
@@ -323,7 +324,7 @@ class TestUserFollowingListView:
 
         response = client.get(f'/api/users/{_uuid.uuid4()}/following/')
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert_problem_detail(response, 404)
 
     def test_following_unauthenticated_returns_401(self):
         user = UserFactory()
@@ -331,7 +332,7 @@ class TestUserFollowingListView:
 
         response = client.get(f'/api/users/{user.id}/following/')
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert_problem_detail(response, 401)
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/integration/test_user_profile_update.py
+++ b/backend/api/tests/integration/test_user_profile_update.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from api.tests.helpers.factories import UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 from api.models import Badge, UserBadge
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 ME_URL = '/api/users/me/'
@@ -31,7 +32,7 @@ class TestFeaturedBadgesPatch:
         _earn_badge(user, b1)
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': ['b1']}, format='json')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         data = resp.json()
         assert 'b1' in data['featured_badges']
 
@@ -43,7 +44,7 @@ class TestFeaturedBadgesPatch:
         _earn_badge(user, b2)
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': ['b1', 'b2']}, format='json')
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         data = resp.json()
         assert set(data['featured_badges']) == {'b1', 'b2'}
 
@@ -63,7 +64,7 @@ class TestFeaturedBadgesPatch:
         _create_badge('unearned', 'Unearned Badge')
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': ['unearned']}, format='json')
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert self._has_featured_badges_error(resp)
 
     def test_patch_more_than_two_returns_400(self):
@@ -76,7 +77,7 @@ class TestFeaturedBadgesPatch:
         _earn_badge(user, b3)
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': ['b1', 'b2', 'b3']}, format='json')
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert self._has_featured_badges_error(resp)
 
     def test_patch_duplicates_returns_400(self):
@@ -85,15 +86,14 @@ class TestFeaturedBadgesPatch:
         _earn_badge(user, b1)
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': ['b1', 'b1']}, format='json')
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(resp, 400)
         assert self._has_featured_badges_error(resp)
 
     def test_patch_empty_list_succeeds(self):
         user = UserFactory()
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.patch(ME_URL, {'featured_badges': []}, format='json')
-        assert resp.status_code == status.HTTP_200_OK
-        assert resp.json()['featured_badges'] == []
+        assert_api_response(resp, 200, schema={'featured_badges': []})
 
 
 @pytest.mark.django_db
@@ -107,7 +107,7 @@ class TestFeaturedBadgesGet:
         user.save()
         client = AuthenticatedAPIClient().authenticate_user(user)
         resp = client.get(ME_URL)
-        assert resp.status_code == status.HTTP_200_OK
+        assert_api_response(resp, 200)
         data = resp.json()
         assert 'featured_badges' in data
         assert 'featured_badges_detail' in data

--- a/backend/api/tests/integration/test_verification_api.py
+++ b/backend/api/tests/integration/test_verification_api.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 from api.models import EmailVerificationToken, PasswordResetToken
 from api.tests.helpers.factories import UserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 User = get_user_model()
 
@@ -26,8 +27,7 @@ class TestVerificationAPI:
         )
         client = APIClient()
         response = client.post('/api/auth/verify-email/', {'token': 'valid_token_123'})
-        assert response.status_code == status.HTTP_200_OK
-        assert 'access' in response.data
+        assert_api_response(response, 200, contains={'access'})
         user.refresh_from_db()
         assert user.is_verified is True
         token.refresh_from_db()
@@ -36,7 +36,7 @@ class TestVerificationAPI:
     def test_verify_email_invalid_token(self):
         client = APIClient()
         response = client.post('/api/auth/verify-email/', {'token': 'invalid_string'})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     def test_verify_email_expired_token(self):
         user = UserFactory(is_verified=False)
@@ -47,7 +47,7 @@ class TestVerificationAPI:
         )
         client = APIClient()
         response = client.post('/api/auth/verify-email/', {'token': 'expired_token_123'})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     @patch('api.views._send_email_async')
     def test_send_verification_authenticated(self, mock_send):
@@ -56,7 +56,7 @@ class TestVerificationAPI:
         client.authenticate_user(user)
 
         response = client.post('/api/auth/send-verification/')
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         assert EmailVerificationToken.objects.filter(user=user, is_used=False).exists()
         mock_send.assert_called_once()
 
@@ -66,21 +66,21 @@ class TestVerificationAPI:
         client.authenticate_user(user)
 
         response = client.post('/api/auth/send-verification/')
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)
 
     @patch('api.views._send_email_async')
     def test_resend_verification_public(self, mock_send):
         user = UserFactory(is_verified=False, email='testunverified@test.com')
         client = APIClient()
         response = client.post('/api/auth/resend-verification/', {'email': 'testunverified@test.com'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         mock_send.assert_called_once()
 
     @patch('api.views._send_email_async')
     def test_resend_verification_public_does_not_exist(self, mock_send):
         client = APIClient()
         response = client.post('/api/auth/resend-verification/', {'email': 'doesnotexist@test.com'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         mock_send.assert_not_called()
 
 
@@ -93,7 +93,7 @@ class TestPasswordResetAPI:
         UserFactory(email='forgotpass@test.com')
         client = APIClient()
         response = client.post('/api/auth/forgot-password/', {'email': 'forgotpass@test.com'})
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         mock_send.assert_called_once()
 
     def test_reset_password_success(self):
@@ -113,7 +113,7 @@ class TestPasswordResetAPI:
             'password': 'newsecurepass123'
         })
         
-        assert response.status_code == status.HTTP_200_OK
+        assert_api_response(response, 200)
         user.refresh_from_db()
         assert user.check_password('newsecurepass123') is True
         token.refresh_from_db()
@@ -125,4 +125,4 @@ class TestPasswordResetAPI:
             'token': 'bad_token',
             'password': 'newsecurepass123'
         })
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert_problem_detail(response, 400)

--- a/backend/api/tests/unit/test_backfill_tags.py
+++ b/backend/api/tests/unit/test_backfill_tags.py
@@ -5,131 +5,132 @@ Phase 4 tests — verify backfill populates parent_qid and entity_type
 for existing tags from WikiData.
 """
 from io import StringIO
-from django.test import TestCase
-from django.core.management import call_command
+from types import SimpleNamespace
 from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
 
 from api.models import Tag
 
 
-class BackfillTagHierarchyTestCase(TestCase):
-    """Tests for the backfill_tag_hierarchy management command."""
+@pytest.fixture
+def env(db):
+    return SimpleNamespace(
+        tag_python=Tag.objects.create(id='Q28865', name='Python'),
+        tag_cooking=Tag.objects.create(id='Q25403900', name='Cooking'),
+        tag_custom=Tag.objects.create(id='my_custom_tag', name='Custom Tag'),
+    )
 
-    def setUp(self):
-        self.tag_python = Tag.objects.create(id='Q28865', name='Python')
-        self.tag_cooking = Tag.objects.create(id='Q25403900', name='Cooking')
-        self.tag_custom = Tag.objects.create(id='my_custom_tag', name='Custom Tag')
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_populates_parent_qid(self, mock_resolve, mock_claims):
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
-        mock_resolve.return_value = 'technology'
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_populates_parent_qid(mock_resolve, mock_claims, env):
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
+    mock_resolve.return_value = 'technology'
 
-        call_command('backfill_tag_hierarchy', stdout=StringIO())
+    call_command('backfill_tag_hierarchy', stdout=StringIO())
 
-        self.tag_python.refresh_from_db()
-        self.assertEqual(self.tag_python.parent_qid, 'Q9143')
+    env.tag_python.refresh_from_db()
+    assert env.tag_python.parent_qid == 'Q9143'
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_populates_entity_type(self, mock_resolve, mock_claims):
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
-        mock_resolve.return_value = 'technology'
 
-        call_command('backfill_tag_hierarchy', stdout=StringIO())
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_populates_entity_type(mock_resolve, mock_claims, env):
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
+    mock_resolve.return_value = 'technology'
 
-        self.tag_python.refresh_from_db()
-        self.assertEqual(self.tag_python.entity_type, 'technology')
+    call_command('backfill_tag_hierarchy', stdout=StringIO())
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_is_idempotent(self, mock_resolve, mock_claims):
-        """Second run skips tags already populated."""
-        self.tag_python.parent_qid = 'Q9143'
-        self.tag_python.entity_type = 'technology'
-        self.tag_python.save()
+    env.tag_python.refresh_from_db()
+    assert env.tag_python.entity_type == 'technology'
 
-        mock_claims.return_value = {'instance_of': ['Q2095'], 'subclass_of': []}
-        mock_resolve.return_value = 'food'
 
-        call_command('backfill_tag_hierarchy', stdout=StringIO())
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_is_idempotent(mock_resolve, mock_claims, env):
+    """Second run skips tags already populated."""
+    env.tag_python.parent_qid = 'Q9143'
+    env.tag_python.entity_type = 'technology'
+    env.tag_python.save()
 
-        # Should not have been called for tag_python (already has parent_qid)
-        called_qids = [c[0][0] for c in mock_claims.call_args_list]
-        self.assertNotIn('Q28865', called_qids)
+    mock_claims.return_value = {'instance_of': ['Q2095'], 'subclass_of': []}
+    mock_resolve.return_value = 'food'
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_skips_non_qid_tags(self, mock_resolve, mock_claims):
-        """Tags with non-QID ids are skipped."""
-        mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
-        mock_resolve.return_value = 'technology'
+    call_command('backfill_tag_hierarchy', stdout=StringIO())
 
-        call_command('backfill_tag_hierarchy', stdout=StringIO())
+    called_qids = [c[0][0] for c in mock_claims.call_args_list]
+    assert 'Q28865' not in called_qids
 
-        called_qids = [c[0][0] for c in mock_claims.call_args_list]
-        self.assertNotIn('my_custom_tag', called_qids)
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_handles_api_failure(self, mock_resolve, mock_claims):
-        """API failure for one tag doesn't block others."""
-        def claims_side_effect(qid):
-            if qid == 'Q28865':
-                return None  # API failure
-            return {'instance_of': ['Q2095'], 'subclass_of': []}
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_skips_non_qid_tags(mock_resolve, mock_claims, env):
+    """Tags with non-QID ids are skipped."""
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
+    mock_resolve.return_value = 'technology'
 
-        mock_claims.side_effect = claims_side_effect
-        mock_resolve.return_value = 'food'
+    call_command('backfill_tag_hierarchy', stdout=StringIO())
 
-        call_command('backfill_tag_hierarchy', stdout=StringIO())
+    called_qids = [c[0][0] for c in mock_claims.call_args_list]
+    assert 'my_custom_tag' not in called_qids
 
-        # Python tag should be unchanged (API failed)
-        self.tag_python.refresh_from_db()
-        self.assertIsNone(self.tag_python.parent_qid)
 
-        # Cooking tag should be populated
-        self.tag_cooking.refresh_from_db()
-        self.assertEqual(self.tag_cooking.parent_qid, 'Q2095')
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_handles_api_failure(mock_resolve, mock_claims, env):
+    """API failure for one tag doesn't block others."""
+    def claims_side_effect(qid):
+        if qid == 'Q28865':
+            return None
+        return {'instance_of': ['Q2095'], 'subclass_of': []}
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_force_flag(self, mock_resolve, mock_claims):
-        """--force re-fetches already-populated tags."""
-        self.tag_python.parent_qid = 'Q9143'
-        self.tag_python.entity_type = 'technology'
-        self.tag_python.save()
+    mock_claims.side_effect = claims_side_effect
+    mock_resolve.return_value = 'food'
 
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
-        mock_resolve.return_value = 'technology'
+    call_command('backfill_tag_hierarchy', stdout=StringIO())
 
-        call_command('backfill_tag_hierarchy', '--force', stdout=StringIO())
+    env.tag_python.refresh_from_db()
+    assert env.tag_python.parent_qid is None
 
-        called_qids = [c[0][0] for c in mock_claims.call_args_list]
-        self.assertIn('Q28865', called_qids)
+    env.tag_cooking.refresh_from_db()
+    assert env.tag_cooking.parent_qid == 'Q2095'
 
-    @patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
-    @patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
-    def test_dry_run(self, mock_resolve, mock_claims):
-        """--dry-run does not save changes."""
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
-        mock_resolve.return_value = 'technology'
 
-        call_command('backfill_tag_hierarchy', '--dry-run', stdout=StringIO())
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_force_flag(mock_resolve, mock_claims, env):
+    """--force re-fetches already-populated tags."""
+    env.tag_python.parent_qid = 'Q9143'
+    env.tag_python.entity_type = 'technology'
+    env.tag_python.save()
 
-        self.tag_python.refresh_from_db()
-        self.assertIsNone(self.tag_python.parent_qid)
-        self.assertIsNone(self.tag_python.entity_type)
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
+    mock_resolve.return_value = 'technology'
+
+    call_command('backfill_tag_hierarchy', '--force', stdout=StringIO())
+
+    called_qids = [c[0][0] for c in mock_claims.call_args_list]
+    assert 'Q28865' in called_qids
+
+
+@pytest.mark.django_db
+@patch('api.management.commands.backfill_tag_hierarchy.fetch_wikidata_claims')
+@patch('api.management.commands.backfill_tag_hierarchy.resolve_entity_type')
+def test_dry_run(mock_resolve, mock_claims, env):
+    """--dry-run does not save changes."""
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
+    mock_resolve.return_value = 'technology'
+
+    call_command('backfill_tag_hierarchy', '--dry-run', stdout=StringIO())
+
+    env.tag_python.refresh_from_db()
+    assert env.tag_python.parent_qid is None
+    assert env.tag_python.entity_type is None

--- a/backend/api/tests/unit/test_cache_utils.py
+++ b/backend/api/tests/unit/test_cache_utils.py
@@ -175,43 +175,51 @@ class TestRegisterCalendarCacheKey:
     Regression: the original implementation had an unconditional `return`
     inside the `for _ in range(3)` loop, so the retry never kicked in and
     a racing writer could clobber the tracking set with a single-key set.
+
+    Each test mints its own user_id via uuid because pytest-xdist runs
+    these in parallel against a shared Redis on CI — a literal 'user-1'
+    would let workers trample each other's tracking sets, and a setup-
+    level `cache.clear()` would wreck other workers' in-flight state.
     """
 
-    def setup_method(self, method):
-        from django.core.cache import cache as django_cache
-        django_cache.clear()
-
     def test_register_two_keys_for_same_user_keeps_both(self):
+        import uuid
         from django.core.cache import cache as django_cache
-        register_calendar_cache_key('user-1', 'cal_key_a')
-        register_calendar_cache_key('user-1', 'cal_key_b')
-        tracked = django_cache.get('user_calendar_keys:user-1', set())
+        user_id = f'cache-test-{uuid.uuid4().hex[:8]}'
+        register_calendar_cache_key(user_id, 'cal_key_a')
+        register_calendar_cache_key(user_id, 'cal_key_b')
+        tracked = django_cache.get(f'user_calendar_keys:{user_id}', set())
         assert tracked == {'cal_key_a', 'cal_key_b'}
 
     def test_register_idempotent_for_same_key(self):
+        import uuid
         from django.core.cache import cache as django_cache
-        register_calendar_cache_key('user-1', 'cal_key_a')
-        register_calendar_cache_key('user-1', 'cal_key_a')
-        tracked = django_cache.get('user_calendar_keys:user-1', set())
+        user_id = f'cache-test-{uuid.uuid4().hex[:8]}'
+        register_calendar_cache_key(user_id, 'cal_key_a')
+        register_calendar_cache_key(user_id, 'cal_key_a')
+        tracked = django_cache.get(f'user_calendar_keys:{user_id}', set())
         assert tracked == {'cal_key_a'}
 
     def test_register_recovers_when_first_set_was_clobbered(self, monkeypatch):
         """If a racing caller landed between our get and set, the verify-then-
         retry loop must re-read and merge instead of leaving the new key out."""
+        import uuid
         from django.core import cache as cache_mod
         cache = cache_mod.cache
+        user_id = f'cache-test-{uuid.uuid4().hex[:8]}'
 
-        register_calendar_cache_key('user-1', 'a')
+        register_calendar_cache_key(user_id, 'a')
 
         original_set = cache.set
         call_count = {'n': 0}
+        tracking_key = f'user_calendar_keys:{user_id}'
 
         def racy_set(key, value, timeout=None, **kwargs):
             # On the first set for our user's tracking key, simulate a racing
             # writer that overwrote the value AFTER we read but BEFORE we
             # write — i.e. our write lands first, then the racer's write
             # immediately clobbers it. The retry must detect that and merge.
-            if key == 'user_calendar_keys:user-1' and call_count['n'] == 0:
+            if key == tracking_key and call_count['n'] == 0:
                 call_count['n'] += 1
                 result = original_set(key, value, timeout=timeout, **kwargs)
                 # Simulate the racing clobber:
@@ -221,9 +229,9 @@ class TestRegisterCalendarCacheKey:
 
         monkeypatch.setattr(cache, 'set', racy_set)
 
-        register_calendar_cache_key('user-1', 'b')
+        register_calendar_cache_key(user_id, 'b')
 
-        tracked = cache.get('user_calendar_keys:user-1', set())
+        tracked = cache.get(tracking_key, set())
         assert 'b' in tracked, (
             'After a racing clobber, the retry loop must re-add our key'
         )

--- a/backend/api/tests/unit/test_cache_utils.py
+++ b/backend/api/tests/unit/test_cache_utils.py
@@ -10,7 +10,8 @@ from api.cache_utils import (
     cache_service_list, get_cached_service_list, invalidate_service_lists,
     cache_service_detail, get_cached_service_detail, invalidate_service_detail,
     cache_hot_services, get_cached_hot_services, invalidate_hot_services,
-    invalidate_on_service_change, invalidate_on_user_change
+    invalidate_on_service_change, invalidate_on_user_change,
+    register_calendar_cache_key,
 )
 from api.tests.helpers.factories import UserFactory, ServiceFactory
 
@@ -165,3 +166,64 @@ class TestInvalidateOnChange:
         user.id = 'user-1'
         invalidate_on_user_change(user)
         mock_invalidate.assert_called_once_with(str(user.id))
+
+
+@pytest.mark.unit
+class TestRegisterCalendarCacheKey:
+    """Cover the read-modify-write retry loop in register_calendar_cache_key.
+
+    Regression: the original implementation had an unconditional `return`
+    inside the `for _ in range(3)` loop, so the retry never kicked in and
+    a racing writer could clobber the tracking set with a single-key set.
+    """
+
+    def setup_method(self, method):
+        from django.core.cache import cache as django_cache
+        django_cache.clear()
+
+    def test_register_two_keys_for_same_user_keeps_both(self):
+        from django.core.cache import cache as django_cache
+        register_calendar_cache_key('user-1', 'cal_key_a')
+        register_calendar_cache_key('user-1', 'cal_key_b')
+        tracked = django_cache.get('user_calendar_keys:user-1', set())
+        assert tracked == {'cal_key_a', 'cal_key_b'}
+
+    def test_register_idempotent_for_same_key(self):
+        from django.core.cache import cache as django_cache
+        register_calendar_cache_key('user-1', 'cal_key_a')
+        register_calendar_cache_key('user-1', 'cal_key_a')
+        tracked = django_cache.get('user_calendar_keys:user-1', set())
+        assert tracked == {'cal_key_a'}
+
+    def test_register_recovers_when_first_set_was_clobbered(self, monkeypatch):
+        """If a racing caller landed between our get and set, the verify-then-
+        retry loop must re-read and merge instead of leaving the new key out."""
+        from django.core import cache as cache_mod
+        cache = cache_mod.cache
+
+        register_calendar_cache_key('user-1', 'a')
+
+        original_set = cache.set
+        call_count = {'n': 0}
+
+        def racy_set(key, value, timeout=None, **kwargs):
+            # On the first set for our user's tracking key, simulate a racing
+            # writer that overwrote the value AFTER we read but BEFORE we
+            # write — i.e. our write lands first, then the racer's write
+            # immediately clobbers it. The retry must detect that and merge.
+            if key == 'user_calendar_keys:user-1' and call_count['n'] == 0:
+                call_count['n'] += 1
+                result = original_set(key, value, timeout=timeout, **kwargs)
+                # Simulate the racing clobber:
+                original_set(key, {'racer_only'}, timeout=timeout, **kwargs)
+                return result
+            return original_set(key, value, timeout=timeout, **kwargs)
+
+        monkeypatch.setattr(cache, 'set', racy_set)
+
+        register_calendar_cache_key('user-1', 'b')
+
+        tracked = cache.get('user_calendar_keys:user-1', set())
+        assert 'b' in tracked, (
+            'After a racing clobber, the retry loop must re-add our key'
+        )

--- a/backend/api/tests/unit/test_comments_ranking.py
+++ b/backend/api/tests/unit/test_comments_ranking.py
@@ -2,748 +2,611 @@
 Tests for Comments, Ranking Algorithm, and Extended Badge System
 """
 from decimal import Decimal
-from django.test import TestCase
+from types import SimpleNamespace
+
+import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
-from rest_framework import status
-from unittest.mock import patch
-from datetime import timedelta
-from django.utils import timezone
 
+from api.achievement_utils import (
+    check_and_assign_badges, get_achievement_progress, get_user_stats,
+)
 from api.models import (
-    User, Service, Handshake, Comment, NegativeRep, 
-    ReputationRep, Badge, UserBadge, TransactionHistory
+    Comment, Handshake, NegativeRep, ReputationRep, Service, User, UserBadge,
 )
 from api.ranking import calculate_hot_score, calculate_hot_scores_batch
-from api.achievement_utils import check_and_assign_badges, get_user_stats, get_achievement_progress
 
 
-class CommentModelTest(TestCase):
-    """Test Comment model functionality"""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User'
-        )
-        self.service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-    
-    def test_create_top_level_comment(self):
-        """Test creating a top-level comment"""
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='Great service!'
-        )
-        self.assertIsNotNone(comment.id)
-        self.assertIsNone(comment.parent)
-        self.assertFalse(comment.is_deleted)
-    
-    def test_create_reply_comment(self):
-        """Test creating a reply to a comment"""
-        parent = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='Great service!'
-        )
-        reply = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            parent=parent,
-            body='Thanks!'
-        )
-        self.assertEqual(reply.parent, parent)
-        self.assertEqual(parent.replies.count(), 1)
-    
-    def test_soft_delete_comment(self):
-        """Test soft deleting a comment"""
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='Test comment'
-        )
-        comment.is_deleted = True
-        comment.save()
-        
-        # Comment still exists but is marked as deleted
-        self.assertTrue(Comment.objects.filter(id=comment.id).exists())
-        self.assertTrue(Comment.objects.get(id=comment.id).is_deleted)
+# ── Comment model ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def comment_env(db):
+    user = User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+    )
+    service = Service.objects.create(
+        user=user, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    return SimpleNamespace(user=user, service=service)
 
 
-class NegativeRepModelTest(TestCase):
-    """Test NegativeRep model functionality"""
-    
-    def setUp(self):
-        self.provider = User.objects.create_user(
-            email='provider@example.com',
-            password='testpass123',
-            first_name='Provider',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.receiver = User.objects.create_user(
-            email='receiver@example.com',
-            password='testpass123',
-            first_name='Receiver',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.service = Service.objects.create(
-            user=self.provider,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        self.handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.receiver,
-            status='completed',
-            provisioned_hours=Decimal('2.00')
-        )
-    
-    def test_create_negative_rep(self):
-        """Test creating a negative reputation"""
-        neg_rep = NegativeRep.objects.create(
-            handshake=self.handshake,
-            giver=self.receiver,
-            receiver=self.provider,
-            is_late=True,
-            comment='Was 30 minutes late'
-        )
-        self.assertIsNotNone(neg_rep.id)
-        self.assertTrue(neg_rep.is_late)
-        self.assertFalse(neg_rep.is_unhelpful)
-        self.assertFalse(neg_rep.is_rude)
-    
-    def test_unique_negative_rep_per_handshake_giver(self):
-        """Test that a user can only give one negative rep per handshake"""
+@pytest.mark.django_db
+def test_create_top_level_comment(comment_env):
+    comment = Comment.objects.create(
+        service=comment_env.service, user=comment_env.user, body='Great service!',
+    )
+    assert comment.id is not None
+    assert comment.parent is None
+    assert not comment.is_deleted
+
+
+@pytest.mark.django_db
+def test_create_reply_comment(comment_env):
+    parent = Comment.objects.create(
+        service=comment_env.service, user=comment_env.user, body='Great service!',
+    )
+    reply = Comment.objects.create(
+        service=comment_env.service, user=comment_env.user,
+        parent=parent, body='Thanks!',
+    )
+    assert reply.parent == parent
+    assert parent.replies.count() == 1
+
+
+@pytest.mark.django_db
+def test_soft_delete_comment(comment_env):
+    comment = Comment.objects.create(
+        service=comment_env.service, user=comment_env.user, body='Test comment',
+    )
+    comment.is_deleted = True
+    comment.save()
+
+    assert Comment.objects.filter(id=comment.id).exists()
+    assert Comment.objects.get(id=comment.id).is_deleted
+
+
+# ── NegativeRep model ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def neg_rep_env(db):
+    provider = User.objects.create_user(
+        email='provider@example.com', password='testpass123',
+        first_name='Provider', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    receiver = User.objects.create_user(
+        email='receiver@example.com', password='testpass123',
+        first_name='Receiver', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    service = Service.objects.create(
+        user=provider, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    handshake = Handshake.objects.create(
+        service=service, requester=receiver,
+        status='completed', provisioned_hours=Decimal('2.00'),
+    )
+    return SimpleNamespace(provider=provider, receiver=receiver, service=service, handshake=handshake)
+
+
+@pytest.mark.django_db
+def test_create_negative_rep(neg_rep_env):
+    neg_rep = NegativeRep.objects.create(
+        handshake=neg_rep_env.handshake,
+        giver=neg_rep_env.receiver,
+        receiver=neg_rep_env.provider,
+        is_late=True, comment='Was 30 minutes late',
+    )
+    assert neg_rep.id is not None
+    assert neg_rep.is_late
+    assert not neg_rep.is_unhelpful
+    assert not neg_rep.is_rude
+
+
+@pytest.mark.django_db
+def test_unique_negative_rep_per_handshake_giver(neg_rep_env):
+    NegativeRep.objects.create(
+        handshake=neg_rep_env.handshake,
+        giver=neg_rep_env.receiver,
+        receiver=neg_rep_env.provider,
+        is_late=True,
+    )
+    from django.db import IntegrityError
+    with pytest.raises(IntegrityError):
         NegativeRep.objects.create(
-            handshake=self.handshake,
-            giver=self.receiver,
-            receiver=self.provider,
-            is_late=True
+            handshake=neg_rep_env.handshake,
+            giver=neg_rep_env.receiver,
+            receiver=neg_rep_env.provider,
+            is_rude=True,
         )
-        # Attempt to create another should raise IntegrityError
-        from django.db import IntegrityError
-        with self.assertRaises(IntegrityError):
-            NegativeRep.objects.create(
-                handshake=self.handshake,
-                giver=self.receiver,
-                receiver=self.provider,
-                is_rude=True
-            )
 
 
-class RankingAlgorithmTest(TestCase):
-    """Test hot score ranking algorithm"""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User'
-        )
-        self.service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-    
-    def test_calculate_hot_score_new_service(self):
-        """Test hot score for a brand new service"""
-        score = calculate_hot_score(self.service)
-        # New service with no reputation or comments should have score ~0
-        self.assertGreaterEqual(score, 0)
-    
-    def test_hot_score_increases_with_comments(self):
-        """Test that hot score increases with comments"""
-        # Seed positive reputation so Quality > 0; otherwise the
-        # Quality * Activity formula collapses to 0 regardless of comments.
-        for _ in range(5):
-            requester = User.objects.create_user(
-                email=f'rep-giver-{_}@example.com',
-                password='testpass123',
-                first_name='Giver',
-                last_name=str(_),
-            )
-            base_service = Service.objects.create(
-                user=self.user,
-                title=f'Quality seed {_}',
-                description='seed',
-                type='Offer',
-                duration=Decimal('1.00'),
-                location_type='Online',
-                schedule_type='One-Time',
-            )
-            hs = Handshake.objects.create(
-                service=base_service,
-                requester=requester,
-                status='completed',
-                provisioned_hours=Decimal('1.00'),
-            )
-            ReputationRep.objects.create(
-                handshake=hs,
-                giver=requester,
-                receiver=self.user,
-                is_helpful=True,
-            )
+# ── Hot score ────────────────────────────────────────────────────────────────
 
-        initial_score = calculate_hot_score(self.service)
-
-        # Add comments
-        for i in range(5):
-            Comment.objects.create(
-                service=self.service,
-                user=self.user,
-                body=f'Comment {i}'
-            )
-
-        new_score = calculate_hot_score(self.service)
-        self.assertGreater(new_score, initial_score)
-    
-    def test_batch_score_calculation(self):
-        """Test batch hot score calculation"""
-        # Create multiple services
-        services = [self.service]
-        for i in range(4):
-            s = Service.objects.create(
-                user=self.user,
-                title=f'Service {i}',
-                description='Test',
-                type='Offer',
-                duration=Decimal('1.00'),
-                location_type='Online',
-                schedule_type='One-Time'
-            )
-            services.append(s)
-        
-        scores = calculate_hot_scores_batch(services)
-        
-        self.assertEqual(len(scores), 5)
-        for service in services:
-            self.assertIn(service.id, scores)
+@pytest.mark.django_db
+def test_calculate_hot_score_new_service(comment_env):
+    score = calculate_hot_score(comment_env.service)
+    assert score >= 0
 
 
-class BadgeSystemTest(TestCase):
-    """Test extended badge system"""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
+@pytest.mark.django_db
+def test_hot_score_increases_with_comments(comment_env):
+    """Hot score increases with comments after seeded positive reputation."""
+    for i in range(5):
+        requester = User.objects.create_user(
+            email=f'rep-giver-{i}@example.com',
+            password='testpass123', first_name='Giver', last_name=str(i),
         )
-        self.other_user = User.objects.create_user(
-            email='other@example.com',
-            password='testpass123',
-            first_name='Other',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
+        base_service = Service.objects.create(
+            user=comment_env.user, title=f'Quality seed {i}', description='seed',
+            type='Offer', duration=Decimal('1.00'), location_type='Online',
+            schedule_type='One-Time',
         )
-    
-    def test_get_user_stats(self):
-        """Test that user stats are calculated correctly"""
-        stats = get_user_stats(self.user)
-        
-        self.assertIn('completed_services', stats)
-        self.assertIn('offer_count', stats)
-        self.assertIn('helpful_count', stats)
-        self.assertIn('kindness_count', stats)
-        self.assertIn('punctual_count', stats)
-        self.assertIn('comments_posted', stats)
-        self.assertIn('comments_on_services', stats)
-        self.assertIn('hours_given', stats)
-        self.assertIn('negative_rep_count', stats)
-    
-    def test_community_voice_badge(self):
-        """Test earning Community Voice badge for 10+ comments"""
-        service = Service.objects.create(
-            user=self.other_user,
-            title='Test Service',
-            description='Test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
+        hs = Handshake.objects.create(
+            service=base_service, requester=requester,
+            status='completed', provisioned_hours=Decimal('1.00'),
         )
-        
-        # Create 10 comments
-        for i in range(10):
-            Comment.objects.create(
-                service=service,
-                user=self.user,
-                body=f'Comment {i}'
-            )
-        
-        # Check badges
-        new_badges = check_and_assign_badges(self.user)
-        
-        self.assertIn('community-voice', new_badges)
-        self.assertTrue(
-            UserBadge.objects.filter(user=self.user, badge_id='community-voice').exists()
+        ReputationRep.objects.create(
+            handshake=hs, giver=requester, receiver=comment_env.user,
+            is_helpful=True,
         )
-    
-    def test_first_service_badge(self):
-        """Test earning First Service badge after first completed handshake"""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='Test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        
-        handshake = Handshake.objects.create(
-            service=service,
-            requester=self.other_user,
-            status='completed',
-            provisioned_hours=Decimal('1.00')
-        )
-        
-        new_badges = check_and_assign_badges(self.user)
-        
-        self.assertIn('first-service', new_badges)
-    
-    def test_badge_not_duplicated(self):
-        """Test that badges are not assigned twice"""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='Test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        
-        Handshake.objects.create(
-            service=service,
-            requester=self.other_user,
-            status='completed',
-            provisioned_hours=Decimal('1.00')
-        )
-        
-        # First check
-        new_badges1 = check_and_assign_badges(self.user)
-        # Second check
-        new_badges2 = check_and_assign_badges(self.user)
-        
-        self.assertIn('first-service', new_badges1)
-        self.assertNotIn('first-service', new_badges2)
-        
-        # Should only have one badge record
-        self.assertEqual(
-            UserBadge.objects.filter(user=self.user, badge_id='first-service').count(),
-            1
-        )
-    
-    def test_get_badge_progress(self):
-        """Test getting badge progress"""
-        progress = get_achievement_progress(self.user)
-        
-        self.assertIn('first-service', progress)
-        self.assertIn('community-voice', progress)
-        self.assertIn('time-giver-bronze', progress)
-        
-        # Check structure
-        first_service = progress['first-service']
-        self.assertIn('earned', first_service)
-        self.assertIn('current', first_service)
-        self.assertIn('threshold', first_service)
-        self.assertIn('progress_percent', first_service)
 
+    initial_score = calculate_hot_score(comment_env.service)
 
-class CommentAPITest(TestCase):
-    """Test Comment API endpoints"""
-    
-    def setUp(self):
-        self.client = APIClient()
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User'
-        )
-        self.other_user = User.objects.create_user(
-            email='other@example.com',
-            password='testpass123',
-            first_name='Other',
-            last_name='User'
-        )
-        self.service = Service.objects.create(
-            user=self.other_user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-    
-    def test_list_comments_unauthenticated(self):
-        """Test that unauthenticated users can view comments"""
+    for i in range(5):
         Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='Test comment'
-        )
-        
-        url = reverse('service-comments', kwargs={'service_id': self.service.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-    
-    def test_create_comment_authenticated(self):
-        """Test that authenticated users cannot create service comments (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        url = reverse('service-comments', kwargs={'service_id': self.service.id})
-        data = {'body': 'Great service!'}
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(Comment.objects.count(), 0)
-    
-    def test_create_comment_unauthenticated(self):
-        """Test that unauthenticated users cannot create comments"""
-        url = reverse('service-comments', kwargs={'service_id': self.service.id})
-        data = {'body': 'Test comment'}
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-    
-    def test_create_reply(self):
-        """Test that replies cannot be created via service comments API (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        parent = Comment.objects.create(
-            service=self.service,
-            user=self.other_user,
-            body='Original comment'
-        )
-        
-        url = reverse('service-comments', kwargs={'service_id': self.service.id})
-        data = {'body': 'Reply!', 'parent_id': str(parent.id)}
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        self.assertEqual(Comment.objects.count(), 1)
-    
-    def test_cannot_reply_to_reply(self):
-        """Test that service comments API rejects posting (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        parent = Comment.objects.create(
-            service=self.service,
-            user=self.other_user,
-            body='Original comment'
-        )
-        reply = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            parent=parent,
-            body='Reply'
-        )
-        
-        url = reverse('service-comments', kwargs={'service_id': self.service.id})
-        data = {'body': 'Reply to reply!', 'parent_id': str(reply.id)}
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-    
-    def test_edit_own_comment(self):
-        """Test that service comments API rejects edits (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='Original text'
-        )
-        
-        url = reverse('service-comment-detail', kwargs={
-            'service_id': self.service.id,
-            'pk': comment.id
-        })
-        data = {'body': 'Updated text'}
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        comment.refresh_from_db()
-        self.assertEqual(comment.body, 'Original text')
-    
-    def test_cannot_edit_others_comment(self):
-        """Test that service comments API rejects edits (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.other_user,
-            body='Other user comment'
-        )
-        
-        url = reverse('service-comment-detail', kwargs={
-            'service_id': self.service.id,
-            'pk': comment.id
-        })
-        data = {'body': 'Hacked!'}
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-    
-    def test_delete_own_comment(self):
-        """Test that service comments API rejects deletes (read-only endpoint)"""
-        self.client.force_authenticate(user=self.user)
-        
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.user,
-            body='To be deleted'
-        )
-        
-        url = reverse('service-comment-detail', kwargs={
-            'service_id': self.service.id,
-            'pk': comment.id
-        })
-        response = self.client.delete(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-        comment.refresh_from_db()
-        self.assertFalse(comment.is_deleted)
-    
-    def test_service_owner_can_delete_any_comment(self):
-        """Test that service comments API rejects deletes even for service owners (read-only endpoint)"""
-        self.client.force_authenticate(user=self.other_user)  # Service owner
-        
-        comment = Comment.objects.create(
-            service=self.service,
-            user=self.user,  # Different user
-            body='Comment on my service'
-        )
-        
-        url = reverse('service-comment-detail', kwargs={
-            'service_id': self.service.id,
-            'pk': comment.id
-        })
-        response = self.client.delete(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-        comment.refresh_from_db()
-        self.assertFalse(comment.is_deleted)
-
-
-class NegativeRepAPITest(TestCase):
-    """Test Negative Reputation API endpoints"""
-    
-    def setUp(self):
-        self.client = APIClient()
-        self.provider = User.objects.create_user(
-            email='provider@example.com',
-            password='testpass123',
-            first_name='Provider',
-            last_name='User',
-            timebank_balance=Decimal('10.00'),
-            karma_score=50
-        )
-        self.receiver = User.objects.create_user(
-            email='receiver@example.com',
-            password='testpass123',
-            first_name='Receiver',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.service = Service.objects.create(
-            user=self.provider,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        self.completed_handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.receiver,
-            status='completed',
-            provisioned_hours=Decimal('2.00')
-        )
-    
-    def test_submit_negative_rep(self):
-        """Test submitting negative reputation"""
-        self.client.force_authenticate(user=self.receiver)
-        
-        url = reverse('negative-reputation')
-        data = {
-            'handshake_id': str(self.completed_handshake.id),
-            'is_late': True,
-            'is_unhelpful': False,
-            'is_rude': False,
-            'comment': 'Was 30 minutes late'
-        }
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(NegativeRep.objects.count(), 1)
-    
-    def test_negative_rep_reduces_karma(self):
-        """Test that negative rep reduces karma"""
-        self.client.force_authenticate(user=self.receiver)
-        initial_karma = self.provider.karma_score
-        
-        url = reverse('negative-reputation')
-        data = {
-            'handshake_id': str(self.completed_handshake.id),
-            'is_late': True,
-            'is_unhelpful': True,
-            'is_rude': False
-        }
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        
-        self.provider.refresh_from_db()
-        # Each negative trait costs -2 karma
-        expected_karma = initial_karma - 4  # 2 traits × -2
-        self.assertEqual(self.provider.karma_score, expected_karma)
-    
-    def test_cannot_submit_without_negative_trait(self):
-        """Test that at least one negative trait must be selected"""
-        self.client.force_authenticate(user=self.receiver)
-        
-        url = reverse('negative-reputation')
-        data = {
-            'handshake_id': str(self.completed_handshake.id),
-            'is_late': False,
-            'is_unhelpful': False,
-            'is_rude': False
-        }
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    
-    def test_cannot_submit_for_non_completed_handshake(self):
-        """Test that negative rep can only be submitted for completed handshakes"""
-        pending_handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.receiver,
-            status='pending',
-            provisioned_hours=Decimal('2.00')
-        )
-        
-        self.client.force_authenticate(user=self.receiver)
-        
-        url = reverse('negative-reputation')
-        data = {
-            'handshake_id': str(pending_handshake.id),
-            'is_late': True
-        }
-        response = self.client.post(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-
-class ServiceHotScoreSortingTest(TestCase):
-    """Test service sorting by hot score"""
-    
-    def setUp(self):
-        self.client = APIClient()
-        # Use unique email to avoid conflicts with other tests
-        self.user = User.objects.create_user(
-            email='hotscore_test@example.com',
-            password='testpass123',
-            first_name='HotScore',
-            last_name='Tester'
-        )
-        
-        # Create services with different hot scores and unique prefix
-        self.service1 = Service.objects.create(
-            user=self.user,
-            title='[HS] Low Score Service',
-            description='Hot score test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        self.service2 = Service.objects.create(
-            user=self.user,
-            title='[HS] High Score Service',
-            description='Hot score test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
-        )
-        self.service3 = Service.objects.create(
-            user=self.user,
-            title='[HS] Medium Score Service',
-            description='Hot score test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time'
+            service=comment_env.service, user=comment_env.user, body=f'Comment {i}',
         )
 
-        # Service.save() calculates hot_score automatically for active services,
-        # so set deterministic test values directly in DB.
-        Service.objects.filter(pk=self.service1.pk).update(hot_score=0.5)
-        Service.objects.filter(pk=self.service2.pk).update(hot_score=10.0)
-        Service.objects.filter(pk=self.service3.pk).update(hot_score=5.0)
-    
-    def test_sort_by_hot_score(self):
-        """Test sorting services by hot score"""
-        # Filter to only our test services using search
-        url = reverse('service-list') + '?sort=hot&search=[HS]'
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        results = response.data.get('results', response.data)
-        # Filter to only our services (in case search isn't exact)
-        our_services = [s for s in results if s['title'].startswith('[HS]')]
-        titles = [s['title'] for s in our_services]
-        
-        # Should be ordered by hot_score descending
-        self.assertEqual(len(our_services), 3)
-        self.assertEqual(titles[0], '[HS] High Score Service')
-        self.assertEqual(titles[1], '[HS] Medium Score Service')
-        self.assertEqual(titles[2], '[HS] Low Score Service')
-    
-    def test_default_sort_by_latest(self):
-        """Test that default sorting is by created_at descending"""
-        # Filter to only our test services
-        url = reverse('service-list') + '?search=[HS]'
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        results = response.data.get('results', response.data)
-        # Filter to only our services
-        our_services = [s for s in results if s['title'].startswith('[HS]')]
-        
-        # Most recently created (service3) should be first
-        self.assertEqual(len(our_services), 3)
-        self.assertEqual(our_services[0]['title'], '[HS] Medium Score Service')
+    new_score = calculate_hot_score(comment_env.service)
+    assert new_score > initial_score
+
+
+@pytest.mark.django_db
+def test_batch_score_calculation(comment_env):
+    services = [comment_env.service]
+    for i in range(4):
+        s = Service.objects.create(
+            user=comment_env.user, title=f'Service {i}', description='Test',
+            type='Offer', duration=Decimal('1.00'), location_type='Online',
+            schedule_type='One-Time',
+        )
+        services.append(s)
+
+    scores = calculate_hot_scores_batch(services)
+
+    assert len(scores) == 5
+    for service in services:
+        assert service.id in scores
+
+
+# ── Extended badge system ────────────────────────────────────────────────────
+
+@pytest.fixture
+def badge_env(db):
+    user = User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    other_user = User.objects.create_user(
+        email='other@example.com', password='testpass123',
+        first_name='Other', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    return SimpleNamespace(user=user, other_user=other_user)
+
+
+@pytest.mark.django_db
+def test_get_user_stats(badge_env):
+    stats = get_user_stats(badge_env.user)
+
+    assert 'completed_services' in stats
+    assert 'offer_count' in stats
+    assert 'helpful_count' in stats
+    assert 'kindness_count' in stats
+    assert 'punctual_count' in stats
+    assert 'comments_posted' in stats
+    assert 'comments_on_services' in stats
+    assert 'hours_given' in stats
+    assert 'negative_rep_count' in stats
+
+
+@pytest.mark.django_db
+def test_community_voice_badge(badge_env):
+    """Earn Community Voice badge for 10+ comments."""
+    service = Service.objects.create(
+        user=badge_env.other_user, title='Test Service', description='Test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+
+    for i in range(10):
+        Comment.objects.create(service=service, user=badge_env.user, body=f'Comment {i}')
+
+    new_badges = check_and_assign_badges(badge_env.user)
+
+    assert 'community-voice' in new_badges
+    assert UserBadge.objects.filter(user=badge_env.user, badge_id='community-voice').exists()
+
+
+@pytest.mark.django_db
+def test_first_service_badge(badge_env):
+    service = Service.objects.create(
+        user=badge_env.user, title='Test Service', description='Test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+
+    Handshake.objects.create(
+        service=service, requester=badge_env.other_user,
+        status='completed', provisioned_hours=Decimal('1.00'),
+    )
+
+    new_badges = check_and_assign_badges(badge_env.user)
+    assert 'first-service' in new_badges
+
+
+@pytest.mark.django_db
+def test_badge_not_duplicated(badge_env):
+    service = Service.objects.create(
+        user=badge_env.user, title='Test Service', description='Test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    Handshake.objects.create(
+        service=service, requester=badge_env.other_user,
+        status='completed', provisioned_hours=Decimal('1.00'),
+    )
+
+    new_badges1 = check_and_assign_badges(badge_env.user)
+    new_badges2 = check_and_assign_badges(badge_env.user)
+
+    assert 'first-service' in new_badges1
+    assert 'first-service' not in new_badges2
+
+    assert UserBadge.objects.filter(user=badge_env.user, badge_id='first-service').count() == 1
+
+
+@pytest.mark.django_db
+def test_get_badge_progress(badge_env):
+    progress = get_achievement_progress(badge_env.user)
+
+    assert 'first-service' in progress
+    assert 'community-voice' in progress
+    assert 'time-giver-bronze' in progress
+
+    first_service = progress['first-service']
+    assert 'earned' in first_service
+    assert 'current' in first_service
+    assert 'threshold' in first_service
+    assert 'progress_percent' in first_service
+
+
+# ── Comment API endpoints ────────────────────────────────────────────────────
+
+@pytest.fixture
+def comment_api_env(db):
+    user = User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+    )
+    other_user = User.objects.create_user(
+        email='other@example.com', password='testpass123',
+        first_name='Other', last_name='User',
+    )
+    service = Service.objects.create(
+        user=other_user, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    return SimpleNamespace(user=user, other_user=other_user, service=service, client=APIClient())
+
+
+@pytest.mark.django_db
+def test_list_comments_unauthenticated(comment_api_env):
+    Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.user, body='Test comment',
+    )
+
+    url = reverse('service-comments', kwargs={'service_id': comment_api_env.service.id})
+    response = comment_api_env.client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_create_comment_authenticated(comment_api_env):
+    """Service-comments endpoint is read-only."""
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    url = reverse('service-comments', kwargs={'service_id': comment_api_env.service.id})
+    response = comment_api_env.client.post(url, {'body': 'Great service!'}, format='json')
+
+    assert response.status_code == 405
+    assert Comment.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_comment_unauthenticated(comment_api_env):
+    url = reverse('service-comments', kwargs={'service_id': comment_api_env.service.id})
+    response = comment_api_env.client.post(url, {'body': 'Test comment'}, format='json')
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_create_reply(comment_api_env):
+    """Replies cannot be created via service comments API (read-only endpoint)."""
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    parent = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.other_user, body='Original comment',
+    )
+
+    url = reverse('service-comments', kwargs={'service_id': comment_api_env.service.id})
+    response = comment_api_env.client.post(
+        url, {'body': 'Reply!', 'parent_id': str(parent.id)}, format='json',
+    )
+
+    assert response.status_code == 405
+    assert Comment.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_cannot_reply_to_reply(comment_api_env):
+    """Service comments API rejects posting (read-only endpoint)."""
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    parent = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.other_user, body='Original comment',
+    )
+    reply = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.user, parent=parent, body='Reply',
+    )
+
+    url = reverse('service-comments', kwargs={'service_id': comment_api_env.service.id})
+    response = comment_api_env.client.post(
+        url, {'body': 'Reply to reply!', 'parent_id': str(reply.id)}, format='json',
+    )
+
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_edit_own_comment(comment_api_env):
+    """Service comments API rejects edits (read-only endpoint)."""
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    comment = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.user, body='Original text',
+    )
+
+    url = reverse(
+        'service-comment-detail',
+        kwargs={'service_id': comment_api_env.service.id, 'pk': comment.id},
+    )
+    response = comment_api_env.client.patch(url, {'body': 'Updated text'}, format='json')
+
+    assert response.status_code == 405
+    comment.refresh_from_db()
+    assert comment.body == 'Original text'
+
+
+@pytest.mark.django_db
+def test_cannot_edit_others_comment(comment_api_env):
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    comment = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.other_user, body='Other user comment',
+    )
+
+    url = reverse(
+        'service-comment-detail',
+        kwargs={'service_id': comment_api_env.service.id, 'pk': comment.id},
+    )
+    response = comment_api_env.client.patch(url, {'body': 'Hacked!'}, format='json')
+
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_delete_own_comment(comment_api_env):
+    comment_api_env.client.force_authenticate(user=comment_api_env.user)
+
+    comment = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.user, body='To be deleted',
+    )
+
+    url = reverse(
+        'service-comment-detail',
+        kwargs={'service_id': comment_api_env.service.id, 'pk': comment.id},
+    )
+    response = comment_api_env.client.delete(url)
+
+    assert response.status_code == 405
+    comment.refresh_from_db()
+    assert not comment.is_deleted
+
+
+@pytest.mark.django_db
+def test_service_owner_can_delete_any_comment(comment_api_env):
+    """Service comments API rejects deletes even for service owners."""
+    comment_api_env.client.force_authenticate(user=comment_api_env.other_user)
+
+    comment = Comment.objects.create(
+        service=comment_api_env.service, user=comment_api_env.user,
+        body='Comment on my service',
+    )
+
+    url = reverse(
+        'service-comment-detail',
+        kwargs={'service_id': comment_api_env.service.id, 'pk': comment.id},
+    )
+    response = comment_api_env.client.delete(url)
+
+    assert response.status_code == 405
+    comment.refresh_from_db()
+    assert not comment.is_deleted
+
+
+# ── Negative Reputation API ──────────────────────────────────────────────────
+
+@pytest.fixture
+def negative_api_env(db):
+    provider = User.objects.create_user(
+        email='provider@example.com', password='testpass123',
+        first_name='Provider', last_name='User',
+        timebank_balance=Decimal('10.00'), karma_score=50,
+    )
+    receiver = User.objects.create_user(
+        email='receiver@example.com', password='testpass123',
+        first_name='Receiver', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    service = Service.objects.create(
+        user=provider, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    completed_handshake = Handshake.objects.create(
+        service=service, requester=receiver,
+        status='completed', provisioned_hours=Decimal('2.00'),
+    )
+    return SimpleNamespace(
+        provider=provider, receiver=receiver, service=service,
+        completed_handshake=completed_handshake, client=APIClient(),
+    )
+
+
+@pytest.mark.django_db
+def test_submit_negative_rep(negative_api_env):
+    negative_api_env.client.force_authenticate(user=negative_api_env.receiver)
+
+    url = reverse('negative-reputation')
+    response = negative_api_env.client.post(url, {
+        'handshake_id': str(negative_api_env.completed_handshake.id),
+        'is_late': True, 'is_unhelpful': False, 'is_rude': False,
+        'comment': 'Was 30 minutes late',
+    }, format='json')
+
+    assert response.status_code == 201
+    assert NegativeRep.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_negative_rep_reduces_karma(negative_api_env):
+    negative_api_env.client.force_authenticate(user=negative_api_env.receiver)
+    initial_karma = negative_api_env.provider.karma_score
+
+    url = reverse('negative-reputation')
+    response = negative_api_env.client.post(url, {
+        'handshake_id': str(negative_api_env.completed_handshake.id),
+        'is_late': True, 'is_unhelpful': True, 'is_rude': False,
+    }, format='json')
+
+    assert response.status_code == 201
+
+    negative_api_env.provider.refresh_from_db()
+    expected_karma = initial_karma - 4
+    assert negative_api_env.provider.karma_score == expected_karma
+
+
+@pytest.mark.django_db
+def test_cannot_submit_without_negative_trait(negative_api_env):
+    negative_api_env.client.force_authenticate(user=negative_api_env.receiver)
+
+    url = reverse('negative-reputation')
+    response = negative_api_env.client.post(url, {
+        'handshake_id': str(negative_api_env.completed_handshake.id),
+        'is_late': False, 'is_unhelpful': False, 'is_rude': False,
+    }, format='json')
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_cannot_submit_for_non_completed_handshake(negative_api_env):
+    pending_handshake = Handshake.objects.create(
+        service=negative_api_env.service, requester=negative_api_env.receiver,
+        status='pending', provisioned_hours=Decimal('2.00'),
+    )
+
+    negative_api_env.client.force_authenticate(user=negative_api_env.receiver)
+
+    url = reverse('negative-reputation')
+    response = negative_api_env.client.post(url, {
+        'handshake_id': str(pending_handshake.id), 'is_late': True,
+    }, format='json')
+
+    assert response.status_code == 404
+
+
+# ── Service hot-score sorting ────────────────────────────────────────────────
+
+@pytest.fixture
+def hot_sort_env(db):
+    user = User.objects.create_user(
+        email='hotscore_test@example.com', password='testpass123',
+        first_name='HotScore', last_name='Tester',
+    )
+
+    service1 = Service.objects.create(
+        user=user, title='[HS] Low Score Service', description='Hot score test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    service2 = Service.objects.create(
+        user=user, title='[HS] High Score Service', description='Hot score test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+    service3 = Service.objects.create(
+        user=user, title='[HS] Medium Score Service', description='Hot score test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time',
+    )
+
+    Service.objects.filter(pk=service1.pk).update(hot_score=0.5)
+    Service.objects.filter(pk=service2.pk).update(hot_score=10.0)
+    Service.objects.filter(pk=service3.pk).update(hot_score=5.0)
+
+    return SimpleNamespace(
+        user=user, service1=service1, service2=service2, service3=service3,
+        client=APIClient(),
+    )
+
+
+@pytest.mark.django_db
+def test_sort_by_hot_score(hot_sort_env):
+    url = reverse('service-list') + '?sort=hot&search=[HS]'
+    response = hot_sort_env.client.get(url)
+
+    assert response.status_code == 200
+
+    results = response.data.get('results', response.data)
+    our_services = [s for s in results if s['title'].startswith('[HS]')]
+    titles = [s['title'] for s in our_services]
+
+    assert len(our_services) == 3
+    assert titles[0] == '[HS] High Score Service'
+    assert titles[1] == '[HS] Medium Score Service'
+    assert titles[2] == '[HS] Low Score Service'
+
+
+@pytest.mark.django_db
+def test_default_sort_by_latest(hot_sort_env):
+    url = reverse('service-list') + '?search=[HS]'
+    response = hot_sort_env.client.get(url)
+
+    assert response.status_code == 200
+
+    results = response.data.get('results', response.data)
+    our_services = [s for s in results if s['title'].startswith('[HS]')]
+
+    assert len(our_services) == 3
+    assert our_services[0]['title'] == '[HS] Medium Score Service'

--- a/backend/api/tests/unit/test_profile_media.py
+++ b/backend/api/tests/unit/test_profile_media.py
@@ -6,379 +6,292 @@ Covers:
 - GET /api/users/{id}/history/ endpoint
 - Privacy toggle behavior
 """
-
+import uuid
 from decimal import Decimal
-from django.test import TestCase
+from types import SimpleNamespace
+
+import pytest
 from django.urls import reverse
-from rest_framework.test import APITestCase
-from rest_framework import status
+from rest_framework.test import APIClient
 
-from api.models import User, Service, Handshake
-
-
-class UserProfileMediaFieldsTestCase(TestCase):
-    """Test cases for User model profile media fields."""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('5.00')
-        )
-    
-    def test_video_intro_url_default_null(self):
-        """video_intro_url should be null by default."""
-        self.assertIsNone(self.user.video_intro_url)
-    
-    def test_video_intro_url_can_be_set(self):
-        """video_intro_url can be set to a YouTube URL."""
-        self.user.video_intro_url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-        self.user.save()
-        self.user.refresh_from_db()
-        self.assertEqual(
-            self.user.video_intro_url, 
-            'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-        )
-    
-    def test_portfolio_images_default_empty_list(self):
-        """portfolio_images should default to an empty list."""
-        self.assertEqual(self.user.portfolio_images, [])
-    
-    def test_portfolio_images_can_store_urls(self):
-        """portfolio_images can store an array of URLs."""
-        images = [
-            'https://example.com/image1.jpg',
-            'https://example.com/image2.jpg',
-            'https://example.com/image3.jpg',
-        ]
-        self.user.portfolio_images = images
-        self.user.save()
-        self.user.refresh_from_db()
-        self.assertEqual(self.user.portfolio_images, images)
-    
-    def test_show_history_default_true(self):
-        """show_history should default to True."""
-        self.assertTrue(self.user.show_history)
-    
-    def test_show_history_can_be_toggled(self):
-        """show_history can be set to False."""
-        self.user.show_history = False
-        self.user.save()
-        self.user.refresh_from_db()
-        self.assertFalse(self.user.show_history)
+from api.models import Handshake, Service, User
 
 
-class UserHistoryEndpointTestCase(APITestCase):
-    """Test cases for GET /api/users/{id}/history/ endpoint."""
-    
-    def setUp(self):
-        # Create users
-        self.user1 = User.objects.create_user(
-            email='user1@example.com',
-            password='testpass123',
-            first_name='User',
-            last_name='One',
-            timebank_balance=Decimal('10.00'),
-            show_history=True
-        )
-        self.user2 = User.objects.create_user(
-            email='user2@example.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Two',
-            timebank_balance=Decimal('10.00'),
-            show_history=True
-        )
-        self.private_user = User.objects.create_user(
-            email='private@example.com',
-            password='testpass123',
-            first_name='Private',
-            last_name='User',
-            timebank_balance=Decimal('10.00'),
-            show_history=False
-        )
-        
-        # Create a service by user1 (offer)
-        self.service = Service.objects.create(
-            user=self.user1,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            status='Active',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        # Create a completed handshake (user2 requested from user1's offer)
-        self.handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.user2,
-            status='completed',
-            provisioned_hours=Decimal('2.00'),
-            provider_confirmed_complete=True,
-            receiver_confirmed_complete=True
-        )
-    
-    def test_history_endpoint_returns_completed_handshakes(self):
-        """History endpoint returns completed handshakes for public users."""
-        url = reverse('user-history', kwargs={'id': self.user1.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['service_title'], 'Test Service')
-    
-    def test_history_endpoint_includes_correct_fields(self):
-        """History response includes all required fields."""
-        url = reverse('user-history', kwargs={'id': self.user1.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        item = response.data[0]
-        
-        self.assertIn('service_title', item)
-        self.assertIn('service_type', item)
-        self.assertIn('duration', item)
-        self.assertIn('partner_name', item)
-        self.assertIn('partner_id', item)
-        self.assertIn('completed_date', item)
-        self.assertIn('was_provider', item)
-    
-    def test_history_identifies_provider_correctly(self):
-        """History correctly identifies when user was provider vs receiver."""
-        # User1 was the provider (service owner for Offer)
-        url = reverse('user-history', kwargs={'id': self.user1.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data[0]['was_provider'])
-        
-        # User2 was the receiver (requester for Offer)
-        url = reverse('user-history', kwargs={'id': self.user2.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data[0]['was_provider'])
-    
-    def test_private_history_returns_empty_for_others(self):
-        """Private user's history returns empty list for other users."""
-        # Create a completed handshake for private user
-        service = Service.objects.create(
-            user=self.private_user,
-            title='Private Service',
-            description='A private service',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            status='Active',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        Handshake.objects.create(
-            service=service,
-            requester=self.user1,
-            status='completed',
-            provisioned_hours=Decimal('1.00'),
-            provider_confirmed_complete=True,
-            receiver_confirmed_complete=True
-        )
-        
-        # Anonymous request should get empty list
-        url = reverse('user-history', kwargs={'id': self.private_user.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])
-    
-    def test_owner_can_see_own_private_history(self):
-        """User can see their own history even if private."""
-        # Create a completed handshake for private user
-        service = Service.objects.create(
-            user=self.private_user,
-            title='Private Service',
-            description='A private service',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            status='Active',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        Handshake.objects.create(
-            service=service,
-            requester=self.user1,
-            status='completed',
-            provisioned_hours=Decimal('1.00'),
-            provider_confirmed_complete=True,
-            receiver_confirmed_complete=True
-        )
-        
-        # Authenticated request as owner should see history
-        self.client.force_authenticate(user=self.private_user)
-        url = reverse('user-history', kwargs={'id': self.private_user.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-    
-    def test_nonexistent_user_returns_404(self):
-        """Request for nonexistent user returns 404."""
-        import uuid
-        fake_id = uuid.uuid4()
-        url = reverse('user-history', kwargs={'id': fake_id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-    
-    def test_history_only_shows_completed_handshakes(self):
-        """History only includes completed handshakes, not pending/cancelled."""
-        # Create a pending handshake
-        Handshake.objects.create(
-            service=self.service,
-            requester=self.user2,
-            status='pending',
-            provisioned_hours=Decimal('1.00')
-        )
-        
-        url = reverse('user-history', kwargs={'id': self.user1.id})
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Should only show the completed one, not the pending
-        self.assertEqual(len(response.data), 1)
+@pytest.fixture
+def basic_user(db):
+    return User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('5.00'),
+    )
 
 
-class PortfolioImagesValidationTestCase(APITestCase):
-    """Test cases for portfolio images validation."""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('5.00')
-        )
-        self.client.force_authenticate(user=self.user)
-    
-    def test_portfolio_images_max_5(self):
-        """Portfolio images are limited to 5 items."""
-        url = reverse('user-profile')
-        data = {
-            'portfolio_images': [
-                'https://example.com/1.jpg',
-                'https://example.com/2.jpg',
-                'https://example.com/3.jpg',
-                'https://example.com/4.jpg',
-                'https://example.com/5.jpg',
-                'https://example.com/6.jpg',  # This exceeds the limit
-            ]
-        }
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    
-    def test_portfolio_images_accepts_5_or_less(self):
-        """Portfolio images accepts 5 or fewer items."""
-        url = reverse('user-profile')
-        data = {
-            'portfolio_images': [
-                'https://example.com/1.jpg',
-                'https://example.com/2.jpg',
-                'https://example.com/3.jpg',
-            ]
-        }
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['portfolio_images']), 3)
+@pytest.mark.django_db
+def test_video_intro_url_default_null(basic_user):
+    assert basic_user.video_intro_url is None
 
 
-class VideoIntroValidationTestCase(APITestCase):
-    """Test cases for video intro URL validation."""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('5.00')
-        )
-        self.client.force_authenticate(user=self.user)
-    
-    def test_youtube_url_accepted(self):
-        """YouTube URLs are accepted."""
-        url = reverse('user-profile')
-        data = {
-            'video_intro_url': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-        }
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['video_intro_url'], data['video_intro_url'])
-    
-    def test_vimeo_url_accepted(self):
-        """Vimeo URLs are accepted."""
-        url = reverse('user-profile')
-        data = {
-            'video_intro_url': 'https://vimeo.com/123456789'
-        }
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['video_intro_url'], data['video_intro_url'])
-    
-    def test_https_url_accepted(self):
-        """Regular HTTPS URLs are accepted."""
-        url = reverse('user-profile')
-        data = {
-            'video_intro_url': 'https://example.com/video.mp4'
-        }
-        response = self.client.patch(url, data, format='json')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+@pytest.mark.django_db
+def test_video_intro_url_can_be_set(basic_user):
+    basic_user.video_intro_url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    basic_user.save()
+    basic_user.refresh_from_db()
+    assert basic_user.video_intro_url == 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 
 
-class PrivacyToggleTestCase(APITestCase):
-    """Test cases for privacy toggle persistence and behavior."""
-    
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('5.00')
-        )
-        self.client.force_authenticate(user=self.user)
-    
-    def test_show_history_can_be_updated(self):
-        """show_history can be updated via API."""
-        url = reverse('user-profile')
-        
-        # Turn off
-        response = self.client.patch(url, {'show_history': False}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data['show_history'])
-        
-        # Verify in database
-        self.user.refresh_from_db()
-        self.assertFalse(self.user.show_history)
-        
-        # Turn back on
-        response = self.client.patch(url, {'show_history': True}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.data['show_history'])
-    
-    def test_show_history_included_in_profile_response(self):
-        """show_history is included in profile response."""
-        url = reverse('user-profile')
-        response = self.client.get(url)
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('show_history', response.data)
+@pytest.mark.django_db
+def test_portfolio_images_default_empty_list(basic_user):
+    assert basic_user.portfolio_images == []
+
+
+@pytest.mark.django_db
+def test_portfolio_images_can_store_urls(basic_user):
+    images = [
+        'https://example.com/image1.jpg',
+        'https://example.com/image2.jpg',
+        'https://example.com/image3.jpg',
+    ]
+    basic_user.portfolio_images = images
+    basic_user.save()
+    basic_user.refresh_from_db()
+    assert basic_user.portfolio_images == images
+
+
+@pytest.mark.django_db
+def test_show_history_default_true(basic_user):
+    assert basic_user.show_history
+
+
+@pytest.mark.django_db
+def test_show_history_can_be_toggled(basic_user):
+    basic_user.show_history = False
+    basic_user.save()
+    basic_user.refresh_from_db()
+    assert not basic_user.show_history
+
+
+@pytest.fixture
+def history_env(db):
+    user1 = User.objects.create_user(
+        email='user1@example.com', password='testpass123',
+        first_name='User', last_name='One',
+        timebank_balance=Decimal('10.00'), show_history=True,
+    )
+    user2 = User.objects.create_user(
+        email='user2@example.com', password='testpass123',
+        first_name='User', last_name='Two',
+        timebank_balance=Decimal('10.00'), show_history=True,
+    )
+    private_user = User.objects.create_user(
+        email='private@example.com', password='testpass123',
+        first_name='Private', last_name='User',
+        timebank_balance=Decimal('10.00'), show_history=False,
+    )
+    service = Service.objects.create(
+        user=user1, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        status='Active', max_participants=1, schedule_type='One-Time',
+    )
+    handshake = Handshake.objects.create(
+        service=service, requester=user2,
+        status='completed', provisioned_hours=Decimal('2.00'),
+        provider_confirmed_complete=True, receiver_confirmed_complete=True,
+    )
+    return SimpleNamespace(
+        user1=user1, user2=user2, private_user=private_user,
+        service=service, handshake=handshake, client=APIClient(),
+    )
+
+
+@pytest.mark.django_db
+def test_history_endpoint_returns_completed_handshakes(history_env):
+    url = reverse('user-history', kwargs={'id': history_env.user1.id})
+    response = history_env.client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]['service_title'] == 'Test Service'
+
+
+@pytest.mark.django_db
+def test_history_endpoint_includes_correct_fields(history_env):
+    url = reverse('user-history', kwargs={'id': history_env.user1.id})
+    response = history_env.client.get(url)
+
+    assert response.status_code == 200
+    item = response.data[0]
+    assert 'service_title' in item
+    assert 'service_type' in item
+    assert 'duration' in item
+    assert 'partner_name' in item
+    assert 'partner_id' in item
+    assert 'completed_date' in item
+    assert 'was_provider' in item
+
+
+@pytest.mark.django_db
+def test_history_identifies_provider_correctly(history_env):
+    url = reverse('user-history', kwargs={'id': history_env.user1.id})
+    response = history_env.client.get(url)
+    assert response.status_code == 200
+    assert response.data[0]['was_provider']
+
+    url = reverse('user-history', kwargs={'id': history_env.user2.id})
+    response = history_env.client.get(url)
+    assert response.status_code == 200
+    assert not response.data[0]['was_provider']
+
+
+@pytest.mark.django_db
+def test_private_history_returns_empty_for_others(history_env):
+    service = Service.objects.create(
+        user=history_env.private_user,
+        title='Private Service', description='A private service',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        status='Active', max_participants=1, schedule_type='One-Time',
+    )
+    Handshake.objects.create(
+        service=service, requester=history_env.user1,
+        status='completed', provisioned_hours=Decimal('1.00'),
+        provider_confirmed_complete=True, receiver_confirmed_complete=True,
+    )
+
+    url = reverse('user-history', kwargs={'id': history_env.private_user.id})
+    response = history_env.client.get(url)
+
+    assert response.status_code == 200
+    assert response.data == []
+
+
+@pytest.mark.django_db
+def test_owner_can_see_own_private_history(history_env):
+    service = Service.objects.create(
+        user=history_env.private_user,
+        title='Private Service', description='A private service',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        status='Active', max_participants=1, schedule_type='One-Time',
+    )
+    Handshake.objects.create(
+        service=service, requester=history_env.user1,
+        status='completed', provisioned_hours=Decimal('1.00'),
+        provider_confirmed_complete=True, receiver_confirmed_complete=True,
+    )
+
+    history_env.client.force_authenticate(user=history_env.private_user)
+    url = reverse('user-history', kwargs={'id': history_env.private_user.id})
+    response = history_env.client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+def test_nonexistent_user_returns_404(history_env):
+    fake_id = uuid.uuid4()
+    url = reverse('user-history', kwargs={'id': fake_id})
+    response = history_env.client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_history_only_shows_completed_handshakes(history_env):
+    Handshake.objects.create(
+        service=history_env.service, requester=history_env.user2,
+        status='pending', provisioned_hours=Decimal('1.00'),
+    )
+    url = reverse('user-history', kwargs={'id': history_env.user1.id})
+    response = history_env.client.get(url)
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+
+
+@pytest.fixture
+def authed_client(db):
+    user = User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('5.00'),
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return SimpleNamespace(user=user, client=client)
+
+
+@pytest.mark.django_db
+def test_portfolio_images_max_5(authed_client):
+    url = reverse('user-profile')
+    response = authed_client.client.patch(url, {
+        'portfolio_images': [
+            'https://example.com/1.jpg',
+            'https://example.com/2.jpg',
+            'https://example.com/3.jpg',
+            'https://example.com/4.jpg',
+            'https://example.com/5.jpg',
+            'https://example.com/6.jpg',
+        ],
+    }, format='json')
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_portfolio_images_accepts_5_or_less(authed_client):
+    url = reverse('user-profile')
+    response = authed_client.client.patch(url, {
+        'portfolio_images': [
+            'https://example.com/1.jpg',
+            'https://example.com/2.jpg',
+            'https://example.com/3.jpg',
+        ],
+    }, format='json')
+    assert response.status_code == 200
+    assert len(response.data['portfolio_images']) == 3
+
+
+@pytest.mark.django_db
+def test_youtube_url_accepted(authed_client):
+    url = reverse('user-profile')
+    data = {'video_intro_url': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
+    response = authed_client.client.patch(url, data, format='json')
+    assert response.status_code == 200
+    assert response.data['video_intro_url'] == data['video_intro_url']
+
+
+@pytest.mark.django_db
+def test_vimeo_url_accepted(authed_client):
+    url = reverse('user-profile')
+    data = {'video_intro_url': 'https://vimeo.com/123456789'}
+    response = authed_client.client.patch(url, data, format='json')
+    assert response.status_code == 200
+    assert response.data['video_intro_url'] == data['video_intro_url']
+
+
+@pytest.mark.django_db
+def test_https_url_accepted(authed_client):
+    url = reverse('user-profile')
+    response = authed_client.client.patch(url, {'video_intro_url': 'https://example.com/video.mp4'}, format='json')
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_show_history_can_be_updated(authed_client):
+    url = reverse('user-profile')
+
+    response = authed_client.client.patch(url, {'show_history': False}, format='json')
+    assert response.status_code == 200
+    assert not response.data['show_history']
+
+    authed_client.user.refresh_from_db()
+    assert not authed_client.user.show_history
+
+    response = authed_client.client.patch(url, {'show_history': True}, format='json')
+    assert response.status_code == 200
+    assert response.data['show_history']
+
+
+@pytest.mark.django_db
+def test_show_history_included_in_profile_response(authed_client):
+    url = reverse('user-profile')
+    response = authed_client.client.get(url)
+    assert response.status_code == 200
+    assert 'show_history' in response.data

--- a/backend/api/tests/unit/test_property_tests.py
+++ b/backend/api/tests/unit/test_property_tests.py
@@ -1,416 +1,303 @@
 """Property-based tests for critical business logic."""
-from decimal import Decimal
-from hypothesis.extra.django import TestCase as HypothesisTestCase
-from django.contrib.auth import get_user_model
-from hypothesis import given, strategies as st, assume, settings, HealthCheck
-from hypothesis.stateful import RuleBasedStateMachine, rule, invariant, precondition
 import uuid
+from decimal import Decimal
 
 import pytest
+from django.contrib.auth import get_user_model
+from hypothesis import HealthCheck, given, settings, strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
-from api.models import Service, Handshake, TransactionHistory, UserBadge
+from api.models import Handshake, Service, TransactionHistory
 from api.ranking import calculate_hot_score
 from api.services import HandshakeService
-from api.utils import provision_timebank, complete_timebank_transfer, get_provider_and_receiver
-from api.tests.helpers.factories import (
-    ServiceFactory, UserFactory, CommentFactory, HandshakeFactory,
-)
+from api.tests.helpers.factories import CommentFactory, ServiceFactory
+from api.utils import provision_timebank
 
 User = get_user_model()
 
 
-class PropertyTestTimeBankBalanceConsistency(HypothesisTestCase):
-    """Test TimeBank balance consistency property."""
-    
-    @settings(max_examples=50, deadline=None)
-    @given(
-        initial_balance=st.decimals(min_value=Decimal('3.00'), max_value=Decimal('100.00'), places=2),
-        transaction_amounts=st.lists(
-            st.decimals(min_value=Decimal('-10.00'), max_value=Decimal('50.00'), places=2),
-            min_size=1,
-            max_size=10
-        )
+@pytest.mark.django_db
+@settings(max_examples=50, deadline=None,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    initial_balance=st.decimals(min_value=Decimal('3.00'), max_value=Decimal('100.00'), places=2),
+    transaction_amounts=st.lists(
+        st.decimals(min_value=Decimal('-10.00'), max_value=Decimal('50.00'), places=2),
+        min_size=1, max_size=10,
+    ),
+)
+def test_balance_consistency_property(initial_balance, transaction_amounts):
+    """Balance must match transaction history sum."""
+    user = User.objects.create_user(
+        email=f'test_{uuid.uuid4().hex[:8]}@test.com',
+        password='testpass123', first_name='Test', last_name='User',
+        timebank_balance=initial_balance,
     )
-    def test_balance_consistency_property(self, initial_balance, transaction_amounts):
-        """Test that balance matches transaction history sum."""
-        # Create user with initial balance
+
+    current_balance = initial_balance
+    for amount in transaction_amounts:
+        if current_balance + amount < Decimal('-10.00'):
+            continue
+        TransactionHistory.objects.create(
+            user=user, transaction_type='transfer', amount=amount,
+            balance_after=current_balance + amount,
+            description=f'Test transaction: {amount}',
+        )
+        current_balance += amount
+        user.timebank_balance = current_balance
+        user.save(update_fields=['timebank_balance'])
+
+    user.refresh_from_db()
+
+    history_sum = sum(
+        TransactionHistory.objects.filter(user=user).values_list('amount', flat=True)
+    )
+
+    expected_balance = initial_balance + history_sum
+    assert float(user.timebank_balance) == float(expected_balance)
+
+
+@pytest.fixture
+def handshake_env(db):
+    user1 = User.objects.create_user(
+        email='user1@test.com', password='testpass123',
+        first_name='User', last_name='One',
+        timebank_balance=Decimal('10.00'),
+    )
+    user2 = User.objects.create_user(
+        email='user2@test.com', password='testpass123',
+        first_name='User', last_name='Two',
+        timebank_balance=Decimal('10.00'),
+    )
+    service = Service.objects.create(
+        user=user1, title='Test Service', description='Test description for property testing',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time', max_participants=1,
+    )
+    return user1, user2, service
+
+
+@pytest.mark.django_db
+@settings(max_examples=30,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(status=st.sampled_from(['pending', 'accepted', 'completed', 'cancelled', 'denied']))
+def test_handshake_state_transitions(status, handshake_env):
+    """Test handshake state transitions."""
+    _, user2, service = handshake_env
+    handshake = Handshake.objects.create(
+        service=service, requester=user2,
+        status='pending', provisioned_hours=Decimal('2.00'),
+    )
+    handshake.status = status
+    handshake.save()
+
+    valid_statuses = [choice[0] for choice in Handshake.STATUS_CHOICES]
+    assert handshake.status in valid_statuses
+
+
+@pytest.fixture
+def participation_user(db):
+    return User.objects.create_user(
+        email='user1@test.com', password='testpass123',
+        first_name='User', last_name='One',
+        timebank_balance=Decimal('100.00'),
+    )
+
+
+@pytest.mark.django_db
+@settings(max_examples=20, deadline=None,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    max_participants=st.integers(min_value=1, max_value=10),
+    num_requests=st.integers(min_value=1, max_value=15),
+)
+def test_participation_limit_property(max_participants, num_requests, participation_user):
+    """Capacity-consuming handshakes never exceed max_participants."""
+    service = Service.objects.create(
+        user=participation_user, title='Test Service', description='Test description',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        schedule_type='One-Time', max_participants=max_participants,
+    )
+
+    users = []
+    for i in range(num_requests):
         user = User.objects.create_user(
-            email=f'test_{uuid.uuid4().hex[:8]}@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=initial_balance
+            email=f'requester{i}_{uuid.uuid4().hex[:6]}@test.com',
+            password='testpass123', first_name=f'User{i}', last_name='Test',
+            timebank_balance=Decimal('10.00'),
         )
-        
-        # Simulate transactions
-        current_balance = initial_balance
-        for amount in transaction_amounts:
-            # Ensure balance doesn't go below -10.00
-            if current_balance + amount < Decimal('-10.00'):
-                continue
-            
-            TransactionHistory.objects.create(
-                user=user,
-                transaction_type='transfer',
-                amount=amount,
-                balance_after=current_balance + amount,
-                description=f'Test transaction: {amount}'
-            )
-            current_balance += amount
-            user.timebank_balance = current_balance
-            user.save(update_fields=['timebank_balance'])
-        
-        # Refresh from DB
-        user.refresh_from_db()
-        
-        # Calculate sum from transaction history
-        history_sum = sum(
-            TransactionHistory.objects.filter(user=user)
-            .values_list('amount', flat=True)
-        )
-        
-        # Verify balance matches transaction history
-        expected_balance = initial_balance + history_sum
-        self.assertEqual(
-            float(user.timebank_balance),
-            float(expected_balance),
-            msg=f"Balance mismatch: current={user.timebank_balance}, expected={expected_balance}"
-        )
+        users.append(user)
+
+    for user in users:
+        is_valid, _ = HandshakeService.can_express_interest(service, user)
+        if is_valid:
+            try:
+                HandshakeService.express_interest(service, user)
+            except Exception:
+                pass
+
+    capacity_statuses = ['accepted', 'completed', 'reported', 'paused']
+    capacity_used = Handshake.objects.filter(
+        service=service, status__in=capacity_statuses,
+    ).count()
+
+    assert capacity_used <= max_participants
 
 
-class PropertyTestHandshakeStateIntegrity(HypothesisTestCase):
-    """Test handshake state integrity property."""
-    
-    def setUp(self):
-        self.user1 = User.objects.create_user(
-            email='user1@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='One',
-            timebank_balance=Decimal('10.00')
-        )
-        self.user2 = User.objects.create_user(
-            email='user2@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Two',
-            timebank_balance=Decimal('10.00')
-        )
-        self.service = Service.objects.create(
-            user=self.user1,
-            title='Test Service',
-            description='Test description for property testing',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time',
-            max_participants=1
-        )
-    
-    @settings(max_examples=30)
-    @given(
-        status=st.sampled_from(['pending', 'accepted', 'completed', 'cancelled', 'denied'])
+@pytest.fixture
+def provision_env(db):
+    provider = User.objects.create_user(
+        email='provider@test.com', password='testpass123',
+        first_name='Provider', last_name='User',
+        timebank_balance=Decimal('10.00'),
     )
-    def test_handshake_state_transitions(self, status):
-        """Test handshake state transitions."""
-        handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.user2,
-            status='pending',
-            provisioned_hours=Decimal('2.00')
-        )
-        
-        # Transition to new status
-        handshake.status = status
-        handshake.save()
-        
-        valid_statuses = [choice[0] for choice in Handshake.STATUS_CHOICES]
-        self.assertIn(handshake.status, valid_statuses)
-
-
-class PropertyTestServiceParticipationLimits(HypothesisTestCase):
-    """Test service participation limits property."""
-    
-    def setUp(self):
-        self.user1 = User.objects.create_user(
-            email='user1@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='One',
-            timebank_balance=Decimal('100.00')
-        )
-    
-    @settings(max_examples=20, deadline=None)
-    @given(
-        max_participants=st.integers(min_value=1, max_value=10),
-        num_requests=st.integers(min_value=1, max_value=15)
+    receiver = User.objects.create_user(
+        email='receiver@test.com', password='testpass123',
+        first_name='Receiver', last_name='User',
+        timebank_balance=Decimal('10.00'),
     )
-    def test_participation_limit_property(self, max_participants, num_requests):
-        """Test that capacity-consuming handshakes never exceed max_participants.
-
-        Pending handshakes do NOT consume a slot — multiple users can express
-        interest simultaneously. Only accepted (and completed/reported/paused)
-        handshakes count against capacity for One-Time services.
-        """
-        service = Service.objects.create(
-            user=self.user1,
-            title='Test Service',
-            description='Test description',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            schedule_type='One-Time',
-            max_participants=max_participants
-        )
-
-        users = []
-        for i in range(num_requests):
-            user = User.objects.create_user(
-                email=f'requester{i}_{uuid.uuid4().hex[:6]}@test.com',
-                password='testpass123',
-                first_name=f'User{i}',
-                last_name='Test',
-                timebank_balance=Decimal('10.00')
-            )
-            users.append(user)
-
-        for user in users:
-            is_valid, _ = HandshakeService.can_express_interest(service, user)
-            if is_valid:
-                try:
-                    HandshakeService.express_interest(service, user)
-                except Exception:
-                    pass
-
-        # Capacity-consuming statuses for One-Time (mirrors _capacity_statuses)
-        capacity_statuses = ['accepted', 'completed', 'reported', 'paused']
-        capacity_used = Handshake.objects.filter(
-            service=service,
-            status__in=capacity_statuses,
-        ).count()
-
-        self.assertLessEqual(
-            capacity_used,
-            max_participants,
-            msg=f"Capacity-consuming handshakes ({capacity_used}) exceeded max_participants ({max_participants})"
-        )
-
-
-class PropertyTestBalanceProvisioningAccuracy(HypothesisTestCase):
-    """Test balance provisioning accuracy property."""
-    
-    def setUp(self):
-        self.provider = User.objects.create_user(
-            email='provider@test.com',
-            password='testpass123',
-            first_name='Provider',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.receiver = User.objects.create_user(
-            email='receiver@test.com',
-            password='testpass123',
-            first_name='Receiver',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.service = Service.objects.create(
-            user=self.provider,
-            title='Test Service',
-            description='Test description',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            schedule_type='One-Time',
-            max_participants=1
-        )
-    
-    @settings(max_examples=30)
-    @given(
-        hours=st.integers(min_value=1, max_value=5).map(lambda value: Decimal(str(value))),
-        initial_balance=st.integers(min_value=3, max_value=20).map(lambda value: Decimal(str(value)))
+    service = Service.objects.create(
+        user=provider, title='Test Service', description='Test description',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        schedule_type='One-Time', max_participants=1,
     )
-    def test_provisioning_accuracy_property(self, hours, initial_balance):
-        """Test that provisioning accurately deducts hours."""
-        # Set initial balance
-        self.receiver.timebank_balance = initial_balance
-        self.receiver.save()
-        
-        # Skip if balance would go below -10.00
-        if initial_balance - hours < Decimal('-10.00'):
-            return
-        
-        # Create handshake
-        handshake = Handshake.objects.create(
-            service=self.service,
-            requester=self.receiver,
-            status='pending',
-            provisioned_hours=hours
-        )
-        
-        # Accept handshake (this should provision hours)
-        handshake.status = 'accepted'
-        handshake.save()
-        
-        # Provision hours
-        try:
-            provision_timebank(handshake)
-        except ValueError:
-            # Balance too low, skip this test case
-            return
-        
-        # Refresh receiver
-        self.receiver.refresh_from_db()
-        
-        expected_balance = initial_balance - hours
-        self.assertEqual(
-            float(self.receiver.timebank_balance),
-            float(expected_balance),
-            msg=f"Balance mismatch after provisioning: current={self.receiver.timebank_balance}, expected={expected_balance}"
-        )
-        provision_transaction = TransactionHistory.objects.filter(
-            user=self.receiver,
-            transaction_type='provision',
-            handshake=handshake
-        ).first()
-        
-        self.assertIsNotNone(provision_transaction, "Provision transaction should exist")
-        self.assertEqual(
-            float(provision_transaction.amount),
-            float(-hours),
-            msg=f"Transaction amount mismatch: {provision_transaction.amount} vs {-hours}"
-        )
+    return provider, receiver, service
 
 
-class PropertyTestUserRegistrationCompleteness(HypothesisTestCase):
-    """Test user registration completeness property."""
-    
-    @settings(max_examples=50, deadline=None)
-    @given(
-        email=st.emails(),
-        first_name=st.text(min_size=1, max_size=150),
-        last_name=st.text(min_size=1, max_size=150),
-        password=st.text(min_size=10, max_size=128)
+@pytest.mark.django_db
+@settings(max_examples=30,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    hours=st.integers(min_value=1, max_value=5).map(lambda v: Decimal(str(v))),
+    initial_balance=st.integers(min_value=3, max_value=20).map(lambda v: Decimal(str(v))),
+)
+def test_provisioning_accuracy_property(hours, initial_balance, provision_env):
+    """Provisioning accurately deducts hours."""
+    _, receiver, service = provision_env
+    receiver.timebank_balance = initial_balance
+    receiver.save()
+
+    if initial_balance - hours < Decimal('-10.00'):
+        return
+
+    handshake = Handshake.objects.create(
+        service=service, requester=receiver,
+        status='pending', provisioned_hours=hours,
     )
-    def test_registration_completeness_property(self, email, first_name, last_name, password):
-        """Test that new users have complete and valid data."""
-        # Clean email and names (remove invalid characters)
-        email = email.lower().strip()
-        first_name = first_name.replace("\x00", "").strip()[:150]
-        last_name = last_name.replace("\x00", "").strip()[:150]
 
-        # If cleaning makes names empty, skip this generated example
-        if not first_name or not last_name:
-            return
-        
-        # Skip if email already exists
-        if User.objects.filter(email=email).exists():
-            return
-        
-        # Create user
-        user = User.objects.create_user(
-            email=email,
-            password=password,
-            first_name=first_name,
-            last_name=last_name
-        )
-        
-        self.assertEqual(user.timebank_balance, Decimal('3.00'))
-        self.assertTrue(user.is_active)
-        self.assertEqual(user.role, 'member')
-        self.assertIsNotNone(user.email)
-        self.assertIn('@', user.email)
-        self.assertIsNotNone(user.first_name)
-        self.assertIsNotNone(user.last_name)
-        self.assertGreater(len(user.first_name), 0)
-        self.assertGreater(len(user.last_name), 0)
+    handshake.status = 'accepted'
+    handshake.save()
+
+    try:
+        provision_timebank(handshake)
+    except ValueError:
+        return
+
+    receiver.refresh_from_db()
+
+    expected_balance = initial_balance - hours
+    assert float(receiver.timebank_balance) == float(expected_balance)
+    provision_transaction = TransactionHistory.objects.filter(
+        user=receiver, transaction_type='provision', handshake=handshake,
+    ).first()
+
+    assert provision_transaction is not None
+    assert float(provision_transaction.amount) == float(-hours)
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Property tests — ranking, balance flow, handshake state machine
-# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.django_db
+@settings(max_examples=50, deadline=None,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    email=st.emails(),
+    first_name=st.text(min_size=1, max_size=150),
+    last_name=st.text(min_size=1, max_size=150),
+    password=st.text(min_size=10, max_size=128),
+)
+def test_registration_completeness_property(email, first_name, last_name, password):
+    """New users have complete and valid data."""
+    email = email.lower().strip()
+    first_name = first_name.replace('\x00', '').strip()[:150]
+    last_name = last_name.replace('\x00', '').strip()[:150]
 
-class PropertyTestRankingScoreMonotonicity(HypothesisTestCase):
-    """For a service that never loses engagement, hot score is monotone non-
-    decreasing in the number of positive interactions. The capacity multiplier
-    is the only step function — outside of that range the score must only go
-    up as more comments are added.
-    """
+    if not first_name or not last_name:
+        return
 
-    @settings(max_examples=20, deadline=None,
-              suppress_health_check=[HealthCheck.too_slow])
-    @given(steps=st.integers(min_value=1, max_value=8))
-    def test_score_never_decreases_with_more_comments(self, steps):
-        service = ServiceFactory(
-            type='Offer', status='Active', max_participants=1,
-        )
-        previous = calculate_hot_score(service)
-        for _ in range(steps):
-            CommentFactory(service=service)
-            service.refresh_from_db()
-            current = calculate_hot_score(service)
-            self.assertGreaterEqual(
-                current, previous,
-                msg=f'Hot score regressed: {previous} -> {current} after a comment',
-            )
-            previous = current
+    if User.objects.filter(email=email).exists():
+        return
 
-
-class PropertyTestTimeBankNetFlowInvariant(HypothesisTestCase):
-    """The user's balance must always equal initial_balance + sum(transactions).
-
-    Stronger than ``PropertyTestTimeBankBalanceConsistency`` because we
-    interleave provisions and completions through ``HandshakeService`` rather
-    than constructing transaction rows directly.
-    """
-
-    @settings(max_examples=15, deadline=None,
-              suppress_health_check=[HealthCheck.too_slow])
-    @given(
-        initial=st.integers(min_value=5, max_value=50).map(lambda v: Decimal(str(v))),
-        deltas=st.lists(
-            st.integers(min_value=-3, max_value=5).map(lambda v: Decimal(str(v))),
-            min_size=1, max_size=8,
-        ),
+    user = User.objects.create_user(
+        email=email, password=password,
+        first_name=first_name, last_name=last_name,
     )
-    def test_net_flow_matches_balance_delta(self, initial, deltas):
-        user = User.objects.create_user(
-            email=f'flow_{uuid.uuid4().hex[:8]}@test.com',
-            password='testpass123',
-            first_name='Flow', last_name='User',
-            timebank_balance=initial,
-        )
-        for delta in deltas:
-            new_balance = user.timebank_balance + delta
-            if new_balance < Decimal('-10.00'):
-                continue
-            TransactionHistory.objects.create(
-                user=user,
-                transaction_type='transfer',
-                amount=delta,
-                balance_after=new_balance,
-                description='property test',
-            )
-            user.timebank_balance = new_balance
-            user.save(update_fields=['timebank_balance'])
 
-        user.refresh_from_db()
-        history_sum = sum(
-            TransactionHistory.objects.filter(user=user)
-            .values_list('amount', flat=True)
+    assert user.timebank_balance == Decimal('3.00')
+    assert user.is_active
+    assert user.role == 'member'
+    assert user.email is not None
+    assert '@' in user.email
+    assert user.first_name is not None
+    assert user.last_name is not None
+    assert len(user.first_name) > 0
+    assert len(user.last_name) > 0
+
+
+@pytest.mark.django_db
+@settings(max_examples=20, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@given(steps=st.integers(min_value=1, max_value=8))
+def test_score_never_decreases_with_more_comments(steps):
+    """Hot score is monotone non-decreasing in positive interactions."""
+    service = ServiceFactory(type='Offer', status='Active', max_participants=1)
+    previous = calculate_hot_score(service)
+    for _ in range(steps):
+        CommentFactory(service=service)
+        service.refresh_from_db()
+        current = calculate_hot_score(service)
+        assert current >= previous
+        previous = current
+
+
+@pytest.mark.django_db
+@settings(max_examples=15, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@given(
+    initial=st.integers(min_value=5, max_value=50).map(lambda v: Decimal(str(v))),
+    deltas=st.lists(
+        st.integers(min_value=-3, max_value=5).map(lambda v: Decimal(str(v))),
+        min_size=1, max_size=8,
+    ),
+)
+def test_net_flow_matches_balance_delta(initial, deltas):
+    """Balance equals initial + sum(transactions) under interleaved transfers."""
+    user = User.objects.create_user(
+        email=f'flow_{uuid.uuid4().hex[:8]}@test.com',
+        password='testpass123', first_name='Flow', last_name='User',
+        timebank_balance=initial,
+    )
+    for delta in deltas:
+        new_balance = user.timebank_balance + delta
+        if new_balance < Decimal('-10.00'):
+            continue
+        TransactionHistory.objects.create(
+            user=user, transaction_type='transfer', amount=delta,
+            balance_after=new_balance, description='property test',
         )
-        self.assertEqual(user.timebank_balance, initial + history_sum)
+        user.timebank_balance = new_balance
+        user.save(update_fields=['timebank_balance'])
+
+    user.refresh_from_db()
+    history_sum = sum(
+        TransactionHistory.objects.filter(user=user).values_list('amount', flat=True)
+    )
+    assert user.timebank_balance == initial + history_sum
 
 
 # Stateful test: handshake transitions must follow the published state machine.
-# Pending → accepted | denied | cancelled
-# Accepted → completed | cancelled | reported
-# Completed/Denied/Cancelled/Reported → terminal (only paused as the exception)
 LEGAL_TRANSITIONS = {
     'pending':   {'accepted', 'denied', 'cancelled'},
     'accepted':  {'completed', 'cancelled', 'reported', 'paused'},
     'paused':    {'accepted', 'cancelled'},
-    # Terminals — anything else is a violation
     'completed': set(),
     'denied':    set(),
     'cancelled': set(),

--- a/backend/api/tests/unit/test_public_chat.py
+++ b/backend/api/tests/unit/test_public_chat.py
@@ -4,283 +4,214 @@ Unit tests for Public Chat feature.
 Tests the ChatRoom model, signal-based auto-creation, and PublicChatMessage functionality.
 """
 from decimal import Decimal
-from django.test import TestCase
-from django.urls import reverse
-from rest_framework.test import APITestCase, APIClient
-from rest_framework import status
+from types import SimpleNamespace
 
-from api.models import User, Service, ChatRoom, PublicChatMessage
+import pytest
+from rest_framework.test import APIClient
 
-
-class ChatRoomSignalTestCase(TestCase):
-    """Test cases for automatic ChatRoom creation on Service creation."""
-
-    def setUp(self):
-        """Set up test data."""
-        self.user = User.objects.create_user(
-            email='test@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-
-    def test_chat_room_created_on_service_creation(self):
-        """Test that a ChatRoom is created when a Service is created."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-
-        # Verify ChatRoom was created
-        self.assertTrue(ChatRoom.objects.filter(related_service=service).exists())
-        
-        room = ChatRoom.objects.get(related_service=service)
-        self.assertEqual(room.type, 'public')
-        self.assertIn(service.title, room.name)
-
-    def test_chat_room_type_is_public(self):
-        """Test that auto-created ChatRoom has type 'public'."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Need',
-            duration=Decimal('1.00'),
-            location_type='In-Person',
-            location_area='Test Area',
-            max_participants=5,
-            schedule_type='Recurrent'
-        )
-
-        room = service.chat_room
-        self.assertEqual(room.type, 'public')
-
-    def test_chat_room_one_to_one_relationship(self):
-        """Test that Service and ChatRoom have OneToOne relationship."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-
-        # Access chat_room via related_name
-        room = service.chat_room
-        self.assertIsNotNone(room)
-        self.assertEqual(room.related_service, service)
+from api.models import ChatRoom, PublicChatMessage, Service, User
 
 
-class PublicChatMessageTestCase(TestCase):
-    """Test cases for PublicChatMessage model."""
-
-    def setUp(self):
-        """Set up test data."""
-        self.user1 = User.objects.create_user(
-            email='user1@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='One',
-            timebank_balance=Decimal('10.00')
-        )
-        self.user2 = User.objects.create_user(
-            email='user2@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Two',
-            timebank_balance=Decimal('5.00')
-        )
-        
-        self.service = Service.objects.create(
-            user=self.user1,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        self.room = self.service.chat_room
-
-    def test_create_public_chat_message(self):
-        """Test creating a public chat message."""
-        message = PublicChatMessage.objects.create(
-            room=self.room,
-            sender=self.user2,
-            body='Hello, this is a public message!'
-        )
-
-        self.assertIsNotNone(message.id)
-        self.assertEqual(message.room, self.room)
-        self.assertEqual(message.sender, self.user2)
-        self.assertEqual(message.body, 'Hello, this is a public message!')
-
-    def test_multiple_users_can_post_messages(self):
-        """Test that multiple users can post messages to the same room."""
-        message1 = PublicChatMessage.objects.create(
-            room=self.room,
-            sender=self.user1,
-            body='Message from user 1'
-        )
-        message2 = PublicChatMessage.objects.create(
-            room=self.room,
-            sender=self.user2,
-            body='Message from user 2'
-        )
-
-        messages = PublicChatMessage.objects.filter(room=self.room)
-        self.assertEqual(messages.count(), 2)
-
-    def test_messages_ordered_by_created_at(self):
-        """Test that messages are ordered by created_at ascending."""
-        PublicChatMessage.objects.create(
-            room=self.room,
-            sender=self.user1,
-            body='First message'
-        )
-        PublicChatMessage.objects.create(
-            room=self.room,
-            sender=self.user2,
-            body='Second message'
-        )
-
-        messages = list(PublicChatMessage.objects.filter(room=self.room))
-        self.assertEqual(messages[0].body, 'First message')
-        self.assertEqual(messages[1].body, 'Second message')
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        email='test@test.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
 
 
-class PublicChatAPITestCase(APITestCase):
-    """Test cases for Public Chat API endpoints."""
+@pytest.mark.django_db
+def test_chat_room_created_on_service_creation(user):
+    service = Service.objects.create(
+        user=user, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
 
-    def setUp(self):
-        """Set up test data."""
-        self.user = User.objects.create_user(
-            email='test@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-        self.other_user = User.objects.create_user(
-            email='other@test.com',
-            password='testpass123',
-            first_name='Other',
-            last_name='User',
-            timebank_balance=Decimal('5.00')
-        )
-        
-        self.service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        self.client = APIClient()
+    assert ChatRoom.objects.filter(related_service=service).exists()
+    room = ChatRoom.objects.get(related_service=service)
+    assert room.type == 'public'
+    assert service.title in room.name
 
-    def test_get_public_chat_authenticated(self):
-        """Test that authenticated users can retrieve public chat."""
-        self.client.force_authenticate(user=self.other_user)
-        
-        response = self.client.get(f'/api/public-chat/{self.service.id}/')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('room', response.data)
-        self.assertIn('messages', response.data)
 
-    def test_get_public_chat_unauthenticated(self):
-        """Test that unauthenticated users cannot access public chat."""
-        response = self.client.get(f'/api/public-chat/{self.service.id}/')
-        
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+@pytest.mark.django_db
+def test_chat_room_type_is_public(user):
+    service = Service.objects.create(
+        user=user, title='Test Service', description='A test service',
+        type='Need', duration=Decimal('1.00'), location_type='In-Person',
+        location_area='Test Area', max_participants=5, schedule_type='Recurrent',
+    )
+    assert service.chat_room.type == 'public'
 
-    def test_send_message_authenticated(self):
-        """Test that authenticated users can send messages."""
-        self.client.force_authenticate(user=self.other_user)
-        
-        response = self.client.post(f'/api/public-chat/{self.service.id}/', {
-            'body': 'Hello from the lobby!'
-        })
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['body'], 'Hello from the lobby!')
-        self.assertEqual(response.data['sender_name'], 'Other User')
 
-    def test_send_message_unauthenticated(self):
-        """Test that unauthenticated users cannot send messages."""
-        response = self.client.post(f'/api/public-chat/{self.service.id}/', {
-            'body': 'Hello!'
-        })
-        
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+@pytest.mark.django_db
+def test_chat_room_one_to_one_relationship(user):
+    service = Service.objects.create(
+        user=user, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    room = service.chat_room
+    assert room is not None
+    assert room.related_service == service
 
-    def test_send_empty_message_fails(self):
-        """Test that empty messages are rejected."""
-        self.client.force_authenticate(user=self.user)
-        
-        response = self.client.post(f'/api/public-chat/{self.service.id}/', {
-            'body': ''
-        })
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_send_message_whitespace_only_fails(self):
-        """Test that whitespace-only messages are rejected."""
-        self.client.force_authenticate(user=self.user)
-        
-        response = self.client.post(f'/api/public-chat/{self.service.id}/', {
-            'body': '   '
-        })
-        
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+@pytest.fixture
+def message_env(db):
+    user1 = User.objects.create_user(
+        email='user1@test.com', password='testpass123',
+        first_name='User', last_name='One',
+        timebank_balance=Decimal('10.00'),
+    )
+    user2 = User.objects.create_user(
+        email='user2@test.com', password='testpass123',
+        first_name='User', last_name='Two',
+        timebank_balance=Decimal('5.00'),
+    )
+    service = Service.objects.create(
+        user=user1, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    return SimpleNamespace(user1=user1, user2=user2, service=service, room=service.chat_room)
 
-    def test_get_nonexistent_service(self):
-        """Test getting public chat for nonexistent service."""
-        self.client.force_authenticate(user=self.user)
-        
-        response = self.client.get('/api/public-chat/00000000-0000-0000-0000-000000000000/')
-        
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_message_sanitization(self):
-        """Test that HTML in messages is sanitized."""
-        self.client.force_authenticate(user=self.user)
-        
-        response = self.client.post(f'/api/public-chat/{self.service.id}/', {
-            'body': '<script>alert("xss")</script>Hello'
-        })
-        
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertNotIn('<script>', response.data['body'])
-        self.assertIn('Hello', response.data['body'])
+@pytest.mark.django_db
+def test_create_public_chat_message(message_env):
+    message = PublicChatMessage.objects.create(
+        room=message_env.room,
+        sender=message_env.user2,
+        body='Hello, this is a public message!',
+    )
 
-    def test_chat_room_auto_created_on_first_access(self):
-        """Test that ChatRoom is created on first access if missing."""
-        # Create a service without triggering the signal (manually delete the room)
-        room = self.service.chat_room
-        room.delete()
-        
-        self.client.force_authenticate(user=self.user)
-        
-        response = self.client.get(f'/api/public-chat/{self.service.id}/')
-        
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Room should be recreated
-        self.assertTrue(ChatRoom.objects.filter(related_service=self.service).exists())
+    assert message.id is not None
+    assert message.room == message_env.room
+    assert message.sender == message_env.user2
+    assert message.body == 'Hello, this is a public message!'
 
+
+@pytest.mark.django_db
+def test_multiple_users_can_post_messages(message_env):
+    PublicChatMessage.objects.create(
+        room=message_env.room, sender=message_env.user1, body='Message from user 1',
+    )
+    PublicChatMessage.objects.create(
+        room=message_env.room, sender=message_env.user2, body='Message from user 2',
+    )
+
+    messages = PublicChatMessage.objects.filter(room=message_env.room)
+    assert messages.count() == 2
+
+
+@pytest.mark.django_db
+def test_messages_ordered_by_created_at(message_env):
+    PublicChatMessage.objects.create(
+        room=message_env.room, sender=message_env.user1, body='First message',
+    )
+    PublicChatMessage.objects.create(
+        room=message_env.room, sender=message_env.user2, body='Second message',
+    )
+
+    messages = list(PublicChatMessage.objects.filter(room=message_env.room))
+    assert messages[0].body == 'First message'
+    assert messages[1].body == 'Second message'
+
+
+@pytest.fixture
+def api_env(db):
+    user = User.objects.create_user(
+        email='test@test.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+    other_user = User.objects.create_user(
+        email='other@test.com', password='testpass123',
+        first_name='Other', last_name='User',
+        timebank_balance=Decimal('5.00'),
+    )
+    service = Service.objects.create(
+        user=user, title='Test Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    return SimpleNamespace(user=user, other_user=other_user, service=service, client=APIClient())
+
+
+@pytest.mark.django_db
+def test_get_public_chat_authenticated(api_env):
+    api_env.client.force_authenticate(user=api_env.other_user)
+    response = api_env.client.get(f'/api/public-chat/{api_env.service.id}/')
+    assert response.status_code == 200
+    assert 'room' in response.data
+    assert 'messages' in response.data
+
+
+@pytest.mark.django_db
+def test_get_public_chat_unauthenticated(api_env):
+    response = api_env.client.get(f'/api/public-chat/{api_env.service.id}/')
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_send_message_authenticated(api_env):
+    api_env.client.force_authenticate(user=api_env.other_user)
+    response = api_env.client.post(
+        f'/api/public-chat/{api_env.service.id}/', {'body': 'Hello from the lobby!'},
+    )
+    assert response.status_code == 201
+    assert response.data['body'] == 'Hello from the lobby!'
+    assert response.data['sender_name'] == 'Other User'
+
+
+@pytest.mark.django_db
+def test_send_message_unauthenticated(api_env):
+    response = api_env.client.post(
+        f'/api/public-chat/{api_env.service.id}/', {'body': 'Hello!'},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_send_empty_message_fails(api_env):
+    api_env.client.force_authenticate(user=api_env.user)
+    response = api_env.client.post(f'/api/public-chat/{api_env.service.id}/', {'body': ''})
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_send_message_whitespace_only_fails(api_env):
+    api_env.client.force_authenticate(user=api_env.user)
+    response = api_env.client.post(f'/api/public-chat/{api_env.service.id}/', {'body': '   '})
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_get_nonexistent_service(api_env):
+    api_env.client.force_authenticate(user=api_env.user)
+    response = api_env.client.get('/api/public-chat/00000000-0000-0000-0000-000000000000/')
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_message_sanitization(api_env):
+    api_env.client.force_authenticate(user=api_env.user)
+    response = api_env.client.post(
+        f'/api/public-chat/{api_env.service.id}/',
+        {'body': '<script>alert("xss")</script>Hello'},
+    )
+    assert response.status_code == 201
+    assert '<script>' not in response.data['body']
+    assert 'Hello' in response.data['body']
+
+
+@pytest.mark.django_db
+def test_chat_room_auto_created_on_first_access(api_env):
+    room = api_env.service.chat_room
+    room.delete()
+
+    api_env.client.force_authenticate(user=api_env.user)
+    response = api_env.client.get(f'/api/public-chat/{api_env.service.id}/')
+
+    assert response.status_code == 200
+    assert ChatRoom.objects.filter(related_service=api_env.service).exists()

--- a/backend/api/tests/unit/test_search_hierarchy.py
+++ b/backend/api/tests/unit/test_search_hierarchy.py
@@ -4,106 +4,118 @@ Tests for hierarchical TagStrategy (parent traversal and entity_type filtering).
 Phase 2.1 RED tests — these should fail until search_filters.py is updated.
 """
 from decimal import Decimal
-from django.test import TestCase
+from types import SimpleNamespace
+
+import pytest
 
 from api.models import Service, Tag, User
 from api.search_filters import TagStrategy
 
 
-class HierarchicalTagStrategyTestCase(TestCase):
-    """Test TagStrategy with parent_qid traversal and entity_type filtering."""
+@pytest.fixture
+def env(db):
+    user = User.objects.create_user(
+        email='testuser@test.com',
+        password='testpass123',
+        first_name='Test',
+        last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
 
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='testuser@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00'),
-        )
+    tag_prog_lang = Tag.objects.create(
+        id='Q9143', name='Programming language',
+        entity_type='technology',
+    )
+    tag_python = Tag.objects.create(
+        id='Q28865', name='Python',
+        parent_qid='Q9143', entity_type='technology', depth=1,
+    )
+    tag_django = Tag.objects.create(
+        id='Q290053', name='Django',
+        parent_qid='Q1330336', entity_type='technology', depth=1,
+    )
+    tag_cooking = Tag.objects.create(
+        id='Q25403900', name='Cooking',
+        parent_qid='Q2095', entity_type='food', depth=1,
+    )
 
-        # Tags with hierarchy
-        self.tag_prog_lang = Tag.objects.create(
-            id='Q9143', name='Programming language',
-            entity_type='technology',
-        )
-        self.tag_python = Tag.objects.create(
-            id='Q28865', name='Python',
-            parent_qid='Q9143', entity_type='technology', depth=1,
-        )
-        self.tag_django = Tag.objects.create(
-            id='Q290053', name='Django',
-            parent_qid='Q1330336', entity_type='technology', depth=1,
-        )
-        self.tag_cooking = Tag.objects.create(
-            id='Q25403900', name='Cooking',
-            parent_qid='Q2095', entity_type='food', depth=1,
-        )
+    svc_python = Service.objects.create(
+        user=user, title='Python Tutoring',
+        description='Learn Python', type='Offer',
+        duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    svc_python.tags.add(tag_python)
 
-        # Services
-        self.svc_python = Service.objects.create(
-            user=self.user, title='Python Tutoring',
-            description='Learn Python', type='Offer',
-            duration=Decimal('2.00'), location_type='Online',
-            max_participants=1, schedule_type='One-Time',
-        )
-        self.svc_python.tags.add(self.tag_python)
+    svc_django = Service.objects.create(
+        user=user, title='Django Help',
+        description='Django web framework', type='Offer',
+        duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    svc_django.tags.add(tag_django)
 
-        self.svc_django = Service.objects.create(
-            user=self.user, title='Django Help',
-            description='Django web framework', type='Offer',
-            duration=Decimal('2.00'), location_type='Online',
-            max_participants=1, schedule_type='One-Time',
-        )
-        self.svc_django.tags.add(self.tag_django)
+    svc_cooking = Service.objects.create(
+        user=user, title='Cooking Class',
+        description='Learn to cook', type='Offer',
+        duration=Decimal('3.00'), location_type='In-Person',
+        max_participants=5, schedule_type='Recurrent',
+    )
+    svc_cooking.tags.add(tag_cooking)
 
-        self.svc_cooking = Service.objects.create(
-            user=self.user, title='Cooking Class',
-            description='Learn to cook', type='Offer',
-            duration=Decimal('3.00'), location_type='In-Person',
-            max_participants=5, schedule_type='Recurrent',
-        )
-        self.svc_cooking.tags.add(self.tag_cooking)
+    return SimpleNamespace(
+        user=user,
+        tag_prog_lang=tag_prog_lang,
+        tag_python=tag_python,
+        tag_django=tag_django,
+        tag_cooking=tag_cooking,
+        svc_python=svc_python,
+        svc_django=svc_django,
+        svc_cooking=svc_cooking,
+        strategy=TagStrategy(),
+    )
 
-        self.strategy = TagStrategy()
 
-    def test_direct_tag_match_still_works(self):
-        """Backward compat: direct tag ID match works as before."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.strategy.apply(qs, {'tag': 'Q28865'}))
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].title, 'Python Tutoring')
+@pytest.mark.django_db
+def test_direct_tag_match_still_works(env):
+    qs = Service.objects.filter(status='Active')
+    result = list(env.strategy.apply(qs, {'tag': 'Q28865'}))
+    assert len(result) == 1
+    assert result[0].title == 'Python Tutoring'
 
-    def test_finds_services_via_parent_qid(self):
-        """Searching for parent tag Q9143 finds Python service (parent_qid=Q9143)."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.strategy.apply(qs, {'tag': 'Q9143'}))
-        titles = [s.title for s in result]
-        self.assertIn('Python Tutoring', titles)
 
-    def test_entity_type_filter(self):
-        """Search by entity_type='technology' finds tech-tagged services only."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.strategy.apply(qs, {'entity_type': 'technology'}))
-        titles = [s.title for s in result]
-        self.assertIn('Python Tutoring', titles)
-        self.assertIn('Django Help', titles)
-        self.assertNotIn('Cooking Class', titles)
+@pytest.mark.django_db
+def test_finds_services_via_parent_qid(env):
+    qs = Service.objects.filter(status='Active')
+    result = list(env.strategy.apply(qs, {'tag': 'Q9143'}))
+    titles = [s.title for s in result]
+    assert 'Python Tutoring' in titles
 
-    def test_no_false_positives(self):
-        """Searching for food entity_type does not return tech services."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.strategy.apply(qs, {'entity_type': 'food'}))
-        titles = [s.title for s in result]
-        self.assertIn('Cooking Class', titles)
-        self.assertNotIn('Python Tutoring', titles)
-        self.assertNotIn('Django Help', titles)
 
-    def test_parent_qid_and_direct_combined(self):
-        """Multiple tag IDs including a parent find both direct and child matches."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.strategy.apply(qs, {'tags': ['Q9143', 'Q25403900']}))
-        titles = [s.title for s in result]
-        # Q9143 matches Python via parent_qid, Q25403900 matches Cooking directly
-        self.assertIn('Python Tutoring', titles)
-        self.assertIn('Cooking Class', titles)
+@pytest.mark.django_db
+def test_entity_type_filter(env):
+    qs = Service.objects.filter(status='Active')
+    result = list(env.strategy.apply(qs, {'entity_type': 'technology'}))
+    titles = [s.title for s in result]
+    assert 'Python Tutoring' in titles
+    assert 'Django Help' in titles
+    assert 'Cooking Class' not in titles
+
+
+@pytest.mark.django_db
+def test_no_false_positives(env):
+    qs = Service.objects.filter(status='Active')
+    result = list(env.strategy.apply(qs, {'entity_type': 'food'}))
+    titles = [s.title for s in result]
+    assert 'Cooking Class' in titles
+    assert 'Python Tutoring' not in titles
+    assert 'Django Help' not in titles
+
+
+@pytest.mark.django_db
+def test_parent_qid_and_direct_combined(env):
+    qs = Service.objects.filter(status='Active')
+    result = list(env.strategy.apply(qs, {'tags': ['Q9143', 'Q25403900']}))
+    titles = [s.title for s in result]
+    assert 'Python Tutoring' in titles
+    assert 'Cooking Class' in titles

--- a/backend/api/tests/unit/test_search_scoring.py
+++ b/backend/api/tests/unit/test_search_scoring.py
@@ -4,130 +4,148 @@ Tests for weighted search scoring (FR-SEA-01).
 Phase 2.2 RED tests — these should fail until ScoringStrategy is implemented.
 """
 from decimal import Decimal
-from django.test import TestCase
+from types import SimpleNamespace
+
+import pytest
 
 from api.models import Service, Tag, User
 from api.search_filters import SearchEngine
 
 
-class SearchScoringTestCase(TestCase):
-    """Test annotation-based weighted scoring in SearchEngine."""
+@pytest.fixture
+def env(db):
+    user = User.objects.create_user(
+        email='testuser@test.com',
+        password='testpass123',
+        first_name='Test',
+        last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
 
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='testuser@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00'),
-        )
+    tag_python = Tag.objects.create(
+        id='Q28865', name='Python',
+        parent_qid='Q9143', entity_type='technology', depth=1,
+    )
+    tag_prog_lang = Tag.objects.create(
+        id='Q9143', name='Programming language',
+        entity_type='technology',
+    )
+    tag_cooking = Tag.objects.create(
+        id='Q25403900', name='Cooking',
+        parent_qid='Q2095', entity_type='food', depth=1,
+    )
 
-        self.tag_python = Tag.objects.create(
-            id='Q28865', name='Python',
-            parent_qid='Q9143', entity_type='technology', depth=1,
-        )
-        self.tag_prog_lang = Tag.objects.create(
-            id='Q9143', name='Programming language',
-            entity_type='technology',
-        )
-        self.tag_cooking = Tag.objects.create(
-            id='Q25403900', name='Cooking',
-            parent_qid='Q2095', entity_type='food', depth=1,
-        )
+    svc_title_and_tag = Service.objects.create(
+        user=user, title='Python Tutoring',
+        description='Expert Python help', type='Offer',
+        duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    svc_title_and_tag.tags.add(tag_python)
 
-        # Service with "Python" in title AND tagged Python
-        self.svc_title_and_tag = Service.objects.create(
-            user=self.user, title='Python Tutoring',
-            description='Expert Python help', type='Offer',
-            duration=Decimal('2.00'), location_type='Online',
-            max_participants=1, schedule_type='One-Time',
-        )
-        self.svc_title_and_tag.tags.add(self.tag_python)
+    svc_tag_only = Service.objects.create(
+        user=user, title='Programming Help',
+        description='Various programming', type='Offer',
+        duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    svc_tag_only.tags.add(tag_python)
 
-        # Service with Python tag but NO title match
-        self.svc_tag_only = Service.objects.create(
-            user=self.user, title='Programming Help',
-            description='Various programming', type='Offer',
-            duration=Decimal('2.00'), location_type='Online',
-            max_participants=1, schedule_type='One-Time',
-        )
-        self.svc_tag_only.tags.add(self.tag_python)
+    svc_desc_only = Service.objects.create(
+        user=user, title='Coding Class',
+        description='Learn Python and more', type='Offer',
+        duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
 
-        # Service with "Python" in description only
-        self.svc_desc_only = Service.objects.create(
-            user=self.user, title='Coding Class',
-            description='Learn Python and more', type='Offer',
-            duration=Decimal('2.00'), location_type='Online',
-            max_participants=1, schedule_type='One-Time',
-        )
+    svc_unrelated = Service.objects.create(
+        user=user, title='Cooking Class',
+        description='Learn to cook', type='Offer',
+        duration=Decimal('3.00'), location_type='In-Person',
+        max_participants=5, schedule_type='Recurrent',
+    )
+    svc_unrelated.tags.add(tag_cooking)
 
-        # Completely unrelated service
-        self.svc_unrelated = Service.objects.create(
-            user=self.user, title='Cooking Class',
-            description='Learn to cook', type='Offer',
-            duration=Decimal('3.00'), location_type='In-Person',
-            max_participants=5, schedule_type='Recurrent',
-        )
-        self.svc_unrelated.tags.add(self.tag_cooking)
+    return SimpleNamespace(
+        user=user,
+        tag_python=tag_python,
+        tag_prog_lang=tag_prog_lang,
+        tag_cooking=tag_cooking,
+        svc_title_and_tag=svc_title_and_tag,
+        svc_tag_only=svc_tag_only,
+        svc_desc_only=svc_desc_only,
+        svc_unrelated=svc_unrelated,
+        engine=SearchEngine(),
+    )
 
-        self.engine = SearchEngine()
 
-    def test_title_match_scores_highest(self):
-        """Service with search term in title has the highest score."""
-        qs = Service.objects.filter(status='Active')
-        result = self.engine.search(qs, {'search': 'Python'})
-        scored = list(result)
+@pytest.mark.django_db
+def test_title_match_scores_highest(env):
+    """Service with search term in title has the highest score."""
+    qs = Service.objects.filter(status='Active')
+    result = env.engine.search(qs, {'search': 'Python'})
+    scored = list(result)
 
-        # svc_title_and_tag should have title+tag score, highest
-        self.assertTrue(hasattr(scored[0], 'search_score'))
-        self.assertEqual(scored[0].id, self.svc_title_and_tag.id)
+    assert hasattr(scored[0], 'search_score')
+    assert scored[0].id == env.svc_title_and_tag.id
 
-    def test_tag_id_match_scores_0_8(self):
-        """Service with direct tag ID match gets score of 0.8."""
-        qs = Service.objects.filter(status='Active')
-        # Search by tag ID, not text
-        result = self.engine.search(qs, {'tag': 'Q28865'})
-        scored = {s.id: s.search_score for s in result if hasattr(s, 'search_score')}
 
-        tag_score = scored.get(self.svc_tag_only.id, 0)
-        self.assertGreaterEqual(tag_score, 0.8)
+@pytest.mark.django_db
+def test_tag_id_match_scores_0_8(env):
+    """Service with direct tag ID match gets score of 0.8."""
+    qs = Service.objects.filter(status='Active')
+    result = env.engine.search(qs, {'tag': 'Q28865'})
+    scored = {s.id: s.search_score for s in result if hasattr(s, 'search_score')}
 
-    def test_scores_additive(self):
-        """Title + tag match scores higher than tag match alone."""
-        qs = Service.objects.filter(status='Active')
-        result = self.engine.search(qs, {'search': 'Python'})
-        scored = {s.id: s.search_score for s in result if hasattr(s, 'search_score')}
+    tag_score = scored.get(env.svc_tag_only.id, 0)
+    assert tag_score >= 0.8
 
-        title_and_tag = scored.get(self.svc_title_and_tag.id, 0)
-        tag_only = scored.get(self.svc_tag_only.id, 0)
-        self.assertGreater(title_and_tag, tag_only)
 
-    def test_results_ordered_by_score(self):
-        """Results are in descending score order."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.engine.search(qs, {'search': 'Python'}))
+@pytest.mark.django_db
+def test_scores_additive(env):
+    """Title + tag match scores higher than tag match alone."""
+    qs = Service.objects.filter(status='Active')
+    result = env.engine.search(qs, {'search': 'Python'})
+    scored = {s.id: s.search_score for s in result if hasattr(s, 'search_score')}
 
-        scores = [getattr(s, 'search_score', 0) for s in result]
-        self.assertEqual(scores, sorted(scores, reverse=True))
+    title_and_tag = scored.get(env.svc_title_and_tag.id, 0)
+    tag_only = scored.get(env.svc_tag_only.id, 0)
+    assert title_and_tag > tag_only
 
-    def test_no_search_no_scoring(self):
-        """Without search/tag params, no search_score annotation."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.engine.search(qs, {}))
 
-        for s in result:
-            self.assertFalse(hasattr(s, 'search_score'))
+@pytest.mark.django_db
+def test_results_ordered_by_score(env):
+    """Results are in descending score order."""
+    qs = Service.objects.filter(status='Active')
+    result = list(env.engine.search(qs, {'search': 'Python'}))
 
-    def test_description_match_included(self):
-        """Service with search term in description is found."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.engine.search(qs, {'search': 'Python'}))
-        result_ids = [s.id for s in result]
-        self.assertIn(self.svc_desc_only.id, result_ids)
+    scores = [getattr(s, 'search_score', 0) for s in result]
+    assert scores == sorted(scores, reverse=True)
 
-    def test_unrelated_not_in_results(self):
-        """Unrelated service is not in search results."""
-        qs = Service.objects.filter(status='Active')
-        result = list(self.engine.search(qs, {'search': 'Python'}))
-        result_ids = [s.id for s in result]
-        self.assertNotIn(self.svc_unrelated.id, result_ids)
+
+@pytest.mark.django_db
+def test_no_search_no_scoring(env):
+    """Without search/tag params, no search_score annotation."""
+    qs = Service.objects.filter(status='Active')
+    result = list(env.engine.search(qs, {}))
+
+    for s in result:
+        assert not hasattr(s, 'search_score')
+
+
+@pytest.mark.django_db
+def test_description_match_included(env):
+    """Service with search term in description is found."""
+    qs = Service.objects.filter(status='Active')
+    result = list(env.engine.search(qs, {'search': 'Python'}))
+    result_ids = [s.id for s in result]
+    assert env.svc_desc_only.id in result_ids
+
+
+@pytest.mark.django_db
+def test_unrelated_not_in_results(env):
+    """Unrelated service is not in search results."""
+    qs = Service.objects.filter(status='Active')
+    result = list(env.engine.search(qs, {'search': 'Python'}))
+    result_ids = [s.id for s in result]
+    assert env.svc_unrelated.id not in result_ids

--- a/backend/api/tests/unit/test_service_location.py
+++ b/backend/api/tests/unit/test_service_location.py
@@ -4,243 +4,215 @@ Unit tests for Service.save() location field synchronization.
 Tests for race condition prevention when using update_fields with location coordinates.
 """
 from decimal import Decimal
-from django.test import TestCase
+
+import pytest
 from django.contrib.auth import get_user_model
-from django.contrib.gis.geos import Point
 
 from api.models import Service
 
 User = get_user_model()
 
 
-class ServiceLocationSaveTestCase(TestCase):
-    """Test cases for Service location field synchronization during save."""
-    
-    def setUp(self):
-        """Set up test data."""
-        self.user = User.objects.create_user(
-            email='test@test.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00')
-        )
-    
-    def test_full_save_computes_location(self):
-        """Test that full save correctly computes location from lat/lng."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.015137'),
-            location_lng=Decimal('28.979530'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        # Verify location was computed
-        self.assertIsNotNone(service.location)
-        self.assertAlmostEqual(service.location.x, 28.979530, places=5)
-        self.assertAlmostEqual(service.location.y, 41.015137, places=5)
-    
-    def test_partial_save_with_both_coords_computes_location(self):
-        """Test that partial save with both lat/lng updates location correctly."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.015137'),
-            location_lng=Decimal('28.979530'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        # Update both coordinates
-        service.location_lat = Decimal('40.000000')
-        service.location_lng = Decimal('29.000000')
-        service.save(update_fields=['location_lat', 'location_lng'])
-        
-        # Refresh and verify
-        service.refresh_from_db()
-        self.assertIsNotNone(service.location)
-        self.assertAlmostEqual(service.location.x, 29.000000, places=5)
-        self.assertAlmostEqual(service.location.y, 40.000000, places=5)
-    
-    def test_partial_save_single_coord_refreshes_from_db(self):
-        """
-        Test that partial save with single coord refreshes the other from DB.
-        
-        This is the race condition test: simulates another process updating
-        location_lng while we only update location_lat.
-        """
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.015137'),
-            location_lng=Decimal('28.979530'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        # Simulate another process updating location_lng in the database
-        # This bypasses the save() method to simulate a concurrent update
-        Service.objects.filter(pk=service.pk).update(
-            location_lng=Decimal('30.000000')
-        )
-        
-        # Our in-memory service still has the old location_lng
-        self.assertEqual(service.location_lng, Decimal('28.979530'))
-        
-        # Now update only location_lat using update_fields
-        service.location_lat = Decimal('42.000000')
-        service.save(update_fields=['location_lat'])
-        
-        # Refresh from DB and verify location is consistent with BOTH DB values
-        service.refresh_from_db()
-        
-        # location_lat should be our new value
-        self.assertEqual(service.location_lat, Decimal('42.000000'))
-        
-        # location_lng should be the DB value (from "other process")
-        self.assertEqual(service.location_lng, Decimal('30.000000'))
-        
-        # CRITICAL: location PointField should use the FRESH DB values
-        # NOT the stale in-memory location_lng (28.979530)
-        self.assertIsNotNone(service.location)
-        self.assertAlmostEqual(service.location.x, 30.000000, places=5)  # Fresh DB lng
-        self.assertAlmostEqual(service.location.y, 42.000000, places=5)  # Our updated lat
-    
-    def test_partial_save_single_coord_lng_refreshes_lat(self):
-        """
-        Test that partial save with only lng refreshes lat from DB.
-        
-        Mirror test for updating only longitude.
-        """
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.015137'),
-            location_lng=Decimal('28.979530'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        # Simulate another process updating location_lat in the database
-        Service.objects.filter(pk=service.pk).update(
-            location_lat=Decimal('43.000000')
-        )
-        
-        # Our in-memory service still has the old location_lat
-        self.assertEqual(service.location_lat, Decimal('41.015137'))
-        
-        # Now update only location_lng using update_fields
-        service.location_lng = Decimal('31.000000')
-        service.save(update_fields=['location_lng'])
-        
-        # Refresh from DB and verify location is consistent with BOTH DB values
-        service.refresh_from_db()
-        
-        # location_lat should be the DB value (from "other process")
-        self.assertEqual(service.location_lat, Decimal('43.000000'))
-        
-        # location_lng should be our new value
-        self.assertEqual(service.location_lng, Decimal('31.000000'))
-        
-        # CRITICAL: location PointField should use the FRESH DB values
-        self.assertIsNotNone(service.location)
-        self.assertAlmostEqual(service.location.x, 31.000000, places=5)  # Our updated lng
-        self.assertAlmostEqual(service.location.y, 43.000000, places=5)  # Fresh DB lat
-    
-    def test_partial_save_no_coords_does_not_update_location(self):
-        """Test that partial save without coords doesn't touch location."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Test Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.015137'),
-            location_lng=Decimal('28.979530'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        original_location = service.location
-        
-        # Update unrelated field
-        service.title = 'Updated Title'
-        service.save(update_fields=['title'])
-        
-        # Verify location wasn't touched
-        service.refresh_from_db()
-        self.assertEqual(service.title, 'Updated Title')
-        self.assertEqual(service.location, original_location)
-    
-    def test_new_object_with_coords_computes_location(self):
-        """Test that new objects with coords get location computed."""
-        service = Service(
-            user=self.user,
-            title='New Service',
-            description='A new service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.000000'),
-            location_lng=Decimal('29.000000'),
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        service.save()
-        
-        self.assertIsNotNone(service.location)
-        self.assertAlmostEqual(service.location.x, 29.000000, places=5)
-        self.assertAlmostEqual(service.location.y, 41.000000, places=5)
-    
-    def test_null_coords_results_in_null_location(self):
-        """Test that null coordinates result in null location."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Online Service',
-            description='An online service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            location_lat=None,
-            location_lng=None,
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        self.assertIsNone(service.location)
-    
-    def test_partial_null_coords_results_in_null_location(self):
-        """Test that having only one coordinate results in null location."""
-        service = Service.objects.create(
-            user=self.user,
-            title='Partial Service',
-            description='A service with partial coords',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='In-Person',
-            location_lat=Decimal('41.000000'),
-            location_lng=None,
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        self.assertIsNone(service.location)
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        email='test@test.com',
+        password='testpass123',
+        first_name='Test',
+        last_name='User',
+        timebank_balance=Decimal('10.00'),
+    )
+
+
+@pytest.mark.django_db
+def test_full_save_computes_location(user):
+    service = Service.objects.create(
+        user=user,
+        title='Test Service',
+        description='A test service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.015137'),
+        location_lng=Decimal('28.979530'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    assert service.location is not None
+    assert service.location.x == pytest.approx(28.979530, abs=1e-5)
+    assert service.location.y == pytest.approx(41.015137, abs=1e-5)
+
+
+@pytest.mark.django_db
+def test_partial_save_with_both_coords_computes_location(user):
+    service = Service.objects.create(
+        user=user,
+        title='Test Service',
+        description='A test service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.015137'),
+        location_lng=Decimal('28.979530'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    service.location_lat = Decimal('40.000000')
+    service.location_lng = Decimal('29.000000')
+    service.save(update_fields=['location_lat', 'location_lng'])
+
+    service.refresh_from_db()
+    assert service.location is not None
+    assert service.location.x == pytest.approx(29.000000, abs=1e-5)
+    assert service.location.y == pytest.approx(40.000000, abs=1e-5)
+
+
+@pytest.mark.django_db
+def test_partial_save_single_coord_refreshes_from_db(user):
+    """Race condition test: simulates another process updating location_lng
+    while we only update location_lat."""
+    service = Service.objects.create(
+        user=user,
+        title='Test Service',
+        description='A test service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.015137'),
+        location_lng=Decimal('28.979530'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    Service.objects.filter(pk=service.pk).update(location_lng=Decimal('30.000000'))
+
+    assert service.location_lng == Decimal('28.979530')
+
+    service.location_lat = Decimal('42.000000')
+    service.save(update_fields=['location_lat'])
+
+    service.refresh_from_db()
+
+    assert service.location_lat == Decimal('42.000000')
+    assert service.location_lng == Decimal('30.000000')
+
+    assert service.location is not None
+    assert service.location.x == pytest.approx(30.000000, abs=1e-5)
+    assert service.location.y == pytest.approx(42.000000, abs=1e-5)
+
+
+@pytest.mark.django_db
+def test_partial_save_single_coord_lng_refreshes_lat(user):
+    """Mirror test for updating only longitude."""
+    service = Service.objects.create(
+        user=user,
+        title='Test Service',
+        description='A test service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.015137'),
+        location_lng=Decimal('28.979530'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    Service.objects.filter(pk=service.pk).update(location_lat=Decimal('43.000000'))
+
+    assert service.location_lat == Decimal('41.015137')
+
+    service.location_lng = Decimal('31.000000')
+    service.save(update_fields=['location_lng'])
+
+    service.refresh_from_db()
+
+    assert service.location_lat == Decimal('43.000000')
+    assert service.location_lng == Decimal('31.000000')
+
+    assert service.location is not None
+    assert service.location.x == pytest.approx(31.000000, abs=1e-5)
+    assert service.location.y == pytest.approx(43.000000, abs=1e-5)
+
+
+@pytest.mark.django_db
+def test_partial_save_no_coords_does_not_update_location(user):
+    service = Service.objects.create(
+        user=user,
+        title='Test Service',
+        description='A test service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.015137'),
+        location_lng=Decimal('28.979530'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    original_location = service.location
+
+    service.title = 'Updated Title'
+    service.save(update_fields=['title'])
+
+    service.refresh_from_db()
+    assert service.title == 'Updated Title'
+    assert service.location == original_location
+
+
+@pytest.mark.django_db
+def test_new_object_with_coords_computes_location(user):
+    service = Service(
+        user=user,
+        title='New Service',
+        description='A new service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.000000'),
+        location_lng=Decimal('29.000000'),
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+    service.save()
+
+    assert service.location is not None
+    assert service.location.x == pytest.approx(29.000000, abs=1e-5)
+    assert service.location.y == pytest.approx(41.000000, abs=1e-5)
+
+
+@pytest.mark.django_db
+def test_null_coords_results_in_null_location(user):
+    service = Service.objects.create(
+        user=user,
+        title='Online Service',
+        description='An online service',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='Online',
+        location_lat=None,
+        location_lng=None,
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    assert service.location is None
+
+
+@pytest.mark.django_db
+def test_partial_null_coords_results_in_null_location(user):
+    service = Service.objects.create(
+        user=user,
+        title='Partial Service',
+        description='A service with partial coords',
+        type='Offer',
+        duration=Decimal('2.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.000000'),
+        location_lng=None,
+        max_participants=1,
+        schedule_type='One-Time',
+    )
+
+    assert service.location is None

--- a/backend/api/tests/unit/test_services.py
+++ b/backend/api/tests/unit/test_services.py
@@ -4,379 +4,356 @@ Unit tests for HandshakeService.
 Tests business logic for expressing interest in services, including
 validation for max_participants, balance checks, and duplicate interest prevention.
 """
-from decimal import Decimal
 from datetime import timedelta
-from django.test import TestCase
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from api.models import Service, Handshake, TransactionHistory
+from api.models import Handshake, Service, TransactionHistory
 from api.services import HandshakeService, HandshakeServiceError
 
 User = get_user_model()
 
 
-class HandshakeServiceTestCase(TestCase):
-    """Test cases for HandshakeService."""
-    
-    def setUp(self):
-        """Set up test data."""
-        self.user1 = User.objects.create_user(
-            email='user1@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='One',
-            timebank_balance=Decimal('10.00')
-        )
-        self.user2 = User.objects.create_user(
-            email='user2@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Two',
-            timebank_balance=Decimal('5.00')
-        )
-        self.user3 = User.objects.create_user(
-            email='user3@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Three',
-            timebank_balance=Decimal('3.00')
-        )
-        self.user4 = User.objects.create_user(
-            email='user4@test.com',
-            password='testpass123',
-            first_name='User',
-            last_name='Four',
-            timebank_balance=Decimal('5.00')
-        )
-        
-        self.service_offer = Service.objects.create(
-            user=self.user1,
-            title='Test Offer Service',
-            description='A test service',
-            type='Offer',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=2,
-            schedule_type='One-Time'
-        )
-        
-        self.service_need = Service.objects.create(
-            user=self.user1,
-            title='Test Need Service',
-            description='A test need service',
-            type='Need',
-            duration=Decimal('2.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-    
-    def test_can_express_interest_valid(self):
-        """Test can_express_interest returns True for valid case."""
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user2)
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
-    
-    def test_can_express_interest_own_service(self):
-        """Test cannot express interest in own service."""
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user1)
-        self.assertFalse(is_valid)
-        self.assertIn('own service', error)
-    
-    def test_can_express_interest_insufficient_balance_offer(self):
-        """Test cannot express interest when Offer request would exceed -10h."""
-        self.user2.timebank_balance = Decimal('-9.00')
-        self.user2.save()
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user2)
-        self.assertFalse(is_valid)
-        self.assertIn('Insufficient TimeBank balance', error)
-    
-    def test_can_express_interest_insufficient_balance_need(self):
-        """Test cannot express interest when Need owner is already past the debt floor."""
-        self.user1.timebank_balance = Decimal('-10.01')
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_need, self.user2)
-        self.assertFalse(is_valid)
-        self.assertIn('Insufficient TimeBank balance', error)
+@pytest.fixture
+def env(db):
+    user1 = User.objects.create_user(
+        email='user1@test.com', password='testpass123',
+        first_name='User', last_name='One',
+        timebank_balance=Decimal('10.00'),
+    )
+    user2 = User.objects.create_user(
+        email='user2@test.com', password='testpass123',
+        first_name='User', last_name='Two',
+        timebank_balance=Decimal('5.00'),
+    )
+    user3 = User.objects.create_user(
+        email='user3@test.com', password='testpass123',
+        first_name='User', last_name='Three',
+        timebank_balance=Decimal('3.00'),
+    )
+    user4 = User.objects.create_user(
+        email='user4@test.com', password='testpass123',
+        first_name='User', last_name='Four',
+        timebank_balance=Decimal('5.00'),
+    )
 
-    def test_can_express_interest_allows_offer_debt_within_limit(self):
-        """Offer interest may use available debt as long as projected balance stays >= -10h."""
-        self.user2.timebank_balance = Decimal('-1.00')
-        self.user2.save()
-        self.service_offer.duration = Decimal('6.00')
-        self.service_offer.save(update_fields=['duration'])
+    service_offer = Service.objects.create(
+        user=user1, title='Test Offer Service', description='A test service',
+        type='Offer', duration=Decimal('2.00'), location_type='Online',
+        max_participants=2, schedule_type='One-Time',
+    )
+    service_need = Service.objects.create(
+        user=user1, title='Test Need Service', description='A test need service',
+        type='Need', duration=Decimal('2.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
 
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user2)
+    return SimpleNamespace(
+        user1=user1, user2=user2, user3=user3, user4=user4,
+        service_offer=service_offer, service_need=service_need,
+    )
 
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
 
-    def test_can_express_interest_need_uses_existing_reservation_balance(self):
-        """Need interest checks the already-reserved balance without subtracting duration again."""
-        self.user1.timebank_balance = Decimal('-1.00')
-        self.user1.save()
-        self.service_need.duration = Decimal('6.00')
-        self.service_need.save(update_fields=['duration'])
+@pytest.mark.django_db
+def test_can_express_interest_valid(env):
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user2)
+    assert is_valid
+    assert error is None
 
-        is_valid, error = HandshakeService.can_express_interest(self.service_need, self.user2)
 
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
-    
-    def test_can_express_interest_valid_need(self):
-        """Test can_express_interest returns True for valid Need service case."""
-        self.user1.timebank_balance = Decimal('10.00')
-        self.user1.save()
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_need, self.user2)
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
-    
-    def test_can_express_interest_max_participants(self):
-        """Test cannot express interest when service is at max capacity (accepted slots only)."""
-        # Both slots accepted — capacity reached; pending does NOT count
-        Handshake.objects.create(
-            service=self.service_offer,
-            requester=self.user2,
-            provisioned_hours=Decimal('2.00'),
-            status='accepted'
-        )
-        Handshake.objects.create(
-            service=self.service_offer,
-            requester=self.user3,
-            provisioned_hours=Decimal('2.00'),
-            status='accepted'
-        )
+@pytest.mark.django_db
+def test_can_express_interest_own_service(env):
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user1)
+    assert not is_valid
+    assert 'own service' in error
 
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user4)
-        self.assertFalse(is_valid)
-        self.assertIn('maximum capacity', error)
 
-    def test_pending_does_not_count_toward_capacity_one_time(self):
-        """Pending handshakes must NOT block other users from expressing interest (One-Time)."""
-        # One slot is pending (user2) but capacity uses 'accepted' only → still open
-        Handshake.objects.create(
-            service=self.service_need,   # max_participants=1
-            requester=self.user2,
-            provisioned_hours=Decimal('2.00'),
-            status='pending'
-        )
+@pytest.mark.django_db
+def test_can_express_interest_insufficient_balance_offer(env):
+    env.user2.timebank_balance = Decimal('-9.00')
+    env.user2.save()
 
-        is_valid, error = HandshakeService.can_express_interest(self.service_need, self.user3)
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user2)
+    assert not is_valid
+    assert 'Insufficient TimeBank balance' in error
 
-    def test_one_time_capacity_counts_completed(self):
-        """One-Time services should count completed handshakes toward capacity."""
-        one_time_service = Service.objects.create(
-            user=self.user1,
-            title='One-time capacity test',
-            description='Test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time',
-        )
-        Handshake.objects.create(
-            service=one_time_service,
-            requester=self.user2,
-            provisioned_hours=Decimal('1.00'),
-            status='completed',
-        )
 
-        is_valid, error = HandshakeService.can_express_interest(one_time_service, self.user3)
-        self.assertFalse(is_valid)
-        self.assertIn('maximum capacity', error)
+@pytest.mark.django_db
+def test_can_express_interest_insufficient_balance_need(env):
+    env.user1.timebank_balance = Decimal('-10.01')
 
-    def test_recurrent_capacity_does_not_count_completed(self):
-        """Recurrent services should not count completed handshakes toward capacity."""
-        recurrent_service = Service.objects.create(
-            user=self.user1,
-            title='Recurrent capacity test',
-            description='Test',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='Recurrent',
-        )
-        Handshake.objects.create(
-            service=recurrent_service,
-            requester=self.user2,
-            provisioned_hours=Decimal('1.00'),
-            status='completed',
-        )
+    is_valid, error = HandshakeService.can_express_interest(env.service_need, env.user2)
+    assert not is_valid
+    assert 'Insufficient TimeBank balance' in error
 
-        is_valid, error = HandshakeService.can_express_interest(recurrent_service, self.user3)
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
-    
-    def test_express_interest_success_offer(self):
-        """Test successful express_interest for Offer service."""
-        handshake = HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        self.assertIsNotNone(handshake)
-        self.assertEqual(handshake.service, self.service_offer)
-        self.assertEqual(handshake.requester, self.user2)
-        self.assertEqual(handshake.status, 'pending')
-        self.assertEqual(handshake.provisioned_hours, Decimal('2.00'))
 
-    def test_approve_refetches_locked_handshake_state(self):
-        """A stale pending instance must not approve after another request cancels it."""
-        handshake = Handshake.objects.create(
-            service=self.service_offer,
-            requester=self.user2,
-            provisioned_hours=Decimal('1.00'),
-            status='pending',
-            provider_initiated=True,
-            exact_duration=Decimal('1.00'),
-            scheduled_time=timezone.now() + timedelta(days=1),
-        )
-        stale_pending = Handshake.objects.get(pk=handshake.pk)
-        Handshake.objects.filter(pk=handshake.pk).update(status='cancelled')
+@pytest.mark.django_db
+def test_can_express_interest_allows_offer_debt_within_limit(env):
+    env.user2.timebank_balance = Decimal('-1.00')
+    env.user2.save()
+    env.service_offer.duration = Decimal('6.00')
+    env.service_offer.save(update_fields=['duration'])
 
-        with self.assertRaises(HandshakeServiceError) as context:
-            HandshakeService.approve(stale_pending, self.user2)
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user2)
 
-        self.assertIn('not pending', str(context.exception))
-        handshake.refresh_from_db()
-        self.assertEqual(handshake.status, 'cancelled')
-        self.assertFalse(TransactionHistory.objects.filter(handshake=handshake).exists())
-    
-    def test_express_interest_success_need(self):
-        """Test successful express_interest for Need service."""
-        handshake = HandshakeService.express_interest(self.service_need, self.user2)
-        
-        self.assertIsNotNone(handshake)
-        self.assertEqual(handshake.service, self.service_need)
-        self.assertEqual(handshake.requester, self.user2)
-        self.assertEqual(handshake.status, 'pending')
-        self.assertEqual(handshake.provisioned_hours, Decimal('2.00'))
-    
-    def test_express_interest_duplicate(self):
-        """Test cannot express interest twice."""
-        HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        with self.assertRaises(ValueError) as context:
-            HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        self.assertIn('already expressed interest', str(context.exception))
-    
-    def test_express_interest_max_participants_raises_error(self):
-        """Test express_interest raises ValueError when at max capacity (accepted slot)."""
-        # Capacity is consumed by an ACCEPTED handshake, not pending
-        Handshake.objects.create(
-            service=self.service_need,
-            requester=self.user2,
-            provisioned_hours=Decimal('2.00'),
-            status='accepted'
-        )
+    assert is_valid
+    assert error is None
 
-        with self.assertRaises(ValueError) as context:
-            HandshakeService.express_interest(self.service_need, self.user3)
 
-        self.assertIn('maximum capacity', str(context.exception))
-    
-    def test_express_interest_creates_chat_message(self):
-        """Test that express_interest creates initial chat message."""
-        from api.models import ChatMessage
-        
-        handshake = HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        messages = ChatMessage.objects.filter(handshake=handshake)
-        self.assertEqual(messages.count(), 1)
-        message = messages.first()
-        self.assertIn('interested in your service', message.body)
-        self.assertEqual(message.sender, self.user2)
-        self.assertEqual(message.handshake, handshake)
-    
-    def test_express_interest_creates_notification(self):
-        """Test that express_interest creates notification."""
-        from api.models import Notification
-        
-        handshake = HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        notifications = Notification.objects.filter(
-            user=self.user1,
-            related_handshake=handshake
-        )
-        self.assertEqual(notifications.count(), 1)
-        notification = notifications.first()
-        self.assertEqual(notification.type, 'handshake_request')
-        self.assertEqual(notification.user, self.user1)
-        self.assertEqual(notification.related_handshake, handshake)
-        self.assertEqual(notification.related_service, self.service_offer)
-    
-    def test_can_express_interest_inactive_service(self):
-        """Test cannot express interest in inactive service."""
-        self.service_offer.status = 'Completed'
-        self.service_offer.save()
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user2)
-        self.assertFalse(is_valid)
-        self.assertIn('not active', error)
-    
-    def test_express_interest_inactive_service_raises_error(self):
-        """Test express_interest raises ValueError for inactive service."""
-        self.service_offer.status = 'Cancelled'
-        self.service_offer.save()
-        
-        with self.assertRaises(ValueError) as context:
-            HandshakeService.express_interest(self.service_offer, self.user2)
-        
-        self.assertIn('not active', str(context.exception))
-    
-    def test_payer_determination_offer(self):
-        """Test payer determination for Offer service - requester pays."""
-        self.user2.timebank_balance = Decimal('-9.00')
-        self.user2.save()
-        self.user1.timebank_balance = Decimal('10.00')
-        self.user1.save()
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_offer, self.user2)
-        self.assertFalse(is_valid)
-        self.assertIn('You', error)
-        self.assertIn('Insufficient TimeBank balance', error)
-    
-    def test_payer_determination_need(self):
-        """Test Need interest checks the service owner's reserved balance."""
-        self.user1.timebank_balance = Decimal('-9.00')
-        self.user1.save()
-        self.user2.timebank_balance = Decimal('10.00')
-        self.user2.save()
-        
-        is_valid, error = HandshakeService.can_express_interest(self.service_need, self.user2)
-        self.assertTrue(is_valid)
-        self.assertIsNone(error)
-    
-    def test_lock_ordering_prevents_deadlock(self):
-        """Test that locks are acquired in consistent order to prevent deadlocks."""
-        service_user2 = Service.objects.create(
-            user=self.user2,
-            title='User2 Service',
-            description='A service by user2',
-            type='Offer',
-            duration=Decimal('1.00'),
-            location_type='Online',
-            max_participants=1,
-            schedule_type='One-Time'
-        )
-        
-        self.user1.timebank_balance = Decimal('10.00')
-        self.user1.save()
-        self.user2.timebank_balance = Decimal('10.00')
-        self.user2.save()
-        
-        handshake1 = HandshakeService.express_interest(service_user2, self.user1)
-        self.assertIsNotNone(handshake1)
-        self.assertEqual(handshake1.requester, self.user1)
-        self.assertEqual(handshake1.service, service_user2)
-        
-        handshake2 = HandshakeService.express_interest(self.service_offer, self.user2)
-        self.assertIsNotNone(handshake2)
-        self.assertEqual(handshake2.requester, self.user2)
-        self.assertEqual(handshake2.service, self.service_offer)
+@pytest.mark.django_db
+def test_can_express_interest_need_uses_existing_reservation_balance(env):
+    env.user1.timebank_balance = Decimal('-1.00')
+    env.user1.save()
+    env.service_need.duration = Decimal('6.00')
+    env.service_need.save(update_fields=['duration'])
 
+    is_valid, error = HandshakeService.can_express_interest(env.service_need, env.user2)
+
+    assert is_valid
+    assert error is None
+
+
+@pytest.mark.django_db
+def test_can_express_interest_valid_need(env):
+    env.user1.timebank_balance = Decimal('10.00')
+    env.user1.save()
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_need, env.user2)
+    assert is_valid
+    assert error is None
+
+
+@pytest.mark.django_db
+def test_can_express_interest_max_participants(env):
+    Handshake.objects.create(
+        service=env.service_offer, requester=env.user2,
+        provisioned_hours=Decimal('2.00'), status='accepted',
+    )
+    Handshake.objects.create(
+        service=env.service_offer, requester=env.user3,
+        provisioned_hours=Decimal('2.00'), status='accepted',
+    )
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user4)
+    assert not is_valid
+    assert 'maximum capacity' in error
+
+
+@pytest.mark.django_db
+def test_pending_does_not_count_toward_capacity_one_time(env):
+    Handshake.objects.create(
+        service=env.service_need, requester=env.user2,
+        provisioned_hours=Decimal('2.00'), status='pending',
+    )
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_need, env.user3)
+    assert is_valid
+    assert error is None
+
+
+@pytest.mark.django_db
+def test_one_time_capacity_counts_completed(env):
+    one_time_service = Service.objects.create(
+        user=env.user1, title='One-time capacity test', description='Test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+    Handshake.objects.create(
+        service=one_time_service, requester=env.user2,
+        provisioned_hours=Decimal('1.00'), status='completed',
+    )
+
+    is_valid, error = HandshakeService.can_express_interest(one_time_service, env.user3)
+    assert not is_valid
+    assert 'maximum capacity' in error
+
+
+@pytest.mark.django_db
+def test_recurrent_capacity_does_not_count_completed(env):
+    recurrent_service = Service.objects.create(
+        user=env.user1, title='Recurrent capacity test', description='Test',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        max_participants=1, schedule_type='Recurrent',
+    )
+    Handshake.objects.create(
+        service=recurrent_service, requester=env.user2,
+        provisioned_hours=Decimal('1.00'), status='completed',
+    )
+
+    is_valid, error = HandshakeService.can_express_interest(recurrent_service, env.user3)
+    assert is_valid
+    assert error is None
+
+
+@pytest.mark.django_db
+def test_express_interest_success_offer(env):
+    handshake = HandshakeService.express_interest(env.service_offer, env.user2)
+
+    assert handshake is not None
+    assert handshake.service == env.service_offer
+    assert handshake.requester == env.user2
+    assert handshake.status == 'pending'
+    assert handshake.provisioned_hours == Decimal('2.00')
+
+
+@pytest.mark.django_db
+def test_approve_refetches_locked_handshake_state(env):
+    """A stale pending instance must not approve after another request cancels it."""
+    handshake = Handshake.objects.create(
+        service=env.service_offer, requester=env.user2,
+        provisioned_hours=Decimal('1.00'), status='pending',
+        provider_initiated=True, exact_duration=Decimal('1.00'),
+        scheduled_time=timezone.now() + timedelta(days=1),
+    )
+    stale_pending = Handshake.objects.get(pk=handshake.pk)
+    Handshake.objects.filter(pk=handshake.pk).update(status='cancelled')
+
+    with pytest.raises(HandshakeServiceError) as context:
+        HandshakeService.approve(stale_pending, env.user2)
+
+    assert 'not pending' in str(context.value)
+    handshake.refresh_from_db()
+    assert handshake.status == 'cancelled'
+    assert not TransactionHistory.objects.filter(handshake=handshake).exists()
+
+
+@pytest.mark.django_db
+def test_express_interest_success_need(env):
+    handshake = HandshakeService.express_interest(env.service_need, env.user2)
+
+    assert handshake is not None
+    assert handshake.service == env.service_need
+    assert handshake.requester == env.user2
+    assert handshake.status == 'pending'
+    assert handshake.provisioned_hours == Decimal('2.00')
+
+
+@pytest.mark.django_db
+def test_express_interest_duplicate(env):
+    HandshakeService.express_interest(env.service_offer, env.user2)
+
+    with pytest.raises(ValueError) as context:
+        HandshakeService.express_interest(env.service_offer, env.user2)
+
+    assert 'already expressed interest' in str(context.value)
+
+
+@pytest.mark.django_db
+def test_express_interest_max_participants_raises_error(env):
+    Handshake.objects.create(
+        service=env.service_need, requester=env.user2,
+        provisioned_hours=Decimal('2.00'), status='accepted',
+    )
+
+    with pytest.raises(ValueError) as context:
+        HandshakeService.express_interest(env.service_need, env.user3)
+
+    assert 'maximum capacity' in str(context.value)
+
+
+@pytest.mark.django_db
+def test_express_interest_creates_chat_message(env):
+    from api.models import ChatMessage
+
+    handshake = HandshakeService.express_interest(env.service_offer, env.user2)
+
+    messages = ChatMessage.objects.filter(handshake=handshake)
+    assert messages.count() == 1
+    message = messages.first()
+    assert 'interested in your service' in message.body
+    assert message.sender == env.user2
+    assert message.handshake == handshake
+
+
+@pytest.mark.django_db
+def test_express_interest_creates_notification(env):
+    from api.models import Notification
+
+    handshake = HandshakeService.express_interest(env.service_offer, env.user2)
+
+    notifications = Notification.objects.filter(
+        user=env.user1, related_handshake=handshake,
+    )
+    assert notifications.count() == 1
+    notification = notifications.first()
+    assert notification.type == 'handshake_request'
+    assert notification.user == env.user1
+    assert notification.related_handshake == handshake
+    assert notification.related_service == env.service_offer
+
+
+@pytest.mark.django_db
+def test_can_express_interest_inactive_service(env):
+    env.service_offer.status = 'Completed'
+    env.service_offer.save()
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user2)
+    assert not is_valid
+    assert 'not active' in error
+
+
+@pytest.mark.django_db
+def test_express_interest_inactive_service_raises_error(env):
+    env.service_offer.status = 'Cancelled'
+    env.service_offer.save()
+
+    with pytest.raises(ValueError) as context:
+        HandshakeService.express_interest(env.service_offer, env.user2)
+
+    assert 'not active' in str(context.value)
+
+
+@pytest.mark.django_db
+def test_payer_determination_offer(env):
+    """Offer service - requester pays."""
+    env.user2.timebank_balance = Decimal('-9.00')
+    env.user2.save()
+    env.user1.timebank_balance = Decimal('10.00')
+    env.user1.save()
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_offer, env.user2)
+    assert not is_valid
+    assert 'You' in error
+    assert 'Insufficient TimeBank balance' in error
+
+
+@pytest.mark.django_db
+def test_payer_determination_need(env):
+    """Need interest checks the service owner's reserved balance."""
+    env.user1.timebank_balance = Decimal('-9.00')
+    env.user1.save()
+    env.user2.timebank_balance = Decimal('10.00')
+    env.user2.save()
+
+    is_valid, error = HandshakeService.can_express_interest(env.service_need, env.user2)
+    assert is_valid
+    assert error is None
+
+
+@pytest.mark.django_db
+def test_lock_ordering_prevents_deadlock(env):
+    """Locks are acquired in consistent order to prevent deadlocks."""
+    service_user2 = Service.objects.create(
+        user=env.user2, title='User2 Service', description='A service by user2',
+        type='Offer', duration=Decimal('1.00'), location_type='Online',
+        max_participants=1, schedule_type='One-Time',
+    )
+
+    env.user1.timebank_balance = Decimal('10.00')
+    env.user1.save()
+    env.user2.timebank_balance = Decimal('10.00')
+    env.user2.save()
+
+    handshake1 = HandshakeService.express_interest(service_user2, env.user1)
+    assert handshake1 is not None
+    assert handshake1.requester == env.user1
+    assert handshake1.service == service_user2
+
+    handshake2 = HandshakeService.express_interest(env.service_offer, env.user2)
+    assert handshake2 is not None
+    assert handshake2.requester == env.user2
+    assert handshake2.service == env.service_offer

--- a/backend/api/tests/unit/test_social_proximity.py
+++ b/backend/api/tests/unit/test_social_proximity.py
@@ -13,7 +13,9 @@ Covers:
 - Pending handshake does not count
 """
 from decimal import Decimal
-from django.test import TestCase
+from types import SimpleNamespace
+
+import pytest
 from django.contrib.auth import get_user_model
 
 from api.models import Service, Handshake, UserFollow
@@ -44,88 +46,109 @@ def _make_completed_handshake(provider, requester):
     )
 
 
-class SocialProximityBoostTests(TestCase):
+def _boost(result, user):
+    """Look up boost by UUID key."""
+    return result.get(user.id)
 
-    def setUp(self):
-        self.viewer = _make_user('viewer@test.com')
-        self.u1 = _make_user('u1@test.com')
-        self.u2 = _make_user('u2@test.com')
-        self.u3 = _make_user('u3@test.com')
-        self.stranger = _make_user('stranger@test.com')
 
-    def _boost(self, result, user):
-        """Look up boost by UUID key."""
-        return result.get(user.id)
+@pytest.fixture
+def env(db):
+    return SimpleNamespace(
+        viewer=_make_user('viewer@test.com'),
+        u1=_make_user('u1@test.com'),
+        u2=_make_user('u2@test.com'),
+        u3=_make_user('u3@test.com'),
+        stranger=_make_user('stranger@test.com'),
+    )
 
-    def test_no_viewer_returns_empty(self):
-        result = get_social_proximity_boosts(None)
-        self.assertEqual(result, {})
 
-    def test_no_connections_returns_empty(self):
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertEqual(result, {})
+@pytest.mark.django_db
+def test_no_viewer_returns_empty():
+    result = get_social_proximity_boosts(None)
+    assert result == {}
 
-    def test_first_degree_via_follow(self):
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u1), 1.0)
 
-    def test_first_degree_via_completed_handshake_as_requester(self):
-        _make_completed_handshake(provider=self.u1, requester=self.viewer)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u1), 1.0)
+@pytest.mark.django_db
+def test_no_connections_returns_empty(env):
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert result == {}
 
-    def test_first_degree_via_completed_handshake_as_provider(self):
-        _make_completed_handshake(provider=self.viewer, requester=self.u1)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u1), 1.0)
 
-    def test_second_degree_via_follow_chain(self):
-        # viewer -> u1 -> u2
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        UserFollow.objects.create(follower=self.u1, following=self.u2)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u2), 0.5)
+@pytest.mark.django_db
+def test_first_degree_via_follow(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) == pytest.approx(1.0)
 
-    def test_second_degree_via_transaction_chain(self):
-        # viewer -[completed]- u1 -[completed]- u2
-        _make_completed_handshake(provider=self.u1, requester=self.viewer)
-        _make_completed_handshake(provider=self.u1, requester=self.u2)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u2), 0.5)
 
-    def test_first_degree_takes_precedence_over_second(self):
-        # u1 is directly followed AND reachable via u2 (2nd-degree path)
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        UserFollow.objects.create(follower=self.viewer, following=self.u2)
-        UserFollow.objects.create(follower=self.u2, following=self.u1)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u1), 1.0)
+@pytest.mark.django_db
+def test_first_degree_via_completed_handshake_as_requester(env):
+    _make_completed_handshake(provider=env.u1, requester=env.viewer)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) == pytest.approx(1.0)
 
-    def test_stranger_has_no_entry(self):
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertIsNone(self._boost(result, self.stranger))
 
-    def test_viewer_excluded_from_own_results(self):
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertIsNone(self._boost(result, self.viewer))
+@pytest.mark.django_db
+def test_first_degree_via_completed_handshake_as_provider(env):
+    _make_completed_handshake(provider=env.viewer, requester=env.u1)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) == pytest.approx(1.0)
 
-    def test_pending_handshake_does_not_count(self):
-        svc = _make_service(self.u1)
-        Handshake.objects.create(
-            service=svc, requester=self.viewer,
-            status='pending', provisioned_hours=Decimal('1.00'),
-        )
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertIsNone(self._boost(result, self.u1))
 
-    def test_multiple_paths_do_not_duplicate_entries(self):
-        # u1 is reachable via two 1st-degree paths (follow + handshake)
-        UserFollow.objects.create(follower=self.viewer, following=self.u1)
-        _make_completed_handshake(provider=self.u1, requester=self.viewer)
-        result = get_social_proximity_boosts(self.viewer.id)
-        self.assertAlmostEqual(self._boost(result, self.u1), 1.0)
-        # Only one entry, not two
-        self.assertEqual(list(result.values()).count(1.0), 1)
+@pytest.mark.django_db
+def test_second_degree_via_follow_chain(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    UserFollow.objects.create(follower=env.u1, following=env.u2)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u2) == pytest.approx(0.5)
+
+
+@pytest.mark.django_db
+def test_second_degree_via_transaction_chain(env):
+    _make_completed_handshake(provider=env.u1, requester=env.viewer)
+    _make_completed_handshake(provider=env.u1, requester=env.u2)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u2) == pytest.approx(0.5)
+
+
+@pytest.mark.django_db
+def test_first_degree_takes_precedence_over_second(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    UserFollow.objects.create(follower=env.viewer, following=env.u2)
+    UserFollow.objects.create(follower=env.u2, following=env.u1)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) == pytest.approx(1.0)
+
+
+@pytest.mark.django_db
+def test_stranger_has_no_entry(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.stranger) is None
+
+
+@pytest.mark.django_db
+def test_viewer_excluded_from_own_results(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.viewer) is None
+
+
+@pytest.mark.django_db
+def test_pending_handshake_does_not_count(env):
+    svc = _make_service(env.u1)
+    Handshake.objects.create(
+        service=svc, requester=env.viewer,
+        status='pending', provisioned_hours=Decimal('1.00'),
+    )
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) is None
+
+
+@pytest.mark.django_db
+def test_multiple_paths_do_not_duplicate_entries(env):
+    UserFollow.objects.create(follower=env.viewer, following=env.u1)
+    _make_completed_handshake(provider=env.u1, requester=env.viewer)
+    result = get_social_proximity_boosts(env.viewer.id)
+    assert _boost(result, env.u1) == pytest.approx(1.0)
+    assert list(result.values()).count(1.0) == 1

--- a/backend/api/tests/unit/test_wikidata.py
+++ b/backend/api/tests/unit/test_wikidata.py
@@ -1,396 +1,352 @@
 """
 Tests for Wikidata integration - search endpoint and tag handling
 """
-from django.test import TestCase
-from django.urls import reverse
-from rest_framework.test import APITestCase, APIClient
-from rest_framework import status
-from unittest.mock import patch, MagicMock
 from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-from api.models import User, Tag, Service
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from api.models import Service, Tag, User
 from api.serializers import TagSerializer
-from api.wikidata import search_wikidata_items, fetch_wikidata_item
+from api.wikidata import fetch_wikidata_item, search_wikidata_items
 
 
-class WikidataSearchViewTests(APITestCase):
-    """Tests for the /api/wikidata/search/ endpoint"""
+@pytest.fixture
+def search_env():
+    return SimpleNamespace(client=APIClient(), url=reverse('wikidata-search'))
 
-    def setUp(self):
-        self.client = APIClient()
-        self.url = reverse('wikidata-search')
 
-    @patch('api.wikidata.classify_and_filter_results', side_effect=lambda r: r)
-    @patch('api.wikidata.search_wikidata_items')
-    def test_wikidata_search_success(self, mock_search, _mock_classify):
-        """Test successful Wikidata search returns QID, label, and description"""
-        mock_search.return_value = [
-            {
-                'id': 'Q28865',
-                'label': 'Python',
-                'description': 'high-level programming language'
-            },
-            {
-                'id': 'Q81',
-                'label': 'Python',
-                'description': 'genus of reptiles'
-            }
+@pytest.mark.django_db
+@patch('api.wikidata.classify_and_filter_results', side_effect=lambda r: r)
+@patch('api.wikidata.search_wikidata_items')
+def test_wikidata_search_success(mock_search, _mock_classify, search_env):
+    mock_search.return_value = [
+        {'id': 'Q28865', 'label': 'Python', 'description': 'high-level programming language'},
+        {'id': 'Q81', 'label': 'Python', 'description': 'genus of reptiles'},
+    ]
+
+    response = search_env.client.get(search_env.url, {'q': 'python'})
+
+    assert response.status_code == 200
+    assert len(response.data) == 2
+    assert response.data[0]['id'] == 'Q28865'
+    assert response.data[0]['label'] == 'Python'
+    mock_search.assert_called_once_with('python', limit=10)
+
+
+@pytest.mark.django_db
+def test_wikidata_search_empty_query(search_env):
+    response = search_env.client.get(search_env.url, {'q': ''})
+    assert response.status_code == 400
+
+    response = search_env.client.get(search_env.url, {'q': '   '})
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_wikidata_search_missing_query(search_env):
+    response = search_env.client.get(search_env.url)
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.search_wikidata_items')
+def test_wikidata_search_api_failure(mock_search, search_env):
+    mock_search.return_value = []
+    response = search_env.client.get(search_env.url, {'q': 'nonexistent12345'})
+    assert response.status_code == 200
+    assert response.data == []
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.search_wikidata_items')
+def test_wikidata_search_with_limit(mock_search, search_env):
+    mock_search.return_value = []
+    response = search_env.client.get(search_env.url, {'q': 'python', 'limit': '5'})
+    assert response.status_code == 200
+    mock_search.assert_called_once_with('python', limit=5)
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.search_wikidata_items')
+def test_wikidata_search_limit_clamped(mock_search, search_env):
+    mock_search.return_value = []
+
+    search_env.client.get(search_env.url, {'q': 'python', 'limit': '100'})
+    mock_search.assert_called_with('python', limit=20)
+
+    search_env.client.get(search_env.url, {'q': 'python', 'limit': '0'})
+    mock_search.assert_called_with('python', limit=1)
+
+    search_env.client.get(search_env.url, {'q': 'python', 'limit': 'invalid'})
+    mock_search.assert_called_with('python', limit=10)
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_search_wikidata_items_success(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'search': [
+            {'id': 'Q28865', 'label': 'Python', 'description': 'high-level programming language'},
         ]
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
 
-        response = self.client.get(self.url, {'q': 'python'})
+    results = search_wikidata_items('python', limit=5)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]['id'], 'Q28865')
-        self.assertEqual(response.data[0]['label'], 'Python')
-        self.assertEqual(response.data[0]['description'], 'high-level programming language')
-        mock_search.assert_called_once_with('python', limit=10)
-
-    def test_wikidata_search_empty_query(self):
-        """Test that empty query returns 400 error"""
-        response = self.client.get(self.url, {'q': ''})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.get(self.url, {'q': '   '})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_wikidata_search_missing_query(self):
-        """Test that missing query parameter returns 400 error"""
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    @patch('api.wikidata.search_wikidata_items')
-    def test_wikidata_search_api_failure(self, mock_search):
-        """Test that API failure returns empty list gracefully"""
-        mock_search.return_value = []
-
-        response = self.client.get(self.url, {'q': 'nonexistent12345'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])
-
-    @patch('api.wikidata.search_wikidata_items')
-    def test_wikidata_search_with_limit(self, mock_search):
-        """Test that limit parameter is passed correctly"""
-        mock_search.return_value = []
-
-        response = self.client.get(self.url, {'q': 'python', 'limit': '5'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_search.assert_called_once_with('python', limit=5)
-
-    @patch('api.wikidata.search_wikidata_items')
-    def test_wikidata_search_limit_clamped(self, mock_search):
-        """Test that limit is clamped between 1 and 20"""
-        mock_search.return_value = []
-
-        response = self.client.get(self.url, {'q': 'python', 'limit': '100'})
-        mock_search.assert_called_with('python', limit=20)
-
-        response = self.client.get(self.url, {'q': 'python', 'limit': '0'})
-        mock_search.assert_called_with('python', limit=1)
-
-        response = self.client.get(self.url, {'q': 'python', 'limit': 'invalid'})
-        mock_search.assert_called_with('python', limit=10)
+    assert len(results) == 1
+    assert results[0]['id'] == 'Q28865'
+    assert results[0]['label'] == 'Python'
 
 
-class WikidataUtilityTests(TestCase):
-    """Tests for the wikidata.py utility functions"""
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_search_wikidata_items_api_error(mock_get):
+    import requests as req
+    mock_get.side_effect = req.RequestException('API Error')
 
-    @patch('api.wikidata.requests.get')
-    def test_search_wikidata_items_success(self, mock_get):
-        """Test search_wikidata_items returns properly formatted results"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            'search': [
-                {
-                    'id': 'Q28865',
-                    'label': 'Python',
-                    'description': 'high-level programming language'
-                }
-            ]
-        }
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    results = search_wikidata_items('python')
 
-        results = search_wikidata_items('python', limit=5)
+    assert results == []
 
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['id'], 'Q28865')
-        self.assertEqual(results[0]['label'], 'Python')
 
-    @patch('api.wikidata.requests.get')
-    def test_search_wikidata_items_api_error(self, mock_get):
-        """Test search_wikidata_items returns empty list on API error"""
-        import requests as req
-        mock_get.side_effect = req.RequestException('API Error')
-
-        results = search_wikidata_items('python')
-
-        self.assertEqual(results, [])
-
-    @patch('api.wikidata.requests.get')
-    def test_fetch_wikidata_item_success(self, mock_get):
-        """Test fetch_wikidata_item returns item details"""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            'entities': {
-                'Q28865': {
-                    'labels': {'en': {'value': 'Python'}},
-                    'descriptions': {'en': {'value': 'high-level programming language'}},
-                    'aliases': {'en': [{'value': 'Python programming language'}]}
-                }
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_item_success(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'entities': {
+            'Q28865': {
+                'labels': {'en': {'value': 'Python'}},
+                'descriptions': {'en': {'value': 'high-level programming language'}},
+                'aliases': {'en': [{'value': 'Python programming language'}]},
             }
         }
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
 
-        result = fetch_wikidata_item('Q28865')
+    result = fetch_wikidata_item('Q28865')
 
-        self.assertIsNotNone(result)
-        self.assertEqual(result['id'], 'Q28865')
-        self.assertEqual(result['label'], 'Python')
-        self.assertEqual(result['description'], 'high-level programming language')
+    assert result is not None
+    assert result['id'] == 'Q28865'
+    assert result['label'] == 'Python'
+    assert result['description'] == 'high-level programming language'
 
-    @patch('api.wikidata.requests.get')
-    def test_fetch_wikidata_item_normalizes_lowercase_qid(self, mock_get):
-        """Test lowercase qid input is normalized and fetched correctly."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            'entities': {
-                'Q17195715': {
-                    'labels': {'en': {'value': 'Yoga'}},
-                    'descriptions': {'en': {'value': 'group of physical, mental, and spiritual practices'}},
-                    'aliases': {'en': []}
-                }
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_item_normalizes_lowercase_qid(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'entities': {
+            'Q17195715': {
+                'labels': {'en': {'value': 'Yoga'}},
+                'descriptions': {'en': {'value': 'group of physical, mental, and spiritual practices'}},
+                'aliases': {'en': []},
             }
         }
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
 
-        result = fetch_wikidata_item('q17195715')
+    result = fetch_wikidata_item('q17195715')
 
-        self.assertIsNotNone(result)
-        self.assertEqual(result['id'], 'Q17195715')
-        self.assertEqual(result['label'], 'Yoga')
-
-    def test_fetch_wikidata_item_invalid_id(self):
-        """Test fetch_wikidata_item returns None for invalid ID"""
-        result = fetch_wikidata_item('invalid')
-        self.assertIsNone(result)
-
-        result = fetch_wikidata_item('')
-        self.assertIsNone(result)
-
-        result = fetch_wikidata_item(None)
-        self.assertIsNone(result)
+    assert result is not None
+    assert result['id'] == 'Q17195715'
+    assert result['label'] == 'Yoga'
 
 
-class TagWithWikidataTests(APITestCase):
-    """Tests for tag creation and serialization with Wikidata QIDs"""
-
-    def setUp(self):
-        self.user = User.objects.create_user(
-            email='test@example.com',
-            password='testpass123',
-            first_name='Test',
-            last_name='User',
-            timebank_balance=Decimal('10.00'),
-            is_verified=True,
-        )
-        self.client = APIClient()
-        self.client.force_authenticate(user=self.user)
-
-    def test_tag_creation_with_qid(self):
-        """Test that tags can be created with Wikidata QID as ID"""
-        tag = Tag.objects.create(
-            id='Q28865',
-            name='Python'
-        )
-
-        self.assertEqual(tag.id, 'Q28865')
-        self.assertEqual(tag.name, 'Python')
-
-    def test_tag_creation_preserves_qid_format(self):
-        """Test that QID format is preserved in database"""
-        tag = Tag.objects.create(
-            id='Q12345678',
-            name='Some Concept'
-        )
-
-        retrieved_tag = Tag.objects.get(id='Q12345678')
-        self.assertEqual(retrieved_tag.id, 'Q12345678')
-
-    @patch('api.wikidata.fetch_wikidata_item')
-    def test_tag_serializer_wikidata_enrichment(self, mock_fetch):
-        """Test that TagSerializer enriches tags with Wikidata info when ID starts with Q"""
-        mock_fetch.return_value = {
-            'id': 'Q28865',
-            'label': 'Python',
-            'description': 'high-level programming language',
-            'aliases': ['Python programming language']
-        }
-
-        tag = Tag.objects.create(id='Q28865', name='Python')
-        serializer = TagSerializer(tag)
-
-        self.assertIn('wikidata_info', serializer.data)
-        self.assertEqual(serializer.data['wikidata_info']['label'], 'Python')
-        mock_fetch.assert_called_once_with('Q28865')
-
-    @patch('api.wikidata.fetch_wikidata_item')
-    def test_tag_serializer_uses_wikidata_label_when_name_is_qid(self, mock_fetch):
-        """Display label instead of QID when tag name was saved as fallback."""
-        mock_fetch.return_value = {
-            'id': 'Q17195715',
-            'label': 'Yoga',
-            'description': 'group of physical, mental, and spiritual practices',
-            'aliases': []
-        }
-
-        tag = Tag.objects.create(id='Q17195715', name='Q17195715')
-        serializer = TagSerializer(tag)
-
-        self.assertEqual(serializer.data['name'], 'Yoga')
-        self.assertEqual(serializer.data['wikidata_info']['label'], 'Yoga')
-        mock_fetch.assert_called_once_with('Q17195715')
-
-    def test_tag_serializer_no_enrichment_for_non_qid(self):
-        """Test that TagSerializer does not enrich non-QID tags"""
-        tag = Tag.objects.create(id='cooking', name='Cooking')
-        serializer = TagSerializer(tag)
-
-        self.assertIsNone(serializer.data['wikidata_info'])
-
-    def test_service_creation_with_wikidata_tags(self):
-        """Test that services can be created with Wikidata-based tags"""
-        tag = Tag.objects.create(id='Q28865', name='Python')
-
-        response = self.client.post('/api/services/', {
-            'title': 'Python Tutoring',
-            'description': 'Learn Python programming',
-            'type': 'Offer',
-            'duration': 2,
-            'location_type': 'Online',
-            'max_participants': 1,
-            'schedule_type': 'One-Time',
-            'tag_ids': ['Q28865']
-        })
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        
-        service = Service.objects.get(id=response.data['id'])
-        self.assertEqual(service.tags.count(), 1)
-        self.assertEqual(service.tags.first().id, 'Q28865')
-
-    @patch('api.wikidata.fetch_wikidata_item')
-    def test_service_creation_auto_creates_wikidata_tag(self, mock_fetch):
-        """Test that Wikidata tags are auto-created when they don't exist in DB."""
-        self.assertFalse(Tag.objects.filter(id='Q2005').exists())
-        
-        mock_fetch.return_value = {
-            'id': 'Q2005',
-            'label': 'JavaScript',
-            'description': 'high-level programming language'
-        }
-
-        response = self.client.post('/api/services/', {
-            'title': 'JavaScript Tutoring',
-            'description': 'Learn JavaScript programming',
-            'type': 'Offer',
-            'duration': 2,
-            'location_type': 'Online',
-            'max_participants': 1,
-            'schedule_type': 'One-Time',
-            'tag_ids': ['Q2005']
-        })
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        
-        self.assertTrue(Tag.objects.filter(id='Q2005').exists())
-        tag = Tag.objects.get(id='Q2005')
-        self.assertEqual(tag.name, 'JavaScript')
-        
-        service = Service.objects.get(id=response.data['id'])
-        self.assertEqual(service.tags.count(), 1)
-        self.assertEqual(service.tags.first().id, 'Q2005')
-        
-        mock_fetch.assert_any_call('Q2005')
-
-    @patch('api.wikidata.fetch_wikidata_item')
-    def test_service_creation_handles_wikidata_api_failure(self, mock_fetch):
-        """Test that service creation succeeds even if Wikidata API fails."""
-        self.assertFalse(Tag.objects.filter(id='Q99999').exists())
-        
-        mock_fetch.return_value = None
-
-        response = self.client.post('/api/services/', {
-            'title': 'Mystery Topic Tutoring',
-            'description': 'Learn something mysterious',
-            'type': 'Offer',
-            'duration': 1,
-            'location_type': 'Online',
-            'max_participants': 1,
-            'schedule_type': 'One-Time',
-            'tag_ids': ['Q99999']
-        })
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        
-        self.assertTrue(Tag.objects.filter(id='Q99999').exists())
-        tag = Tag.objects.get(id='Q99999')
-        self.assertEqual(tag.name, 'Q99999')
-        
-        service = Service.objects.get(id=response.data['id'])
-        self.assertEqual(service.tags.count(), 1)
-
-    @patch('api.wikidata.fetch_wikidata_item')
-    def test_service_creation_with_mixed_existing_and_new_qids(self, mock_fetch):
-        """Test creating a service with both existing and new Wikidata tags."""
-        Tag.objects.create(id='Q28865', name='Python')
-        
-        self.assertFalse(Tag.objects.filter(id='Q2005').exists())
-        
-        mock_fetch.return_value = {
-            'id': 'Q2005',
-            'label': 'JavaScript',
-            'description': 'high-level programming language'
-        }
-
-        response = self.client.post('/api/services/', {
-            'title': 'Web Development Tutoring',
-            'description': 'Learn Python and JavaScript',
-            'type': 'Offer',
-            'duration': 3,
-            'location_type': 'Online',
-            'max_participants': 2,
-            'schedule_type': 'Recurrent',
-            'tag_ids': ['Q28865', 'Q2005']
-        })
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        
-        service = Service.objects.get(id=response.data['id'])
-        self.assertEqual(service.tags.count(), 2)
-        tag_ids = set(service.tags.values_list('id', flat=True))
-        self.assertEqual(tag_ids, {'Q28865', 'Q2005'})
-        
-        mock_fetch.assert_any_call('Q2005')
+@pytest.mark.django_db
+def test_fetch_wikidata_item_invalid_id():
+    assert fetch_wikidata_item('invalid') is None
+    assert fetch_wikidata_item('') is None
+    assert fetch_wikidata_item(None) is None
 
 
-class WikidataSearchRateLimitTests(APITestCase):
-    """Tests for rate limiting on Wikidata search endpoint"""
+@pytest.fixture
+def auth_env(db):
+    user = User.objects.create_user(
+        email='test@example.com', password='testpass123',
+        first_name='Test', last_name='User',
+        timebank_balance=Decimal('10.00'), is_verified=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return SimpleNamespace(user=user, client=client)
 
-    def setUp(self):
-        self.client = APIClient()
-        self.url = reverse('wikidata-search')
 
-    @patch('api.wikidata.search_wikidata_items')
-    def test_wikidata_search_allows_normal_usage(self, mock_search):
-        """Test that normal usage is not rate limited"""
-        mock_search.return_value = []
+@pytest.mark.django_db
+def test_tag_creation_with_qid():
+    tag = Tag.objects.create(id='Q28865', name='Python')
+    assert tag.id == 'Q28865'
+    assert tag.name == 'Python'
 
-        for _ in range(5):
-            response = self.client.get(self.url, {'q': 'test'})
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+@pytest.mark.django_db
+def test_tag_creation_preserves_qid_format():
+    Tag.objects.create(id='Q12345678', name='Some Concept')
+    retrieved_tag = Tag.objects.get(id='Q12345678')
+    assert retrieved_tag.id == 'Q12345678'
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_item')
+def test_tag_serializer_wikidata_enrichment(mock_fetch):
+    mock_fetch.return_value = {
+        'id': 'Q28865', 'label': 'Python',
+        'description': 'high-level programming language',
+        'aliases': ['Python programming language'],
+    }
+
+    tag = Tag.objects.create(id='Q28865', name='Python')
+    serializer = TagSerializer(tag)
+
+    assert 'wikidata_info' in serializer.data
+    assert serializer.data['wikidata_info']['label'] == 'Python'
+    mock_fetch.assert_called_once_with('Q28865')
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_item')
+def test_tag_serializer_uses_wikidata_label_when_name_is_qid(mock_fetch):
+    mock_fetch.return_value = {
+        'id': 'Q17195715', 'label': 'Yoga',
+        'description': 'group of physical, mental, and spiritual practices',
+        'aliases': [],
+    }
+
+    tag = Tag.objects.create(id='Q17195715', name='Q17195715')
+    serializer = TagSerializer(tag)
+
+    assert serializer.data['name'] == 'Yoga'
+    assert serializer.data['wikidata_info']['label'] == 'Yoga'
+    mock_fetch.assert_called_once_with('Q17195715')
+
+
+@pytest.mark.django_db
+def test_tag_serializer_no_enrichment_for_non_qid():
+    tag = Tag.objects.create(id='cooking', name='Cooking')
+    serializer = TagSerializer(tag)
+    assert serializer.data['wikidata_info'] is None
+
+
+@pytest.mark.django_db
+def test_service_creation_with_wikidata_tags(auth_env):
+    Tag.objects.create(id='Q28865', name='Python')
+
+    response = auth_env.client.post('/api/services/', {
+        'title': 'Python Tutoring',
+        'description': 'Learn Python programming',
+        'type': 'Offer', 'duration': 2,
+        'location_type': 'Online',
+        'max_participants': 1, 'schedule_type': 'One-Time',
+        'tag_ids': ['Q28865'],
+    })
+
+    assert response.status_code == 201
+    service = Service.objects.get(id=response.data['id'])
+    assert service.tags.count() == 1
+    assert service.tags.first().id == 'Q28865'
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_item')
+def test_service_creation_auto_creates_wikidata_tag(mock_fetch, auth_env):
+    assert not Tag.objects.filter(id='Q2005').exists()
+
+    mock_fetch.return_value = {
+        'id': 'Q2005', 'label': 'JavaScript',
+        'description': 'high-level programming language',
+    }
+
+    response = auth_env.client.post('/api/services/', {
+        'title': 'JavaScript Tutoring',
+        'description': 'Learn JavaScript programming',
+        'type': 'Offer', 'duration': 2,
+        'location_type': 'Online',
+        'max_participants': 1, 'schedule_type': 'One-Time',
+        'tag_ids': ['Q2005'],
+    })
+
+    assert response.status_code == 201
+    assert Tag.objects.filter(id='Q2005').exists()
+    tag = Tag.objects.get(id='Q2005')
+    assert tag.name == 'JavaScript'
+
+    service = Service.objects.get(id=response.data['id'])
+    assert service.tags.count() == 1
+    assert service.tags.first().id == 'Q2005'
+
+    mock_fetch.assert_any_call('Q2005')
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_item')
+def test_service_creation_handles_wikidata_api_failure(mock_fetch, auth_env):
+    assert not Tag.objects.filter(id='Q99999').exists()
+
+    mock_fetch.return_value = None
+
+    response = auth_env.client.post('/api/services/', {
+        'title': 'Mystery Topic Tutoring',
+        'description': 'Learn something mysterious',
+        'type': 'Offer', 'duration': 1,
+        'location_type': 'Online',
+        'max_participants': 1, 'schedule_type': 'One-Time',
+        'tag_ids': ['Q99999'],
+    })
+
+    assert response.status_code == 201
+    assert Tag.objects.filter(id='Q99999').exists()
+    tag = Tag.objects.get(id='Q99999')
+    assert tag.name == 'Q99999'
+
+    service = Service.objects.get(id=response.data['id'])
+    assert service.tags.count() == 1
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_item')
+def test_service_creation_with_mixed_existing_and_new_qids(mock_fetch, auth_env):
+    Tag.objects.create(id='Q28865', name='Python')
+
+    assert not Tag.objects.filter(id='Q2005').exists()
+
+    mock_fetch.return_value = {
+        'id': 'Q2005', 'label': 'JavaScript',
+        'description': 'high-level programming language',
+    }
+
+    response = auth_env.client.post('/api/services/', {
+        'title': 'Web Development Tutoring',
+        'description': 'Learn Python and JavaScript',
+        'type': 'Offer', 'duration': 3,
+        'location_type': 'Online',
+        'max_participants': 2, 'schedule_type': 'Recurrent',
+        'tag_ids': ['Q28865', 'Q2005'],
+    })
+
+    assert response.status_code == 201
+    service = Service.objects.get(id=response.data['id'])
+    assert service.tags.count() == 2
+    tag_ids = set(service.tags.values_list('id', flat=True))
+    assert tag_ids == {'Q28865', 'Q2005'}
+
+    mock_fetch.assert_any_call('Q2005')
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.search_wikidata_items')
+def test_wikidata_search_allows_normal_usage(mock_search, search_env):
+    """Normal usage is not rate limited."""
+    mock_search.return_value = []
+
+    for _ in range(5):
+        response = search_env.client.get(search_env.url, {'q': 'test'})
+        assert response.status_code == 200

--- a/backend/api/tests/unit/test_wikidata_filtering.py
+++ b/backend/api/tests/unit/test_wikidata_filtering.py
@@ -4,139 +4,135 @@ Tests for WikiData autocomplete entity-type filtering.
 Phase 3 tests — verify that search results are filtered to allowed entity types
 and that the WikidataSearchView returns entity_type in responses.
 """
-from django.test import TestCase
+from unittest.mock import patch
+
+import pytest
 from django.urls import reverse
-from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
-from unittest.mock import patch, MagicMock
+from rest_framework.test import APIClient
 
 from api.wikidata import classify_and_filter_results
 
 
-class ClassifyAndFilterResultsTestCase(TestCase):
-    """Tests for classify_and_filter_results()."""
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_allows_programming_languages(mock_claims):
+    """P31=Q9143 (programming language) passes filter."""
+    mock_claims.return_value = {'instance_of': ['Q9143'], 'subclass_of': []}
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_allows_programming_languages(self, mock_claims):
-        """P31=Q9143 (programming language) passes filter."""
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
+    results = [{'id': 'Q28865', 'label': 'Python', 'description': 'programming language'}]
+    filtered = classify_and_filter_results(results)
 
-        results = [{'id': 'Q28865', 'label': 'Python', 'description': 'programming language'}]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]['entity_type'], 'technology')
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_allows_skills(self, mock_claims):
-        """P31=Q205961 (skill) passes filter."""
-        mock_claims.return_value = {
-            'instance_of': ['Q205961'],
-            'subclass_of': [],
-        }
-
-        results = [{'id': 'Q123', 'label': 'Juggling', 'description': 'a skill'}]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]['entity_type'], 'activity')
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_blocks_places(self, mock_claims):
-        """P31=Q515 (city) is filtered out."""
-        mock_claims.return_value = {
-            'instance_of': ['Q515'],
-            'subclass_of': [],
-        }
-
-        results = [{'id': 'Q84', 'label': 'London', 'description': 'capital of England'}]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 0)
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_blocks_people(self, mock_claims):
-        """P31=Q5 (human) is filtered out."""
-        mock_claims.return_value = {
-            'instance_of': ['Q5'],
-            'subclass_of': [],
-        }
-
-        results = [{'id': 'Q937', 'label': 'Albert Einstein', 'description': 'physicist'}]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 0)
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_blocks_countries(self, mock_claims):
-        """P31=Q6256 (country) is filtered out."""
-        mock_claims.return_value = {
-            'instance_of': ['Q6256'],
-            'subclass_of': [],
-        }
-
-        results = [{'id': 'Q30', 'label': 'United States', 'description': 'country'}]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 0)
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_allows_unknown_on_api_failure(self, mock_claims):
-        """When P31 fetch fails, include the result (fail open for UX)."""
-        mock_claims.return_value = None
-
-        results = [{'id': 'Q999', 'label': 'Something', 'description': 'unknown'}]
-        filtered = classify_and_filter_results(results)
-
-        # Fail open: include with entity_type=None
-        self.assertEqual(len(filtered), 1)
-        self.assertIsNone(filtered[0].get('entity_type'))
-
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_mixed_results(self, mock_claims):
-        """Mix of allowed and blocked types filters correctly."""
-        def side_effect(qid):
-            if qid == 'Q28865':
-                return {'instance_of': ['Q9143'], 'subclass_of': []}
-            elif qid == 'Q84':
-                return {'instance_of': ['Q515'], 'subclass_of': []}
-            return None
-
-        mock_claims.side_effect = side_effect
-
-        results = [
-            {'id': 'Q28865', 'label': 'Python', 'description': 'programming language'},
-            {'id': 'Q84', 'label': 'London', 'description': 'capital of England'},
-        ]
-        filtered = classify_and_filter_results(results)
-
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]['id'], 'Q28865')
+    assert len(filtered) == 1
+    assert filtered[0]['entity_type'] == 'technology'
 
 
-class WikidataSearchViewEntityTypeTests(APITestCase):
-    """Test WikidataSearchView returns entity_type in response."""
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_allows_skills(mock_claims):
+    """P31=Q205961 (skill) passes filter."""
+    mock_claims.return_value = {'instance_of': ['Q205961'], 'subclass_of': []}
 
-    def setUp(self):
-        self.client = APIClient()
-        self.url = reverse('wikidata-search')
+    results = [{'id': 'Q123', 'label': 'Juggling', 'description': 'a skill'}]
+    filtered = classify_and_filter_results(results)
 
-    @patch('api.wikidata.classify_and_filter_results')
-    @patch('api.wikidata.search_wikidata_items')
-    def test_returns_entity_type_in_response(self, mock_search, mock_classify):
-        """Response includes entity_type for each result."""
-        mock_search.return_value = [
-            {'id': 'Q28865', 'label': 'Python', 'description': 'programming language'},
-        ]
-        mock_classify.return_value = [
-            {'id': 'Q28865', 'label': 'Python', 'description': 'programming language', 'entity_type': 'technology'},
-        ]
+    assert len(filtered) == 1
+    assert filtered[0]['entity_type'] == 'activity'
 
-        response = self.client.get(self.url, {'q': 'python'})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['entity_type'], 'technology')
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_blocks_places(mock_claims):
+    """P31=Q515 (city) is filtered out."""
+    mock_claims.return_value = {'instance_of': ['Q515'], 'subclass_of': []}
+
+    results = [{'id': 'Q84', 'label': 'London', 'description': 'capital of England'}]
+    filtered = classify_and_filter_results(results)
+
+    assert len(filtered) == 0
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_blocks_people(mock_claims):
+    """P31=Q5 (human) is filtered out."""
+    mock_claims.return_value = {'instance_of': ['Q5'], 'subclass_of': []}
+
+    results = [{'id': 'Q937', 'label': 'Albert Einstein', 'description': 'physicist'}]
+    filtered = classify_and_filter_results(results)
+
+    assert len(filtered) == 0
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_blocks_countries(mock_claims):
+    """P31=Q6256 (country) is filtered out."""
+    mock_claims.return_value = {'instance_of': ['Q6256'], 'subclass_of': []}
+
+    results = [{'id': 'Q30', 'label': 'United States', 'description': 'country'}]
+    filtered = classify_and_filter_results(results)
+
+    assert len(filtered) == 0
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_allows_unknown_on_api_failure(mock_claims):
+    """When P31 fetch fails, include the result (fail open for UX)."""
+    mock_claims.return_value = None
+
+    results = [{'id': 'Q999', 'label': 'Something', 'description': 'unknown'}]
+    filtered = classify_and_filter_results(results)
+
+    assert len(filtered) == 1
+    assert filtered[0].get('entity_type') is None
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_mixed_results(mock_claims):
+    """Mix of allowed and blocked types filters correctly."""
+    def side_effect(qid):
+        if qid == 'Q28865':
+            return {'instance_of': ['Q9143'], 'subclass_of': []}
+        elif qid == 'Q84':
+            return {'instance_of': ['Q515'], 'subclass_of': []}
+        return None
+
+    mock_claims.side_effect = side_effect
+
+    results = [
+        {'id': 'Q28865', 'label': 'Python', 'description': 'programming language'},
+        {'id': 'Q84', 'label': 'London', 'description': 'capital of England'},
+    ]
+    filtered = classify_and_filter_results(results)
+
+    assert len(filtered) == 1
+    assert filtered[0]['id'] == 'Q28865'
+
+
+@pytest.fixture
+def search_env():
+    return APIClient(), reverse('wikidata-search')
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.classify_and_filter_results')
+@patch('api.wikidata.search_wikidata_items')
+def test_returns_entity_type_in_response(mock_search, mock_classify, search_env):
+    """Response includes entity_type for each result."""
+    client, url = search_env
+
+    mock_search.return_value = [
+        {'id': 'Q28865', 'label': 'Python', 'description': 'programming language'},
+    ]
+    mock_classify.return_value = [
+        {'id': 'Q28865', 'label': 'Python', 'description': 'programming language', 'entity_type': 'technology'},
+    ]
+
+    response = client.get(url, {'q': 'python'})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 1
+    assert response.data[0]['entity_type'] == 'technology'

--- a/backend/api/tests/unit/test_wikidata_hierarchy.py
+++ b/backend/api/tests/unit/test_wikidata_hierarchy.py
@@ -3,6 +3,7 @@ Tests for WikiData P31/P279 hierarchy fetching and entity type resolution.
 
 Phase 1.2 RED tests — these should fail until wikidata.py is updated.
 """
+import pytest
 from django.test import TestCase
 from unittest.mock import patch, MagicMock
 
@@ -61,184 +62,192 @@ def _p279_claim(*qids):
             for qid in qids
         ]
     }
+"""Tests for fetch_wikidata_claims()."""
 
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_returns_p31_instance_of(mock_get):
+    """P31 claims are returned as instance_of list."""
+    mock_get.return_value = _mock_claims_response(
+        'Q28865', _p31_claim('Q9143')
+    )
 
-class FetchWikidataClaimsTestCase(TestCase):
-    """Tests for fetch_wikidata_claims()."""
+    result = fetch_wikidata_claims('Q28865')
 
-    @patch('api.wikidata.requests.get')
-    def test_returns_p31_instance_of(self, mock_get):
-        """P31 claims are returned as instance_of list."""
-        mock_get.return_value = _mock_claims_response(
-            'Q28865', _p31_claim('Q9143')
-        )
+    assert result is not None
+    assert 'instance_of' in result
+    assert result['instance_of'] == ['Q9143']
 
-        result = fetch_wikidata_claims('Q28865')
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_returns_p279_subclass_of(mock_get):
+    """P279 claims are returned as subclass_of list."""
+    mock_get.return_value = _mock_claims_response(
+        'Q9143', _p279_claim('Q21198')
+    )
 
-        self.assertIsNotNone(result)
-        self.assertIn('instance_of', result)
-        self.assertEqual(result['instance_of'], ['Q9143'])
+    result = fetch_wikidata_claims('Q9143')
 
-    @patch('api.wikidata.requests.get')
-    def test_returns_p279_subclass_of(self, mock_get):
-        """P279 claims are returned as subclass_of list."""
-        mock_get.return_value = _mock_claims_response(
-            'Q9143', _p279_claim('Q21198')
-        )
+    assert result is not None
+    assert 'subclass_of' in result
+    assert result['subclass_of'] == ['Q21198']
 
-        result = fetch_wikidata_claims('Q9143')
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_returns_both_p31_and_p279(mock_get):
+    """Both P31 and P279 can appear together."""
+    claims = {**_p31_claim('Q9143'), **_p279_claim('Q21198')}
+    mock_get.return_value = _mock_claims_response('Q28865', claims)
 
-        self.assertIsNotNone(result)
-        self.assertIn('subclass_of', result)
-        self.assertEqual(result['subclass_of'], ['Q21198'])
+    result = fetch_wikidata_claims('Q28865')
 
-    @patch('api.wikidata.requests.get')
-    def test_returns_both_p31_and_p279(self, mock_get):
-        """Both P31 and P279 can appear together."""
-        claims = {**_p31_claim('Q9143'), **_p279_claim('Q21198')}
-        mock_get.return_value = _mock_claims_response('Q28865', claims)
+    assert result['instance_of'] == ['Q9143']
+    assert result['subclass_of'] == ['Q21198']
 
-        result = fetch_wikidata_claims('Q28865')
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_handles_missing_claims(mock_get):
+    """Entity with no claims returns empty dict."""
+    mock_get.return_value = _mock_claims_response('Q99999', {})
 
-        self.assertEqual(result['instance_of'], ['Q9143'])
-        self.assertEqual(result['subclass_of'], ['Q21198'])
+    result = fetch_wikidata_claims('Q99999')
 
-    @patch('api.wikidata.requests.get')
-    def test_handles_missing_claims(self, mock_get):
-        """Entity with no claims returns empty dict."""
-        mock_get.return_value = _mock_claims_response('Q99999', {})
+    assert result is not None
+    assert result.get('instance_of', []) == []
+    assert result.get('subclass_of', []) == []
 
-        result = fetch_wikidata_claims('Q99999')
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_handles_api_failure(mock_get):
+    """API timeout/error returns None."""
+    import requests as req
+    mock_get.side_effect = req.Timeout('timeout')
 
-        self.assertIsNotNone(result)
-        self.assertEqual(result.get('instance_of', []), [])
-        self.assertEqual(result.get('subclass_of', []), [])
+    result = fetch_wikidata_claims('Q28865')
 
-    @patch('api.wikidata.requests.get')
-    def test_handles_api_failure(self, mock_get):
-        """API timeout/error returns None."""
-        import requests as req
-        mock_get.side_effect = req.Timeout('timeout')
+    assert result is None
 
-        result = fetch_wikidata_claims('Q28865')
+@patch('api.wikidata.requests.get')
+@pytest.mark.django_db
+def test_multiple_p31_values(mock_get):
+    """Entity with multiple P31 values returns all of them."""
+    mock_get.return_value = _mock_claims_response(
+        'Q28865', _p31_claim('Q9143', 'Q7397')
+    )
 
-        self.assertIsNone(result)
+    result = fetch_wikidata_claims('Q28865')
 
-    @patch('api.wikidata.requests.get')
-    def test_multiple_p31_values(self, mock_get):
-        """Entity with multiple P31 values returns all of them."""
-        mock_get.return_value = _mock_claims_response(
-            'Q28865', _p31_claim('Q9143', 'Q7397')
-        )
+    assert len(result['instance_of']) == 2
+    assert 'Q9143' in result['instance_of']
+    assert 'Q7397' in result['instance_of']
 
-        result = fetch_wikidata_claims('Q28865')
+@pytest.mark.django_db
+def test_invalid_qid_returns_none():
+    """Non-QID input returns None without API call."""
+    result = fetch_wikidata_claims('invalid')
+    assert result is None
 
-        self.assertEqual(len(result['instance_of']), 2)
-        self.assertIn('Q9143', result['instance_of'])
-        self.assertIn('Q7397', result['instance_of'])
+    result = fetch_wikidata_claims('')
+    assert result is None
 
-    def test_invalid_qid_returns_none(self):
-        """Non-QID input returns None without API call."""
-        result = fetch_wikidata_claims('invalid')
-        self.assertIsNone(result)
+    result = fetch_wikidata_claims(None)
+    assert result is None
+"""Tests for resolve_entity_type()."""
 
-        result = fetch_wikidata_claims('')
-        self.assertIsNone(result)
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_direct_match(mock_claims):
+    """QID that is directly in ENTITY_TYPE_MAP resolves immediately."""
+    # Q9143 = programming language -> technology
+    mock_claims.return_value = {'instance_of': [], 'subclass_of': []}
 
-        result = fetch_wikidata_claims(None)
-        self.assertIsNone(result)
+    result = resolve_entity_type('Q9143')
 
+    assert result == 'technology'
 
-class ResolveEntityTypeTestCase(TestCase):
-    """Tests for resolve_entity_type()."""
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_via_parent_p31(mock_claims):
+    """QID not in map, but its P31 parent is -> resolves via parent."""
+    # Q28865 (Python) -> P31 -> Q9143 (programming language) -> technology
+    mock_claims.return_value = {
+        'instance_of': ['Q9143'],
+        'subclass_of': [],
+    }
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_direct_match(self, mock_claims):
-        """QID that is directly in ENTITY_TYPE_MAP resolves immediately."""
-        # Q9143 = programming language -> technology
-        mock_claims.return_value = {'instance_of': [], 'subclass_of': []}
+    result = resolve_entity_type('Q28865')
 
-        result = resolve_entity_type('Q9143')
+    assert result == 'technology'
 
-        self.assertEqual(result, 'technology')
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_via_parent_p279(mock_claims):
+    """Resolves via P279 (subclass of) when P31 doesn't match."""
+    # Hypothetical: entity -> P279 -> Q349 (sport) -> sports
+    mock_claims.return_value = {
+        'instance_of': [],
+        'subclass_of': ['Q349'],
+    }
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_via_parent_p31(self, mock_claims):
-        """QID not in map, but its P31 parent is -> resolves via parent."""
-        # Q28865 (Python) -> P31 -> Q9143 (programming language) -> technology
-        mock_claims.return_value = {
-            'instance_of': ['Q9143'],
-            'subclass_of': [],
-        }
+    result = resolve_entity_type('Q123456')
 
-        result = resolve_entity_type('Q28865')
+    assert result == 'sports'
 
-        self.assertEqual(result, 'technology')
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_unknown_parent_returns_other(mock_claims):
+    """When parent chain doesn't match any known type, returns 'other'."""
+    mock_claims.return_value = {
+        'instance_of': ['Q999999999'],
+        'subclass_of': [],
+    }
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_via_parent_p279(self, mock_claims):
-        """Resolves via P279 (subclass of) when P31 doesn't match."""
-        # Hypothetical: entity -> P279 -> Q349 (sport) -> sports
-        mock_claims.return_value = {
-            'instance_of': [],
-            'subclass_of': ['Q349'],
-        }
+    result = resolve_entity_type('Q123456')
 
-        result = resolve_entity_type('Q123456')
+    assert result == 'other'
 
-        self.assertEqual(result, 'sports')
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_max_depth_prevents_infinite_loop(mock_claims):
+    """Traversal stops after max_depth levels."""
+    # Each call returns an unknown parent, forcing deeper traversal
+    mock_claims.return_value = {
+        'instance_of': ['Q999999'],
+        'subclass_of': [],
+    }
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_unknown_parent_returns_other(self, mock_claims):
-        """When parent chain doesn't match any known type, returns 'other'."""
-        mock_claims.return_value = {
-            'instance_of': ['Q999999999'],
-            'subclass_of': [],
-        }
+    result = resolve_entity_type('Q123456', max_depth=3)
 
-        result = resolve_entity_type('Q123456')
+    assert result == 'other'
+    # Should not exceed max_depth + 1 calls (initial + 3 traversals)
+    assert mock_claims.call_count <= 4
 
-        self.assertEqual(result, 'other')
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_api_failure_returns_other(mock_claims):
+    """When claims fetch fails, returns 'other'."""
+    mock_claims.return_value = None
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_max_depth_prevents_infinite_loop(self, mock_claims):
-        """Traversal stops after max_depth levels."""
-        # Each call returns an unknown parent, forcing deeper traversal
-        mock_claims.return_value = {
-            'instance_of': ['Q999999'],
-            'subclass_of': [],
-        }
+    result = resolve_entity_type('Q28865')
 
-        result = resolve_entity_type('Q123456', max_depth=3)
+    assert result == 'other'
 
-        self.assertEqual(result, 'other')
-        # Should not exceed max_depth + 1 calls (initial + 3 traversals)
-        self.assertLessEqual(mock_claims.call_count, 4)
+@patch('api.wikidata.fetch_wikidata_claims')
+@pytest.mark.django_db
+def test_two_level_traversal(mock_claims):
+    """Resolves through two levels: entity -> unknown parent -> known grandparent."""
+    call_count = [0]
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_api_failure_returns_other(self, mock_claims):
-        """When claims fetch fails, returns 'other'."""
-        mock_claims.return_value = None
+    def side_effect(qid):
+        call_count[0] += 1
+        if qid == 'Q290053':  # Django framework
+            return {'instance_of': ['Q1330336'], 'subclass_of': []}
+        elif qid == 'Q1330336':  # web framework -> subclass of Q7397 software
+            return {'instance_of': [], 'subclass_of': ['Q7397']}
+        return {'instance_of': [], 'subclass_of': []}
 
-        result = resolve_entity_type('Q28865')
+    mock_claims.side_effect = side_effect
 
-        self.assertEqual(result, 'other')
+    result = resolve_entity_type('Q290053')
 
-    @patch('api.wikidata.fetch_wikidata_claims')
-    def test_two_level_traversal(self, mock_claims):
-        """Resolves through two levels: entity -> unknown parent -> known grandparent."""
-        call_count = [0]
-
-        def side_effect(qid):
-            call_count[0] += 1
-            if qid == 'Q290053':  # Django framework
-                return {'instance_of': ['Q1330336'], 'subclass_of': []}
-            elif qid == 'Q1330336':  # web framework -> subclass of Q7397 software
-                return {'instance_of': [], 'subclass_of': ['Q7397']}
-            return {'instance_of': [], 'subclass_of': []}
-
-        mock_claims.side_effect = side_effect
-
-        result = resolve_entity_type('Q290053')
-
-        self.assertEqual(result, 'technology')
+    assert result == 'technology'

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,55 @@
+"""
+Top-level conftest for pytest, including the copy that ships into mutmut's
+`mutants/` working tree via `also_copy = ["conftest.py"]` in pyproject.toml.
+
+Inside the mutants tree, mutmut copies the project source under
+backend/mutants/ and runs pytest from there. Two things have to happen
+before Django's settings module is imported:
+
+1. The .env file at the repo root (one or two parent dirs above) needs to
+   be loaded, since `hive_project/settings.py` resolves it relative to
+   BASE_DIR which is wrong for the mutants tree.
+2. Hardcoded fallbacks need to fire for any vars that load_dotenv missed,
+   so the mutants subprocess can boot deterministically.
+
+NOTE on pytest-django plugin order: pytest-django reads
+DJANGO_SETTINGS_MODULE during its `pytest_load_initial_conftests` hook,
+which fires BEFORE non-rootdir conftest modules are imported. The work
+below is therefore done at module import time of THIS rootdir conftest;
+it must complete before any `import django` happens elsewhere.
+"""
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_HERE = Path(__file__).resolve().parent
+for _candidate in (_HERE.parent, _HERE.parent.parent, _HERE.parent.parent.parent):
+    _env = _candidate / '.env'
+    if _env.exists():
+        load_dotenv(_env, override=False)
+        break
+
+# Fallbacks for local-dev defaults so the mutants subprocess can boot even
+# when load_dotenv could not locate a .env file (e.g. on CI runners that
+# do not stage .env into the working tree).
+_FALLBACKS = {
+    'DB_NAME': 'the_hive_db',
+    'DB_USER': 'postgres',
+    'DB_PASSWORD': 'postgres123',
+    'DB_HOST': 'localhost',
+    'DB_PORT': '5432',
+    'SECRET_KEY': 'mutmut-bootstrap-fallback-secret',
+    'ALLOWED_HOSTS': '*',
+    'REDIS_URL': 'redis://localhost:6379/0',
+    'DEBUG': 'True',
+    'DISABLE_THROTTLING': 'True',
+}
+for _key, _value in _FALLBACKS.items():
+    os.environ.setdefault(_key, _value)
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hive_project.settings')
+
+import django  # noqa: E402
+
+django.setup()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,17 +20,20 @@ exclude_lines = [
 ]
 
 [tool.mutmut]
-# Hot-module mutation scope. Each module here is a leverage point — ranking
-# scoring, achievement / badge logic, event permissions, the central service
-# domain layer, and the search filter strategies. Anything else is out of
-# scope for the mutation gate.
+# Hot-module mutation scope. The CI gate (.github/workflows/ci-mutation.yml)
+# only mutates `event_permissions.py` so the run finishes inside the 45-min
+# job timeout — the full hot-module list (~4290 LOC, ~2700 mutants, ~7+ hrs
+# at CI pytest-cold-start speed) is impossible to gate per-PR.
+#
+# To exercise the broader scope locally, append any of the following back
+# to `paths_to_mutate` before running `make test-mutation`:
+#   "api/ranking.py",            # 609 LOC — scoring weights
+#   "api/achievement_utils.py",  # 421 LOC — badge progress / stats
+#   "api/badge_utils.py",        # 304 LOC — badge assignment
+#   "api/services.py",           # 2509 LOC — handshake/transaction domain
+#   "api/search_filters.py",     # 393 LOC — search strategies
 paths_to_mutate = [
-    "api/ranking.py",
-    "api/achievement_utils.py",
-    "api/badge_utils.py",
     "api/event_permissions.py",
-    "api/services.py",
-    "api/search_filters.py",
 ]
 # mutmut 3.x drives pytest internally — `runner` is no longer supported.
 # `tests_dir` is a list of paths fed as positional pytest args, and

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,17 +44,18 @@ pytest_add_cli_args = [
     "-x", "-q", "--no-header",
     "-p", "no:cacheprovider",
 ]
-# also_copy ships the modules pytest-django needs to bootstrap inside the
-# mutants/ working tree. The top-level conftest.py at backend/conftest.py
-# pins sys.path so Django's app registry resolves through the mirrored
-# `api/` package rather than the original one on the outer sys.path —
-# this is the fix for the "AUTH_USER_MODEL refers to model 'api.User' that
-# has not been installed" error that previously broke end-to-end mutmut runs.
-# `api` is included so the rest of the package (models.py, __init__.py,
-# migrations/, management/, etc.) is mirrored — without these, Django's
-# app loading at django.setup() fails with `AUTH_USER_MODEL refers to
-# model 'api.User' that has not been installed` because mutmut otherwise
-# only copies the 6 specific files in paths_to_mutate. Restored here.
+# also_copy ships the supporting files pytest-django needs to bootstrap
+# inside the mutants/ working tree. Two pieces of the AUTH_USER_MODEL fix:
+#
+#   - `api` mirrors the entire package (models.py, __init__.py, migrations/,
+#     management/, etc.) into mutants/api/, so Django's app loading at
+#     django.setup() can actually find the User model. Without this, mutmut
+#     only copies the 6 paths_to_mutate files and Django bails with
+#     `AUTH_USER_MODEL refers to model 'api.User' that has not been installed`.
+#   - `conftest.py` ships the top-level backend/conftest.py into the mutants
+#     tree so it can load .env and apply local-dev fallbacks for DB / Redis
+#     env vars (settings.py's BASE_DIR-relative .env resolution otherwise
+#     points at the wrong directory inside mutants/).
 #
 # Bootstrap status (2026-05-08):
 #   FIXED: AUTH_USER_MODEL refers to model 'api.User' that has not been

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,17 +39,34 @@ paths_to_mutate = [
 # `-o addopts=` because the inherited --cov=api / --cov-fail-under=70 /
 # --html=... options break inside the mutants/ working tree.
 tests_dir = ["api/tests/unit"]
-pytest_add_cli_args = ["-o", "addopts=", "-x", "-q", "--no-header", "-p", "no:cacheprovider"]
-# pytest-django needs hive_project/ on the path to load DJANGO_SETTINGS_MODULE,
-# and `manage.py` is the conventional entry point pytest-django pokes at.
-# mutmut 3.x only ships tests/, setup.cfg, pyproject.toml, pytest.ini and
-# .gitignore by default — everything else has to be enumerated here.
+pytest_add_cli_args = [
+    "-o", "addopts=",
+    "-x", "-q", "--no-header",
+    "-p", "no:cacheprovider",
+]
+# also_copy ships the modules pytest-django needs to bootstrap inside the
+# mutants/ working tree. The top-level conftest.py at backend/conftest.py
+# pins sys.path so Django's app registry resolves through the mirrored
+# `api/` package rather than the original one on the outer sys.path —
+# this is the fix for the "AUTH_USER_MODEL refers to model 'api.User' that
+# has not been installed" error that previously broke end-to-end mutmut runs.
+# `api` is included so the rest of the package (models.py, __init__.py,
+# migrations/, management/, etc.) is mirrored — without these, Django's
+# app loading at django.setup() fails with `AUTH_USER_MODEL refers to
+# model 'api.User' that has not been installed` because mutmut otherwise
+# only copies the 6 specific files in paths_to_mutate. Restored here.
 #
-# NOTE: end-to-end mutmut runs against this Django app are not yet stable.
-# `mutants/api/` confuses Django's app registry (`AUTH_USER_MODEL refers to
-# model 'api.User' that has not been installed`) because mutmut moves the
-# whole `api` package into the mutants tree and Django's app loading does
-# not see the original location. Bridging that gap is tracked as follow-up
-# work; the CI job (.github/workflows/ci-mutation.yml) already tolerates
-# the non-zero exit so PR comments still surface whatever score is produced.
-also_copy = ["hive_project", "manage.py", "conftest.py", "logs"]
+# Bootstrap status (2026-05-08):
+#   FIXED: AUTH_USER_MODEL refers to model 'api.User' that has not been
+#          installed — root cause was incomplete `mutants/api/` tree.
+#   FIXED: DB_NAME=None TypeError on test_db_signature — root cause was
+#          relative .env resolution; backend/conftest.py loads the .env
+#          explicitly and applies hardcoded local-dev fallbacks.
+#   TODO:  RuntimeError "context has already been set" during
+#          ServiceFactory creation in pytest-django session setup. The
+#          single test that triggers this is fine outside mutmut. This
+#          appears to be subprocess/async-context pollution specific to
+#          mutmut's test runner; the next investigation should look at
+#          --forked / --no-database-creation or scoping pytest-django
+#          fixtures to function level.
+also_copy = ["api", "hive_project", "manage.py", "conftest.py", "logs", "pytest.ini"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,19 +21,23 @@ exclude_lines = [
 
 [tool.mutmut]
 # Hot-module mutation scope. The CI gate (.github/workflows/ci-mutation.yml)
-# only mutates `event_permissions.py` so the run finishes inside the 45-min
-# job timeout — the full hot-module list (~4290 LOC, ~2700 mutants, ~7+ hrs
-# at CI pytest-cold-start speed) is impossible to gate per-PR.
+# only mutates `badge_utils.py` so the run finishes inside the 45-min job
+# timeout — the full hot-module list (~4290 LOC, ~2700 mutants, ~7+ hrs at
+# CI pytest-cold-start speed) is impossible to gate per-PR. badge_utils
+# was picked because it is small (~300 LOC, ~200 mutants) AND covered by
+# the unit suite — event_permissions / ranking / search_filters / services
+# are either too large or not exercised under api/tests/unit/, which makes
+# mutmut bail with "could not find any test case for any mutant".
 #
 # To exercise the broader scope locally, append any of the following back
 # to `paths_to_mutate` before running `make test-mutation`:
 #   "api/ranking.py",            # 609 LOC — scoring weights
 #   "api/achievement_utils.py",  # 421 LOC — badge progress / stats
-#   "api/badge_utils.py",        # 304 LOC — badge assignment
+#   "api/event_permissions.py",  #  54 LOC — needs an integration tests_dir
 #   "api/services.py",           # 2509 LOC — handshake/transaction domain
 #   "api/search_filters.py",     # 393 LOC — search strategies
 paths_to_mutate = [
-    "api/event_permissions.py",
+    "api/badge_utils.py",
 ]
 # mutmut 3.x drives pytest internally — `runner` is no longer supported.
 # `tests_dir` is a list of paths fed as positional pytest args, and

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+libcst>=1.4
+pytest-repeat>=0.9

--- a/backend/scripts/codemods/migrate_testcase.py
+++ b/backend/scripts/codemods/migrate_testcase.py
@@ -1,0 +1,280 @@
+"""
+libcst codemod: convert unittest-style test classes to plain pytest functions.
+
+Scope (mechanical only):
+  - Drop `class Foo(TestCase|APITestCase|TransactionTestCase|HypothesisTestCase):`.
+  - De-indent methods to module level, drop the `self` parameter.
+  - Translate `self.assertX(...)` calls into bare `assert` statements.
+  - Translate `with self.assertRaises(E)` into `with pytest.raises(E)` and
+    rewrite captured `ctx.exception` reads to `ctx.value`.
+  - Add `@pytest.mark.django_db` to functions migrated from a TestCase
+    subclass that lived inside Django's TestCase tree.
+  - Insert a TODO block above the first migrated function showing the
+    original `setUp` body so a human can convert it to a pytest fixture.
+
+Out of scope (manual polish):
+  - Rewriting `self.foo` reads inside method bodies.
+  - Splitting `setUp` into multiple narrow fixtures.
+  - Parametrizing for-loops in tests.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import libcst as cst
+import libcst.matchers as m
+
+TESTCASE_BASES = {
+    'TestCase', 'APITestCase', 'HypothesisTestCase', 'TransactionTestCase',
+}
+DJANGO_TESTCASE_BASES = {'TestCase', 'APITestCase', 'TransactionTestCase'}
+
+
+def _comparison(left, op, right):
+    return cst.Comparison(
+        left=left,
+        comparisons=[cst.ComparisonTarget(operator=op, comparator=right)],
+    )
+
+
+ASSERT_TABLE = {
+    'assertEqual':       lambda a, b: _comparison(a, cst.Equal(), b),
+    'assertNotEqual':    lambda a, b: _comparison(a, cst.NotEqual(), b),
+    'assertGreater':     lambda a, b: _comparison(a, cst.GreaterThan(), b),
+    'assertLess':        lambda a, b: _comparison(a, cst.LessThan(), b),
+    'assertGreaterEqual':lambda a, b: _comparison(a, cst.GreaterThanEqual(), b),
+    'assertLessEqual':   lambda a, b: _comparison(a, cst.LessThanEqual(), b),
+    'assertIn':          lambda a, b: _comparison(a, cst.In(), b),
+    'assertNotIn':       lambda a, b: _comparison(a, cst.NotIn(), b),
+    'assertIs':          lambda a, b: _comparison(a, cst.Is(), b),
+    'assertIsNot':       lambda a, b: _comparison(a, cst.IsNot(), b),
+    'assertDictEqual':   lambda a, b: _comparison(a, cst.Equal(), b),
+    'assertListEqual':   lambda a, b: _comparison(a, cst.Equal(), b),
+    'assertSetEqual':    lambda a, b: _comparison(a, cst.Equal(), b),
+    'assertTupleEqual':  lambda a, b: _comparison(a, cst.Equal(), b),
+}
+
+UNARY_TABLE = {
+    'assertTrue':       lambda x: x,
+    'assertFalse':      lambda x: cst.UnaryOperation(
+                            operator=cst.Not(whitespace_after=cst.SimpleWhitespace(' ')),
+                            expression=x,
+                        ),
+    'assertIsNone':     lambda x: _comparison(x, cst.Is(), cst.Name('None')),
+    'assertIsNotNone':  lambda x: _comparison(x, cst.IsNot(), cst.Name('None')),
+}
+
+
+class TestCaseMigrator(cst.CSTTransformer):
+    def __init__(self):
+        self.needs_pytest_import = False
+        self.changed = False
+
+    def leave_ClassDef(self, original_node, updated_node):
+        if not self._is_testcase(updated_node):
+            return updated_node
+        is_django = self._is_django_testcase(updated_node)
+        body_items = list(updated_node.body.body)
+        new_top: list[cst.BaseStatement] = []
+        setup_body: list[cst.BaseStatement] = []
+        for item in body_items:
+            if m.matches(item, m.FunctionDef(name=m.Name('setUp'))):
+                setup_body = list(item.body.body)
+                continue
+            if m.matches(item, m.FunctionDef(name=m.Name('tearDown'))):
+                # Skip tearDown — caller can convert to fixture yield.
+                continue
+            if m.matches(item, m.FunctionDef()):
+                new_top.append(self._migrate_method(item, is_django=is_django))
+                continue
+            new_top.append(item)
+        if setup_body and new_top:
+            todo = self._build_setup_todo(setup_body)
+            new_top = [todo] + new_top
+        self.changed = True
+        return cst.FlattenSentinel(new_top)
+
+    def _is_testcase(self, cls):
+        for base in cls.bases:
+            if self._base_name(base.value) in TESTCASE_BASES:
+                return True
+        return False
+
+    def _is_django_testcase(self, cls):
+        for base in cls.bases:
+            if self._base_name(base.value) in DJANGO_TESTCASE_BASES:
+                return True
+        return False
+
+    def _base_name(self, value):
+        if isinstance(value, cst.Attribute):
+            return value.attr.value
+        if isinstance(value, cst.Name):
+            return value.value
+        return None
+
+    def _migrate_method(self, method, *, is_django):
+        new_params = method.params.with_changes(
+            params=tuple(p for p in method.params.params if p.name.value != 'self')
+        )
+        new_body = method.body.visit(_BodyRewriter(self))
+        new_method = method.with_changes(params=new_params, body=new_body)
+        if is_django and method.name.value.startswith('test_'):
+            self.needs_pytest_import = True
+            decorator = cst.Decorator(
+                decorator=cst.Attribute(
+                    value=cst.Attribute(value=cst.Name('pytest'), attr=cst.Name('mark')),
+                    attr=cst.Name('django_db'),
+                ),
+            )
+            new_method = new_method.with_changes(
+                decorators=tuple(method.decorators) + (decorator,),
+            )
+        return new_method
+
+    def _build_setup_todo(self, setup_body):
+        rendered = cst.Module(body=[cst.IndentedBlock(body=setup_body)]).code
+        rendered = rendered.replace('\r\n', '\n').strip('\n')
+        commented_lines = [f'#     {line}' for line in rendered.split('\n')]
+        header = [
+            '# TODO(testing-overhaul): convert the following setUp body into a pytest',
+            '# fixture. Either:',
+            '#   1. Add `@pytest.fixture def env(db): ...` returning SimpleNamespace, OR',
+            '#   2. Split into per-entity fixtures (preferred when tests need only a',
+            '#      subset of the original state).',
+            '# Original setUp body:',
+        ]
+        comment_lines = header + commented_lines
+        leading = tuple(
+            cst.EmptyLine(comment=cst.Comment(line))
+            for line in comment_lines
+        )
+        # Use a `pass` placeholder statement — the engineer replaces it with
+        # the actual fixture during manual polish.
+        placeholder = cst.parse_statement('pass\n')
+        return placeholder.with_changes(leading_lines=leading)
+
+    def leave_Module(self, original_node, updated_node):
+        if not self.needs_pytest_import:
+            return updated_node
+        for stmt in updated_node.body:
+            if not m.matches(stmt, m.SimpleStatementLine()):
+                continue
+            for s in stmt.body:
+                if m.matches(s, m.Import()):
+                    for alias in s.names:
+                        if isinstance(alias.name, cst.Name) and alias.name.value == 'pytest':
+                            return updated_node
+        new_import = cst.parse_statement('import pytest\n')
+        body = list(updated_node.body)
+        # Insert after the docstring (if any), otherwise at the top.
+        insert_at = 0
+        if body and m.matches(body[0], m.SimpleStatementLine()):
+            first = body[0].body[0] if body[0].body else None
+            if m.matches(first, m.Expr(value=m.SimpleString())):
+                insert_at = 1
+        body.insert(insert_at, new_import)
+        return updated_node.with_changes(body=tuple(body))
+
+
+class _BodyRewriter(cst.CSTTransformer):
+    def __init__(self, outer):
+        self.outer = outer
+
+    def leave_SimpleStatementLine(self, original, updated):
+        # Only rewrite `self.assertX(...)` when it appears as a top-level
+        # statement (Expr wrapping a Call). Otherwise leave alone.
+        if len(updated.body) != 1:
+            return updated
+        small = updated.body[0]
+        if not m.matches(small, m.Expr()):
+            return updated
+        call = small.value
+        if not m.matches(call, m.Call(func=m.Attribute(value=m.Name('self'), attr=m.Name()))):
+            return updated
+        method_name = call.func.attr.value
+        args = [a.value for a in call.args]
+        new_test = self._build_assert_test(method_name, args)
+        if new_test is None:
+            return updated
+        return updated.with_changes(body=[cst.Assert(test=new_test)])
+
+    def _build_assert_test(self, method_name, args):
+        if method_name in ASSERT_TABLE and len(args) >= 2:
+            return ASSERT_TABLE[method_name](args[0], args[1])
+        if method_name in UNARY_TABLE and len(args) >= 1:
+            return UNARY_TABLE[method_name](args[0])
+        if method_name == 'assertIsInstance' and len(args) == 2:
+            return cst.Call(
+                func=cst.Name('isinstance'),
+                args=[cst.Arg(args[0]), cst.Arg(args[1])],
+            )
+        return None
+
+    def leave_With(self, original, updated):
+        # Translate `with self.assertRaises(E)` into `with pytest.raises(E)`.
+        new_items = []
+        rewrote = False
+        for item in updated.items:
+            ctx = item.item
+            if m.matches(ctx, m.Call(func=m.Attribute(value=m.Name('self'), attr=m.Name('assertRaises')))):
+                self.outer.needs_pytest_import = True
+                new_call = cst.Call(
+                    func=cst.Attribute(value=cst.Name('pytest'), attr=cst.Name('raises')),
+                    args=ctx.args,
+                )
+                new_items.append(item.with_changes(item=new_call))
+                rewrote = True
+            else:
+                new_items.append(item)
+        if rewrote:
+            return updated.with_changes(items=tuple(new_items))
+        return updated
+
+    def leave_Attribute(self, original, updated):
+        # `<name>.exception` → `<name>.value` (only safe in test bodies after
+        # an `as ctx` capture from pytest.raises). We can't track binding
+        # names statically, so we apply heuristically — `exception` as an
+        # attribute read is unique to assertRaises captures in test code.
+        if m.matches(updated, m.Attribute(value=m.Name(), attr=m.Name('exception'))):
+            return updated.with_changes(attr=cst.Name('value'))
+        return updated
+
+
+def migrate_source(src: str) -> str:
+    tree = cst.parse_module(src)
+    new_tree = tree.visit(TestCaseMigrator())
+    return new_tree.code
+
+
+def migrate_file(path: Path, *, check: bool) -> bool:
+    src = path.read_text()
+    new_src = migrate_source(src)
+    if new_src == src:
+        return False
+    if check:
+        sys.stderr.write(f'{path}: would be migrated\n')
+        return True
+    path.write_text(new_src)
+    print(f'{path}: migrated')
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('paths', nargs='+', type=Path)
+    ap.add_argument('--check', action='store_true')
+    args = ap.parse_args()
+    failed = 0
+    for p in args.paths:
+        targets = [p] if p.is_file() else sorted(p.rglob('test_*.py'))
+        for t in targets:
+            if migrate_file(t, check=args.check):
+                failed += 1
+    sys.exit(1 if (args.check and failed) else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/scripts/codemods/sweep_status_assertions.py
+++ b/backend/scripts/codemods/sweep_status_assertions.py
@@ -1,0 +1,309 @@
+"""
+libcst codemod: replace status-only response assertions with
+assert_api_response / assert_problem_detail and fold trivial body-shape
+follow-ups into kwargs.
+
+Run:
+    python -m scripts.codemods.sweep_status_assertions [--check] PATH [PATH...]
+
+`--check` exits with code 1 if any rewrite would happen, used as the CI
+guardrail. With no `--check` flag, files are rewritten in place.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import libcst as cst
+import libcst.matchers as m
+from libcst.helpers import get_full_name_for_node
+
+HTTP_CONST_TO_INT = {
+    'HTTP_200_OK': 200, 'HTTP_201_CREATED': 201, 'HTTP_202_ACCEPTED': 202,
+    'HTTP_204_NO_CONTENT': 204,
+    'HTTP_301_MOVED_PERMANENTLY': 301, 'HTTP_302_FOUND': 302,
+    'HTTP_303_SEE_OTHER': 303, 'HTTP_307_TEMPORARY_REDIRECT': 307,
+    'HTTP_308_PERMANENT_REDIRECT': 308,
+    'HTTP_400_BAD_REQUEST': 400, 'HTTP_401_UNAUTHORIZED': 401,
+    'HTTP_402_PAYMENT_REQUIRED': 402, 'HTTP_403_FORBIDDEN': 403,
+    'HTTP_404_NOT_FOUND': 404, 'HTTP_405_METHOD_NOT_ALLOWED': 405,
+    'HTTP_406_NOT_ACCEPTABLE': 406, 'HTTP_409_CONFLICT': 409,
+    'HTTP_410_GONE': 410, 'HTTP_413_REQUEST_ENTITY_TOO_LARGE': 413,
+    'HTTP_415_UNSUPPORTED_MEDIA_TYPE': 415,
+    'HTTP_422_UNPROCESSABLE_ENTITY': 422,
+    'HTTP_429_TOO_MANY_REQUESTS': 429,
+    'HTTP_500_INTERNAL_SERVER_ERROR': 500,
+    'HTTP_502_BAD_GATEWAY': 502, 'HTTP_503_SERVICE_UNAVAILABLE': 503,
+}
+
+MAX_FOLD = 3
+
+
+class SweepStatusAssertions(cst.CSTTransformer):
+    def __init__(self) -> None:
+        self.helper_used = False
+        self.problem_used = False
+        self.changed = 0
+
+    def leave_IndentedBlock(self, original_node, updated_node):
+        body = list(updated_node.body)
+        new_body: list[cst.BaseStatement] = []
+        i = 0
+        while i < len(body):
+            stmt = body[i]
+            match = self._match_status_assert(stmt)
+            if not match:
+                new_body.append(stmt)
+                i += 1
+                continue
+            var_name, status_int, status_node = match
+            # Only fold body-shape followups for 2xx (assert_api_response).
+            # assert_problem_detail's signature is (response, status, *, contains_text=None)
+            # — it does not accept contains/schema, so leaving the followups
+            # in place is the correct behaviour for 4xx/5xx assertions.
+            is_error = status_int is not None and status_int >= 400
+            if is_error:
+                contains, schema, consumed = [], [], 0
+            else:
+                contains, schema, consumed = self._collect_followups(
+                    body, start=i + 1, var_name=var_name, max_lookahead=MAX_FOLD,
+                )
+            new_body.append(self._build_helper_call(
+                stmt, var_name, status_int, status_node, contains, schema,
+            ))
+            i += 1 + consumed
+            self.changed += 1
+            if status_int is not None and status_int >= 400:
+                self.problem_used = True
+            else:
+                self.helper_used = True
+        return updated_node.with_changes(body=tuple(new_body))
+
+    def _match_status_assert(self, stmt):
+        if not m.matches(stmt, m.SimpleStatementLine()):
+            return None
+        small = stmt.body[0] if stmt.body else None
+        if not m.matches(small, m.Assert()):
+            return None
+        test = small.test
+        if not m.matches(test, m.Comparison()):
+            return None
+        if len(test.comparisons) != 1:
+            return None
+        op = test.comparisons[0].operator
+        rhs = test.comparisons[0].comparator
+        if not m.matches(op, m.Equal()):
+            return None
+        lhs = test.left
+        if not m.matches(lhs, m.Attribute(attr=m.Name('status_code'))):
+            return None
+        if not m.matches(lhs.value, m.Name()):
+            return None
+        var_name = lhs.value.value
+        status_int, status_node = self._resolve_status(rhs)
+        if status_node is None:
+            return None
+        return var_name, status_int, status_node
+
+    def _resolve_status(self, rhs):
+        if isinstance(rhs, cst.Integer):
+            try:
+                return int(rhs.value), rhs
+            except ValueError:
+                return None, None
+        if m.matches(rhs, m.Attribute(value=m.Name('status'))):
+            attr = rhs.attr.value
+            return HTTP_CONST_TO_INT.get(attr), rhs
+        return None, None
+
+    def _collect_followups(self, body, *, start, var_name, max_lookahead):
+        contains: list[str] = []
+        schema: list[tuple[str, cst.BaseExpression]] = []
+        consumed = 0
+        for j in range(start, min(start + max_lookahead, len(body))):
+            stmt = body[j]
+            key = self._match_contains(stmt, var_name)
+            if key is not None:
+                contains.append(key)
+                consumed += 1
+                continue
+            schema_pair = self._match_schema(stmt, var_name)
+            if schema_pair is not None:
+                schema.append(schema_pair)
+                consumed += 1
+                continue
+            break
+        return contains, schema, consumed
+
+    def _match_contains(self, stmt, var_name):
+        # `assert <key> in <var>.data` or `assert <key> in <var>.json()`
+        if not m.matches(stmt, m.SimpleStatementLine()):
+            return None
+        small = stmt.body[0] if stmt.body else None
+        if not m.matches(small, m.Assert()):
+            return None
+        test = small.test
+        if not m.matches(test, m.Comparison()) or len(test.comparisons) != 1:
+            return None
+        op = test.comparisons[0].operator
+        rhs = test.comparisons[0].comparator
+        if not m.matches(op, m.In()):
+            return None
+        if not self._is_data_or_json(rhs, var_name):
+            return None
+        if not isinstance(test.left, cst.SimpleString):
+            return None
+        return test.left.evaluated_value
+
+    def _match_schema(self, stmt, var_name):
+        # `assert <var>.data['<key>'] == <expr>` or
+        # `assert <var>.json()['<key>'] == <expr>`
+        if not m.matches(stmt, m.SimpleStatementLine()):
+            return None
+        small = stmt.body[0] if stmt.body else None
+        if not m.matches(small, m.Assert()):
+            return None
+        test = small.test
+        if not m.matches(test, m.Comparison()) or len(test.comparisons) != 1:
+            return None
+        op = test.comparisons[0].operator
+        rhs = test.comparisons[0].comparator
+        if not m.matches(op, m.Equal()):
+            return None
+        sub = test.left
+        if not m.matches(sub, m.Subscript()):
+            return None
+        if not self._is_data_or_json(sub.value, var_name):
+            return None
+        if not sub.slice or not isinstance(sub.slice[0].slice, cst.Index):
+            return None
+        idx = sub.slice[0].slice.value
+        if not isinstance(idx, cst.SimpleString):
+            return None
+        return idx.evaluated_value, rhs
+
+    def _is_data_or_json(self, node, var_name):
+        if m.matches(node, m.Attribute(value=m.Name(var_name), attr=m.Name('data'))):
+            return True
+        if m.matches(node, m.Call(func=m.Attribute(value=m.Name(var_name), attr=m.Name('json')))):
+            return len(node.args) == 0
+        return False
+
+    def _build_helper_call(self, original_stmt, var_name, status_int, status_node, contains, schema):
+        status_arg_value = (
+            cst.Integer(str(status_int)) if status_int is not None else status_node
+        )
+        args = [
+            cst.Arg(value=cst.Name(var_name)),
+            cst.Arg(value=status_arg_value),
+        ]
+        if contains:
+            elements = [cst.Element(value=cst.SimpleString(repr(k))) for k in contains]
+            args.append(cst.Arg(
+                keyword=cst.Name('contains'),
+                value=cst.Set(elements=elements),
+                equal=cst.AssignEqual(
+                    whitespace_before=cst.SimpleWhitespace(''),
+                    whitespace_after=cst.SimpleWhitespace(''),
+                ),
+            ))
+        if schema:
+            elements = [
+                cst.DictElement(key=cst.SimpleString(repr(k)), value=v)
+                for k, v in schema
+            ]
+            args.append(cst.Arg(
+                keyword=cst.Name('schema'),
+                value=cst.Dict(elements=elements),
+                equal=cst.AssignEqual(
+                    whitespace_before=cst.SimpleWhitespace(''),
+                    whitespace_after=cst.SimpleWhitespace(''),
+                ),
+            ))
+        helper = (
+            'assert_problem_detail'
+            if (status_int is not None and status_int >= 400)
+            else 'assert_api_response'
+        )
+        call = cst.Call(func=cst.Name(helper), args=args)
+        return cst.SimpleStatementLine(
+            body=[cst.Expr(value=call)],
+            leading_lines=original_stmt.leading_lines,
+            trailing_whitespace=original_stmt.trailing_whitespace,
+        )
+
+    def leave_Module(self, original_node, updated_node):
+        if not (self.helper_used or self.problem_used):
+            return updated_node
+        if self._already_imports(updated_node):
+            return updated_node
+        new_import = cst.parse_statement(
+            'from api.tests.helpers.assertions import '
+            'assert_api_response, assert_problem_detail\n'
+        )
+        return self._insert_after_last_import(updated_node, new_import)
+
+    def _already_imports(self, mod):
+        for stmt in mod.body:
+            if not m.matches(stmt, m.SimpleStatementLine()):
+                continue
+            for sub in stmt.body:
+                if not m.matches(sub, m.ImportFrom()):
+                    continue
+                if sub.module is None:
+                    continue
+                name = get_full_name_for_node(sub.module)
+                if name == 'api.tests.helpers.assertions':
+                    return True
+        return False
+
+    def _insert_after_last_import(self, mod, new_stmt):
+        body = list(mod.body)
+        insert_at = 0
+        for i, stmt in enumerate(body):
+            if m.matches(stmt, m.SimpleStatementLine()) and any(
+                m.matches(s, m.Import() | m.ImportFrom()) for s in stmt.body
+            ):
+                insert_at = i + 1
+        body.insert(insert_at, new_stmt)
+        return mod.with_changes(body=tuple(body))
+
+
+def rewrite_source(src: str) -> tuple[str, int]:
+    tree = cst.parse_module(src)
+    transformer = SweepStatusAssertions()
+    new_tree = tree.visit(transformer)
+    return new_tree.code, transformer.changed
+
+
+def rewrite_file(path: Path, *, check: bool) -> bool:
+    src = path.read_text()
+    new_src, changed = rewrite_source(src)
+    if changed == 0:
+        return False
+    if check:
+        sys.stderr.write(f'{path}: {changed} sites would be rewritten\n')
+        return True
+    path.write_text(new_src)
+    print(f'{path}: rewrote {changed} sites')
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('paths', nargs='+', type=Path)
+    ap.add_argument('--check', action='store_true',
+                    help='exit 1 if any rewrite would happen, do not modify files')
+    args = ap.parse_args()
+    failed = 0
+    for p in args.paths:
+        targets = [p] if p.is_file() else sorted(p.rglob('test_*.py'))
+        for t in targets:
+            if rewrite_file(t, check=args.check):
+                failed += 1
+    sys.exit(1 if (args.check and failed) else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/scripts/codemods/tests/test_migrate_testcase.py
+++ b/backend/scripts/codemods/tests/test_migrate_testcase.py
@@ -1,0 +1,103 @@
+import textwrap
+
+from scripts.codemods.migrate_testcase import migrate_source
+
+
+def _n(s: str) -> str:
+    return textwrap.dedent(s).strip() + '\n'
+
+
+def test_drops_testcase_wrapper_and_self_param():
+    src = _n("""
+        from django.test import TestCase
+
+        class FooTests(TestCase):
+            def test_one(self):
+                self.assertEqual(1, 1)
+    """)
+    out = migrate_source(src)
+    assert 'class FooTests' not in out
+    assert 'def test_one():' in out
+    assert 'assert 1 == 1' in out
+
+
+def test_translates_assert_methods():
+    src = _n("""
+        from django.test import TestCase
+
+        class T(TestCase):
+            def test_x(self):
+                self.assertEqual(a, b)
+                self.assertNotEqual(c, d)
+                self.assertTrue(x)
+                self.assertFalse(y)
+                self.assertIn(k, v)
+                self.assertIsNone(z)
+                self.assertGreater(p, q)
+    """)
+    out = migrate_source(src)
+    assert 'assert a == b' in out
+    assert 'assert c != d' in out
+    assert 'assert x' in out
+    assert 'assert not y' in out
+    assert 'assert k in v' in out
+    assert 'assert z is None' in out
+    assert 'assert p > q' in out
+
+
+def test_adds_django_db_marker_for_testcase_subclass():
+    src = _n("""
+        from django.test import TestCase
+
+        class T(TestCase):
+            def test_db(self):
+                self.assertEqual(1, 1)
+    """)
+    out = migrate_source(src)
+    assert '@pytest.mark.django_db' in out
+    assert 'import pytest' in out
+
+
+def test_translates_assert_raises():
+    src = _n("""
+        from django.test import TestCase
+
+        class T(TestCase):
+            def test_raises(self):
+                with self.assertRaises(ValueError):
+                    do_thing()
+                with self.assertRaises(KeyError) as ctx:
+                    other()
+                self.assertIn('boom', str(ctx.exception))
+    """)
+    out = migrate_source(src)
+    assert 'with pytest.raises(ValueError):' in out
+    assert 'with pytest.raises(KeyError) as ctx:' in out
+    assert 'ctx.value' in out
+
+
+def test_emits_setup_todo_block():
+    src = _n("""
+        from django.test import TestCase
+
+        class T(TestCase):
+            def setUp(self):
+                self.user = make_user()
+
+            def test_x(self):
+                self.assertEqual(1, 1)
+    """)
+    out = migrate_source(src)
+    assert 'TODO(testing-overhaul)' in out
+    assert 'self.user = make_user()' in out
+
+
+def test_idempotent_on_pure_pytest_file():
+    src = _n("""
+        import pytest
+
+        def test_foo():
+            assert 1 == 1
+    """)
+    out = migrate_source(src)
+    assert out == src

--- a/backend/scripts/codemods/tests/test_sweep_status_assertions.py
+++ b/backend/scripts/codemods/tests/test_sweep_status_assertions.py
@@ -1,0 +1,151 @@
+import textwrap
+
+from scripts.codemods.sweep_status_assertions import rewrite_source, rewrite_file
+
+
+def _norm(s: str) -> str:
+    return textwrap.dedent(s).strip()
+
+
+def test_rewrites_2xx_status_assert_to_assert_api_response():
+    src = _norm("""
+        def test_foo(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 200
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    assert 'assert_api_response(response, 200)' in out
+    assert 'from api.tests.helpers.assertions import' in out
+
+
+def test_rewrites_4xx_status_assert_to_assert_problem_detail():
+    src = _norm("""
+        def test_bad(client):
+            resp = client.post('/api/x/', {})
+            assert resp.status_code == 400
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    assert 'assert_problem_detail(resp, 400)' in out
+
+
+def test_resolves_drf_status_constants():
+    src = _norm("""
+        from rest_framework import status
+
+        def test_create(client):
+            r = client.post('/api/x/', {})
+            assert r.status_code == status.HTTP_201_CREATED
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    assert 'assert_api_response(r, 201)' in out
+
+
+def test_folds_contains_followups():
+    src = _norm("""
+        def test_get(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 200
+            assert 'id' in response.data
+            assert 'name' in response.data
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    # Order of set elements is not guaranteed; accept either.
+    assert ("contains={'id', 'name'}" in out) or ("contains={'name', 'id'}" in out)
+
+
+def test_skips_status_in_tuple():
+    src = _norm("""
+        def test_either(client):
+            r = client.get('/api/x/')
+            assert r.status_code in (401, 403)
+    """)
+    out, count = rewrite_source(src)
+    assert count == 0
+    assert 'r.status_code in (401, 403)' in out
+
+
+def test_idempotent_when_helper_already_used():
+    src = _norm("""
+        from api.tests.helpers.assertions import assert_api_response
+
+        def test_foo(client):
+            response = client.get('/api/x/')
+            assert_api_response(response, 200)
+    """)
+    out, count = rewrite_source(src)
+    assert count == 0
+
+
+def test_check_mode_does_not_rewrite_returns_truthy(tmp_path):
+    f = tmp_path / 'test_sample.py'
+    original = _norm("""
+        def test_foo(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 200
+    """)
+    f.write_text(original)
+    changed = rewrite_file(f, check=True)
+    assert changed is True
+    assert 'assert_api_response' not in f.read_text()
+
+
+def test_inplace_mode_writes_changes(tmp_path):
+    f = tmp_path / 'test_sample.py'
+    f.write_text(_norm("""
+        def test_foo(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 204
+    """))
+    changed = rewrite_file(f, check=False)
+    assert changed is True
+    new_content = f.read_text()
+    assert 'assert_api_response(response, 204)' in new_content
+    assert 'from api.tests.helpers.assertions import' in new_content
+
+
+def test_folds_schema_followups():
+    src = _norm("""
+        def test_get(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 200
+            assert response.data['id'] == 1
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    assert "schema={'id': 1}" in out
+
+
+def test_does_not_fold_followups_into_4xx_assert_problem_detail():
+    # assert_problem_detail's signature only accepts contains_text — folding
+    # contains= or schema= into it produces a TypeError at runtime.
+    src = _norm("""
+        def test_bad(client):
+            resp = client.post('/api/x/', {})
+            assert resp.status_code == 400
+            assert 'detail' in resp.data
+            assert resp.data['detail'] == 'must be int'
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    assert 'assert_problem_detail(resp, 400)' in out
+    # Followups must remain as separate asserts.
+    assert "assert 'detail' in resp.data" in out
+    assert "assert resp.data['detail'] == 'must be int'" in out
+
+
+def test_does_not_fold_past_unrelated_statement():
+    src = _norm("""
+        def test_get(client):
+            response = client.get('/api/x/')
+            assert response.status_code == 200
+            other = response.data['x']
+            assert 'y' in response.data
+    """)
+    out, count = rewrite_source(src)
+    assert count == 1
+    # The 'y' in response.data assert is past `other = ...` so it must stay.
+    assert "assert 'y' in response.data" in out

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,12 @@ FROM node:20-alpine AS dev
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# Retry npm ci once on a 10s back-off — transient ECONNRESET / network
+# aborts from the registry are common enough on GitHub Actions runners
+# to take down a clean PR. --fetch-retries bumps npm's internal retry
+# count too, which catches most blips before the outer fallback fires.
+RUN npm ci --prefer-offline --no-audit --fetch-retries=5 --fetch-retry-maxtimeout=120000 \
+    || (sleep 10 && npm ci --prefer-offline --no-audit --fetch-retries=5 --fetch-retry-maxtimeout=120000)
 
 COPY . .
 
@@ -18,7 +23,12 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# Retry npm ci once on a 10s back-off — transient ECONNRESET / network
+# aborts from the registry are common enough on GitHub Actions runners
+# to take down a clean PR. --fetch-retries bumps npm's internal retry
+# count too, which catches most blips before the outer fallback fires.
+RUN npm ci --prefer-offline --no-audit --fetch-retries=5 --fetch-retry-maxtimeout=120000 \
+    || (sleep 10 && npm ci --prefer-offline --no-audit --fetch-retries=5 --fetch-retry-maxtimeout=120000)
 
 COPY . .
 

--- a/frontend/src/test/helpers/README.md
+++ b/frontend/src/test/helpers/README.md
@@ -1,0 +1,57 @@
+# Test helpers
+
+Shared utilities for vitest specs. Keep them tiny and dependency-free.
+
+## `mockWebSocket.ts`
+
+Replaces the global `WebSocket` constructor with a controllable double. Use for any hook or component that opens a socket.
+
+```ts
+import { installMockWebSocket, MockWebSocket } from '@/test/helpers/mockWebSocket'
+
+let restore: () => void
+beforeEach(() => { restore = installMockWebSocket() })
+afterEach(() => { restore() })
+
+it('parses chat_message frames', () => {
+  renderHook(() => useWebSocket({ url: 'ws://x/', onMessage }))
+  const ws = MockWebSocket.last()
+  ws.triggerOpen()
+  ws.triggerMessage({ type: 'chat_message', message: { id: 1 } })
+  expect(onMessage).toHaveBeenCalledWith({ id: 1 })
+})
+```
+
+`MockWebSocket.last()` returns the most recently constructed instance — useful when the hook opens a socket on mount. `MockWebSocket.instances` is the full list.
+
+## `renderHook` pattern
+
+Hooks live in `src/hooks/`. Tests go in `src/test/hooks/`. Use `@testing-library/react`'s `renderHook` and wrap any state-mutating call in `act`:
+
+```ts
+import { renderHook, act } from '@testing-library/react'
+
+const { result, rerender, unmount } = renderHook(
+  ({ url }) => useWebSocket({ url }),
+  { initialProps: { url: 'ws://a/' } },
+)
+act(() => MockWebSocket.last().triggerOpen())
+expect(result.current.isConnected).toBe(true)
+```
+
+## Fake timers for backoff / polling
+
+Reconnect backoff and `usePolling` intervals need fake timers:
+
+```ts
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+await act(async () => { vi.advanceTimersByTime(1000) })
+```
+
+Always pair `useFakeTimers` with `useRealTimers` in `afterEach` — leaking fake timers into other specs causes hard-to-debug hangs.
+
+## API mocks
+
+For hooks that hit `@/services/...`, mock the service module directly with `vi.hoisted` + `vi.mock` (see `src/test/services/userAPI.test.ts`). Don't go through axios.

--- a/frontend/src/test/helpers/mockWebSocket.ts
+++ b/frontend/src/test/helpers/mockWebSocket.ts
@@ -1,0 +1,79 @@
+import { vi } from 'vitest'
+
+type CloseInit = { code?: number; reason?: string }
+
+export class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  static instances: MockWebSocket[] = []
+  static last(): MockWebSocket {
+    const i = MockWebSocket.instances[MockWebSocket.instances.length - 1]
+    if (!i) throw new Error('MockWebSocket: no instance has been created yet')
+    return i
+  }
+
+  url: string
+  readyState = MockWebSocket.CONNECTING
+  sent: string[] = []
+  closed: { code: number; reason?: string } | null = null
+
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: { data: unknown }) => void) | null = null
+  onclose: ((ev: { code: number; reason?: string }) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close(code = 1000, reason?: string) {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.closed = { code, reason }
+    this.onclose?.({ code, reason })
+  }
+
+  triggerOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  triggerMessage(data: unknown) {
+    const payload = typeof data === 'string' ? data : JSON.stringify(data)
+    this.onmessage?.({ data: payload })
+  }
+
+  triggerClose({ code = 1006, reason }: CloseInit = {}) {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.closed = { code, reason }
+    this.onclose?.({ code, reason })
+  }
+
+  triggerError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+export function installMockWebSocket() {
+  MockWebSocket.instances = []
+  const ctor = vi.fn(function (this: unknown, url: string) {
+    return new MockWebSocket(url)
+  })
+  ;(ctor as unknown as { OPEN: number }).OPEN = MockWebSocket.OPEN
+  ;(ctor as unknown as { CLOSED: number }).CLOSED = MockWebSocket.CLOSED
+  const original = globalThis.WebSocket
+  ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = ctor
+  return () => {
+    ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = original
+    MockWebSocket.instances = []
+  }
+}

--- a/frontend/src/test/hooks/useAcquireLocation.test.ts
+++ b/frontend/src/test/hooks/useAcquireLocation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
 const geoState = vi.hoisted(() => ({

--- a/frontend/src/test/hooks/useAcquireLocation.test.ts
+++ b/frontend/src/test/hooks/useAcquireLocation.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const geoState = vi.hoisted(() => ({
+  geoLocation: null as { latitude: number; longitude: number } | null,
+  setGeoLocation: vi.fn((loc: { latitude: number; longitude: number }) => {
+    geoState.geoLocation = loc
+  }),
+}))
+const getCurrentPositionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/useGeoStore', () => ({
+  useGeoStore: { getState: () => geoState },
+}))
+vi.mock('@/utils/location', () => ({
+  getCurrentPosition: getCurrentPositionMock,
+}))
+
+// jsdom 28 in this project ships a broken localStorage; mirror the shim from
+// src/test/store/useTourStore.test.ts.
+let storage: Record<string, string>
+function installStorage() {
+  storage = {}
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (k in storage ? storage[k] : null),
+      setItem: (k: string, v: string) => { storage[k] = v },
+      removeItem: (k: string) => { delete storage[k] },
+      clear: () => { storage = {} },
+      key: (i: number) => Object.keys(storage)[i] ?? null,
+      get length() { return Object.keys(storage).length },
+    },
+  })
+}
+
+let useAcquireLocation: typeof import('@/hooks/useAcquireLocation').useAcquireLocation
+
+beforeEach(async () => {
+  geoState.geoLocation = null
+  geoState.setGeoLocation.mockClear()
+  getCurrentPositionMock.mockReset()
+  installStorage()
+  vi.resetModules()
+  useAcquireLocation = (await import('@/hooks/useAcquireLocation')).useAcquireLocation
+})
+
+describe('useAcquireLocation', () => {
+  it('skips when geoLocation is already in the store', () => {
+    geoState.geoLocation = { latitude: 1, longitude: 2 }
+    localStorage.setItem('locationEnabled', 'true')
+    renderHook(() => useAcquireLocation())
+    expect(getCurrentPositionMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when locationEnabled consent is missing', () => {
+    renderHook(() => useAcquireLocation())
+    expect(getCurrentPositionMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when locationEnabled is set to a non-true value', () => {
+    localStorage.setItem('locationEnabled', 'false')
+    renderHook(() => useAcquireLocation())
+    expect(getCurrentPositionMock).not.toHaveBeenCalled()
+  })
+
+  it('writes coords into the store on success', async () => {
+    localStorage.setItem('locationEnabled', 'true')
+    getCurrentPositionMock.mockResolvedValue({ coords: { latitude: 41.04, longitude: 28.99 } })
+    renderHook(() => useAcquireLocation())
+    await waitFor(() => {
+      expect(geoState.setGeoLocation).toHaveBeenCalledWith({ latitude: 41.04, longitude: 28.99 })
+    })
+  })
+
+  it('swallows errors silently', async () => {
+    localStorage.setItem('locationEnabled', 'true')
+    getCurrentPositionMock.mockRejectedValue(new Error('denied'))
+    renderHook(() => useAcquireLocation())
+    // Give the rejected promise a tick to flush.
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(geoState.setGeoLocation).not.toHaveBeenCalled()
+  })
+
+  it('does not call setGeoLocation if the component unmounts before resolution', async () => {
+    localStorage.setItem('locationEnabled', 'true')
+    let resolveFn!: (v: GeolocationPosition) => void
+    getCurrentPositionMock.mockImplementation(() => new Promise((r) => { resolveFn = r }))
+    const { unmount } = renderHook(() => useAcquireLocation())
+    unmount()
+    resolveFn({ coords: { latitude: 0, longitude: 0 } } as GeolocationPosition)
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(geoState.setGeoLocation).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/hooks/useMyReports.test.ts
+++ b/frontend/src/test/hooks/useMyReports.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const userAPIMock = vi.hoisted(() => ({
+  getMyReports: vi.fn(),
+}))
+
+vi.mock('@/services/userAPI', () => ({
+  userAPI: userAPIMock,
+}))
+
+let useMyReports: typeof import('@/hooks/useMyReports').useMyReports
+
+beforeEach(async () => {
+  userAPIMock.getMyReports.mockReset()
+  vi.resetModules()
+  useMyReports = (await import('@/hooks/useMyReports')).useMyReports
+})
+
+describe('useMyReports', () => {
+  it('starts with reports=null and no error', () => {
+    userAPIMock.getMyReports.mockImplementation(() => new Promise(() => {}))
+    const { result } = renderHook(() => useMyReports())
+    expect(result.current.reports).toBeNull()
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes loaded reports on success', async () => {
+    userAPIMock.getMyReports.mockResolvedValue([{ id: 'r-1', title: 't' }])
+    const { result } = renderHook(() => useMyReports())
+    await waitFor(() => expect(result.current.reports).toEqual([{ id: 'r-1', title: 't' }]))
+  })
+
+  it('captures the error message and resets reports to []', async () => {
+    userAPIMock.getMyReports.mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useMyReports())
+    await waitFor(() => expect(result.current.error).toBe('boom'))
+    expect(result.current.reports).toEqual([])
+  })
+
+  it('falls back to a generic message when the rejection is not an Error', async () => {
+    userAPIMock.getMyReports.mockRejectedValue('nope')
+    const { result } = renderHook(() => useMyReports())
+    await waitFor(() => expect(result.current.error).toBe('Failed to load reports'))
+  })
+
+  it('aborts the in-flight request on unmount', async () => {
+    let observedSignal: AbortSignal | undefined
+    userAPIMock.getMyReports.mockImplementation((signal: AbortSignal) => {
+      observedSignal = signal
+      return new Promise(() => {})
+    })
+    const { unmount } = renderHook(() => useMyReports())
+    unmount()
+    expect(observedSignal?.aborted).toBe(true)
+  })
+
+  it('does not surface an error when rejection arrives after abort', async () => {
+    let rejectFn!: (reason?: unknown) => void
+    userAPIMock.getMyReports.mockImplementation((signal: AbortSignal) =>
+      new Promise<never>((_, reject) => {
+        rejectFn = reject
+        signal.addEventListener('abort', () => reject(new Error('aborted')))
+      }),
+    )
+    const { result, unmount } = renderHook(() => useMyReports())
+    unmount()
+    rejectFn(new Error('aborted'))
+    await new Promise<void>((r) => setTimeout(r, 0))
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/frontend/src/test/hooks/useNotificationSocket.test.ts
+++ b/frontend/src/test/hooks/useNotificationSocket.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { installMockWebSocket, MockWebSocket } from '@/test/helpers/mockWebSocket'
+
+const authState = vi.hoisted(() => ({
+  isAuthenticated: true,
+  user: { id: 'u-1', email: 'a@b.c' },
+}))
+const notificationActions = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  fetchUnreadCount: vi.fn(),
+}))
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => authState,
+}))
+vi.mock('@/store/useNotificationStore', () => ({
+  useNotificationStore: () => notificationActions,
+}))
+vi.mock('sonner', () => ({ toast: vi.fn() }))
+
+let restoreWS: () => void
+let useNotificationSocket: typeof import('@/hooks/useNotificationSocket').useNotificationSocket
+
+beforeEach(async () => {
+  authState.isAuthenticated = true
+  authState.user = { id: 'u-1', email: 'a@b.c' }
+  notificationActions.addNotification.mockReset()
+  notificationActions.fetchUnreadCount.mockReset()
+  restoreWS = installMockWebSocket()
+  vi.resetModules()
+  const mod = await import('@/hooks/useNotificationSocket')
+  useNotificationSocket = mod.useNotificationSocket
+})
+
+afterEach(() => {
+  restoreWS()
+  vi.useRealTimers()
+})
+
+describe('useNotificationSocket', () => {
+  it('opens ws://.../ws/notifications/ when authenticated', () => {
+    renderHook(() => useNotificationSocket())
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.last().url).toMatch(/\/ws\/notifications\/$/)
+  })
+
+  it('does not open a socket when unauthenticated', () => {
+    authState.isAuthenticated = false
+    renderHook(() => useNotificationSocket())
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('syncs unread count on (re)connect', () => {
+    renderHook(() => useNotificationSocket())
+    act(() => MockWebSocket.last().triggerOpen())
+    expect(notificationActions.fetchUnreadCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes notification frames into the store', async () => {
+    const { toast } = await import('sonner')
+    renderHook(() => useNotificationSocket())
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage({
+        type: 'notification',
+        notification: { id: 'n-1', title: 'Hi', message: 'there' },
+      })
+    })
+    expect(notificationActions.addNotification).toHaveBeenCalledWith({ id: 'n-1', title: 'Hi', message: 'there' })
+    expect(toast).toHaveBeenCalledWith('Hi', { description: 'there' })
+  })
+
+  it('ignores non-notification frames', () => {
+    renderHook(() => useNotificationSocket())
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage({ type: 'pong' })
+      MockWebSocket.last().triggerMessage('not-json{')
+    })
+    expect(notificationActions.addNotification).not.toHaveBeenCalled()
+  })
+
+  it('does not reconnect on application-level rejection (code ≥ 4000)', () => {
+    vi.useFakeTimers()
+    renderHook(() => useNotificationSocket())
+    act(() => MockWebSocket.last().triggerOpen())
+    act(() => MockWebSocket.last().triggerClose({ code: 4001 }))
+    act(() => { vi.advanceTimersByTime(60_000) })
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('schedules a reconnect on a transient close', () => {
+    vi.useFakeTimers()
+    renderHook(() => useNotificationSocket())
+    act(() => MockWebSocket.last().triggerOpen())
+    act(() => MockWebSocket.last().triggerClose({ code: 1006 }))
+    act(() => { vi.advanceTimersByTime(1_500) })
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('disconnects when auth flips to logged-out', () => {
+    const { rerender } = renderHook(() => useNotificationSocket())
+    act(() => MockWebSocket.last().triggerOpen())
+    const ws = MockWebSocket.last()
+    authState.isAuthenticated = false
+    authState.user = null as unknown as typeof authState.user
+    rerender()
+    expect(ws.closed?.code).toBe(1000)
+  })
+})

--- a/frontend/src/test/hooks/usePolling.test.ts
+++ b/frontend/src/test/hooks/usePolling.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePolling } from '@/hooks/usePolling'
 

--- a/frontend/src/test/hooks/usePolling.test.ts
+++ b/frontend/src/test/hooks/usePolling.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { usePolling } from '@/hooks/usePolling'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('usePolling', () => {
+  it('sets isLoading on the first call and isRefreshing on subsequent ticks', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => usePolling(fn, [fn], { interval: 1_000 }))
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isRefreshing).toBe(false)
+    await act(async () => { await Promise.resolve() })
+    expect(result.current.isLoading).toBe(false)
+
+    await act(async () => { vi.advanceTimersByTime(1_000) })
+    await act(async () => { await Promise.resolve() })
+    expect(fn).toHaveBeenCalledTimes(2)
+    // Background refresh should never re-show the full-page loading state
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('refresh() triggers an extra run between intervals', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => usePolling(fn, [fn], { interval: 60_000 }))
+    await act(async () => { await Promise.resolve() })
+    expect(fn).toHaveBeenCalledTimes(1)
+    act(() => result.current.refresh())
+    await act(async () => { await Promise.resolve() })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats AbortError / CanceledError / ERR_CANCELED as silent cancellations', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+    const { result } = renderHook(() => usePolling(fn, [fn], { interval: 60_000 }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeNull()
+  })
+
+  it('captures non-cancel errors into error state', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => usePolling(fn, [fn], { interval: 60_000 }))
+    await waitFor(() => expect(result.current.error).toBe('boom'))
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isRefreshing).toBe(false)
+  })
+
+  it('falls back to a default error message when err.message is missing', async () => {
+    const fn = vi.fn().mockRejectedValue({})
+    const { result } = renderHook(() => usePolling(fn, [fn], { interval: 60_000 }))
+    await waitFor(() => expect(result.current.error).toBe('Something went wrong'))
+  })
+
+  it('does not run when enabled is false', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockResolvedValue(undefined)
+    renderHook(() => usePolling(fn, [fn], { interval: 1_000, enabled: false }))
+    await act(async () => { vi.advanceTimersByTime(5_000) })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('re-runs when the tab becomes visible again', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockResolvedValue(undefined)
+    renderHook(() => usePolling(fn, [fn], { interval: 60_000 }))
+    await act(async () => { await Promise.resolve() })
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')) })
+    await act(async () => { await Promise.resolve() })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts the in-flight fetch and stops the interval on unmount', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockImplementation((signal: AbortSignal) =>
+      new Promise<void>((_, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+        })
+      }),
+    )
+    const { unmount } = renderHook(() => usePolling(fn, [fn], { interval: 1_000 }))
+    expect(fn).toHaveBeenCalledTimes(1)
+    const signal = (fn.mock.calls[0]![0]) as AbortSignal
+    unmount()
+    expect(signal.aborted).toBe(true)
+    await act(async () => { vi.advanceTimersByTime(5_000) })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/test/hooks/useWebSocket.test.ts
+++ b/frontend/src/test/hooks/useWebSocket.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useWebSocket } from '@/hooks/useWebSocket'
+import { installMockWebSocket, MockWebSocket } from '@/test/helpers/mockWebSocket'
+
+let restoreWS: () => void
+
+beforeEach(() => {
+  restoreWS = installMockWebSocket()
+})
+
+afterEach(() => {
+  restoreWS()
+  vi.useRealTimers()
+})
+
+describe('useWebSocket — connect', () => {
+  it('opens the given url verbatim when no token is supplied', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/ws/chat/1/' }))
+    expect(MockWebSocket.last().url).toBe('ws://host/ws/chat/1/')
+  })
+
+  it('appends ?token= when token is supplied (mobile path)', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/ws/chat/1/', token: 'abc 123' }))
+    expect(MockWebSocket.last().url).toBe('ws://host/ws/chat/1/?token=abc%20123')
+  })
+
+  it('appends with & when url already has a query string', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/ws/chat/1/?room=2', token: 't' }))
+    expect(MockWebSocket.last().url).toBe('ws://host/ws/chat/1/?room=2&token=t')
+  })
+
+  it('does not open when enabled is false', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/', enabled: false }))
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('flips isConnected on open and back on close', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    expect(result.current.isConnected).toBe(false)
+    act(() => MockWebSocket.last().triggerOpen())
+    expect(result.current.isConnected).toBe(true)
+    act(() => MockWebSocket.last().triggerClose({ code: 1000 }))
+    expect(result.current.isConnected).toBe(false)
+  })
+})
+
+describe('useWebSocket — message dispatch', () => {
+  it('forwards chat_message frames to onMessage', () => {
+    const onMessage = vi.fn()
+    renderHook(() => useWebSocket({ url: 'ws://host/', onMessage }))
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage({ type: 'chat_message', message: { id: 1, body: 'hi' } })
+    })
+    expect(onMessage).toHaveBeenCalledWith({ id: 1, body: 'hi' })
+  })
+
+  it('forwards notification frames to onMessage', () => {
+    const onMessage = vi.fn()
+    renderHook(() => useWebSocket({ url: 'ws://host/', onMessage }))
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage({ type: 'notification', message: { id: 'n-1' } })
+    })
+    expect(onMessage).toHaveBeenCalledWith({ id: 'n-1' })
+  })
+
+  it('ignores unknown frame types', () => {
+    const onMessage = vi.fn()
+    renderHook(() => useWebSocket({ url: 'ws://host/', onMessage }))
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage({ type: 'pong' })
+    })
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('swallows malformed JSON frames', () => {
+    const onMessage = vi.fn()
+    renderHook(() => useWebSocket({ url: 'ws://host/', onMessage }))
+    act(() => {
+      MockWebSocket.last().triggerOpen()
+      MockWebSocket.last().triggerMessage('not-json{')
+    })
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('uses the latest onMessage callback even after re-render', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = renderHook(
+      ({ cb }) => useWebSocket({ url: 'ws://host/', onMessage: cb }),
+      { initialProps: { cb: first } },
+    )
+    act(() => MockWebSocket.last().triggerOpen())
+    rerender({ cb: second })
+    act(() => {
+      MockWebSocket.last().triggerMessage({ type: 'chat_message', message: 'x' })
+    })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledWith('x')
+  })
+})
+
+describe('useWebSocket — sendMessage', () => {
+  it('serialises and sends when socket is OPEN', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    let ok = false
+    act(() => { ok = result.current.sendMessage('hello') })
+    expect(ok).toBe(true)
+    expect(MockWebSocket.last().sent).toEqual([
+      JSON.stringify({ type: 'chat_message', body: 'hello' }),
+    ])
+  })
+
+  it('returns false when socket is not OPEN', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    let ok = true
+    act(() => { ok = result.current.sendMessage('hi') })
+    expect(ok).toBe(false)
+    expect(MockWebSocket.last().sent).toEqual([])
+  })
+})
+
+describe('useWebSocket — reconnect', () => {
+  beforeEach(() => vi.useFakeTimers())
+
+  it('schedules a reconnect after a non-clean close', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    expect(MockWebSocket.instances).toHaveLength(1)
+    // open >2s so backoff uses 2^prev, not the 8s "short open" path
+    act(() => { vi.advanceTimersByTime(2_500) })
+    act(() => MockWebSocket.last().triggerClose({ code: 1006 }))
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('uses 8s backoff when the connection lasted less than 2s', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    act(() => MockWebSocket.last().triggerClose({ code: 1006 }))
+    // 1s would be the normal first backoff; we expect 8s instead.
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => { vi.advanceTimersByTime(7_500) })
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('does not reconnect on application-level rejection (code ≥ 4000)', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    act(() => MockWebSocket.last().triggerClose({ code: 4001 }))
+    act(() => { vi.advanceTimersByTime(60_000) })
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('does not reconnect on a clean close (code 1000)', () => {
+    renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    act(() => MockWebSocket.last().triggerClose({ code: 1000 }))
+    act(() => { vi.advanceTimersByTime(60_000) })
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('caps reconnect attempts at 5', () => {
+    // Each iteration: open + close-without-stabilising → 8s backoff branch.
+    // Closing before 2s clears the stable-timer, so reconnectAttempts keeps
+    // climbing and the 5-cap kicks in.
+    renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    for (let i = 0; i < 8; i++) {
+      act(() => MockWebSocket.last().triggerOpen())
+      act(() => MockWebSocket.last().triggerClose({ code: 1006 }))
+      act(() => { vi.advanceTimersByTime(9_000) })
+    }
+    // 1 initial + 5 retries = 6 total; further closes don't schedule.
+    expect(MockWebSocket.instances).toHaveLength(6)
+  })
+})
+
+describe('useWebSocket — url change & disconnect', () => {
+  it('opens a new socket when url changes', () => {
+    const { rerender } = renderHook(
+      ({ url }) => useWebSocket({ url }),
+      { initialProps: { url: 'ws://a/' } },
+    )
+    expect(MockWebSocket.last().url).toBe('ws://a/')
+    rerender({ url: 'ws://b/' })
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(MockWebSocket.last().url).toBe('ws://b/')
+  })
+
+  it('does not reopen when url is unchanged', () => {
+    const { rerender } = renderHook(
+      ({ url }: { url: string }) => useWebSocket({ url }),
+      { initialProps: { url: 'ws://a/' } },
+    )
+    act(() => MockWebSocket.last().triggerOpen())
+    rerender({ url: 'ws://a/' })
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('closes with code 1000 on disconnect()', () => {
+    const { result } = renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    const ws = MockWebSocket.last()
+    act(() => result.current.disconnect())
+    expect(ws.closed?.code).toBe(1000)
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('disconnects on unmount', () => {
+    const { unmount } = renderHook(() => useWebSocket({ url: 'ws://host/' }))
+    act(() => MockWebSocket.last().triggerOpen())
+    const ws = MockWebSocket.last()
+    unmount()
+    expect(ws.closed?.code).toBe(1000)
+  })
+})

--- a/frontend/src/test/services/activityAPI.test.ts
+++ b/frontend/src/test/services/activityAPI.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({ get: vi.fn() }))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let activityAPI: typeof import('@/services/activityAPI').activityAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  vi.resetModules()
+  activityAPI = (await import('@/services/activityAPI')).activityAPI
+})
+
+const event = {
+  id: 1,
+  verb: 'service_created' as const,
+  actor: { id: 'u-1', first_name: 'A', last_name: 'B', avatar_url: null },
+  target_user: null,
+  service: null,
+  created_at: '2026-05-08T00:00:00Z',
+  distance_km: null,
+  event_capacity_pct: null,
+  event_starts_in_seconds: null,
+  handshake_duration_hours: null,
+  actor_skills: null,
+  actor_location: null,
+}
+
+describe('activityAPI.feed', () => {
+  it('GETs /activity/feed/ with empty params when none provided', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } })
+    const out = await activityAPI.feed()
+    const call = apiMocks.get.mock.calls[0]
+    expect(call[0]).toBe('/activity/feed/')
+    expect((call[1].params as URLSearchParams).toString()).toBe('')
+    expect(out).toEqual([])
+  })
+
+  it('builds the query string from days, lat, lng, page, sort', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 1, next: null, previous: null, results: [event] } })
+    await activityAPI.feed({ days: 7, lat: 40.5, lng: -3.7, page: 2, sort: 'nearby' })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('days')).toBe('7')
+    expect(params.get('lat')).toBe('40.5')
+    expect(params.get('lng')).toBe('-3.7')
+    expect(params.get('page')).toBe('2')
+    expect(params.get('sort')).toBe('nearby')
+  })
+
+  it('omits unset params (null vs zero distinction)', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } })
+    await activityAPI.feed({ days: 0, page: 1 })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('days')).toBe('0')
+    expect(params.has('lat')).toBe(false)
+    expect(params.has('sort')).toBe(false)
+  })
+
+  it('extracts results from a paginated response', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: { count: 1, next: null, previous: null, results: [event] },
+    })
+    const out = await activityAPI.feed()
+    expect(out).toEqual([event])
+  })
+
+  it('returns the array directly when the response is already an array', async () => {
+    apiMocks.get.mockResolvedValue({ data: [event] })
+    const out = await activityAPI.feed()
+    expect(out).toEqual([event])
+  })
+
+  it('returns [] when paginated response has no results key', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null } })
+    const out = await activityAPI.feed()
+    expect(out).toEqual([])
+  })
+
+  it('forwards the abort signal', async () => {
+    const ac = new AbortController()
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await activityAPI.feed({}, ac.signal)
+    expect(apiMocks.get.mock.calls[0][1].signal).toBe(ac.signal)
+  })
+})

--- a/frontend/src/test/services/adminAPI.test.ts
+++ b/frontend/src/test/services/adminAPI.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let adminAPI: typeof import('@/services/adminAPI').adminAPI
+
+beforeEach(async () => {
+  Object.values(apiMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  adminAPI = (await import('@/services/adminAPI')).adminAPI
+})
+
+describe('adminAPI.getMetrics / getSettings / updateSettings', () => {
+  it('GETs /metrics/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { active_users: 0 } })
+    await adminAPI.getMetrics()
+    expect(apiMocks.get).toHaveBeenCalledWith('/metrics/', { signal: undefined })
+  })
+
+  it('GETs /admin/settings/', async () => {
+    apiMocks.get.mockResolvedValue({ data: {} })
+    await adminAPI.getSettings()
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/settings/', { signal: undefined })
+  })
+
+  it('PATCHes /admin/settings/ with the partial payload', async () => {
+    apiMocks.patch.mockResolvedValue({ data: {} })
+    await adminAPI.updateSettings({ feature_flag: true } as never)
+    expect(apiMocks.patch).toHaveBeenCalledWith('/admin/settings/', { feature_flag: true }, { signal: undefined })
+  })
+})
+
+describe('adminAPI.getReports', () => {
+  it('defaults status=pending, page=1, page_size=20 and includes a cache-bust _t', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await adminAPI.getReports()
+    const params = apiMocks.get.mock.calls[0][1].params
+    expect(params).toMatchObject({ status: 'pending', page: 1, page_size: 20 })
+    expect(typeof params._t).toBe('number')
+  })
+
+  it('wraps a bare-array response into a paginated structure', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ id: 'r-1' }, { id: 'r-2' }] })
+    const out = await adminAPI.getReports()
+    expect(out).toEqual({ count: 2, next: null, previous: null, results: [{ id: 'r-1' }, { id: 'r-2' }] })
+  })
+
+  it('passes through paginated responses unchanged', async () => {
+    const payload = { count: 5, next: 'p2', previous: null, results: [{ id: 'r-1' }] }
+    apiMocks.get.mockResolvedValue({ data: payload })
+    const out = await adminAPI.getReports('resolved', 2, 50)
+    expect(out).toBe(payload)
+  })
+})
+
+describe('adminAPI.resolveReport / pauseHandshake', () => {
+  it('resolveReport POSTs the action and admin_notes payload', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'r-1' } })
+    await adminAPI.resolveReport('r-1', 'mark_resolved', 'note')
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/admin/reports/r-1/resolve/',
+      { action: 'mark_resolved', admin_notes: 'note' },
+      { signal: undefined },
+    )
+  })
+
+  it('resolveReport defaults admin_notes to empty string when omitted', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'r-1' } })
+    await adminAPI.resolveReport('r-1', 'dismiss')
+    expect(apiMocks.post.mock.calls[0][1].admin_notes).toBe('')
+  })
+
+  it('pauseHandshake POSTs an empty body to /pause/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { status: 'paused' } })
+    await adminAPI.pauseHandshake('r-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/admin/reports/r-1/pause/', {}, { signal: undefined })
+  })
+})
+
+describe('adminAPI.getUsers', () => {
+  it('omits search/status when undefined and forwards page/page_size', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await adminAPI.getUsers()
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/users/', {
+      params: { search: undefined, status: undefined, page: 1, page_size: 20 },
+      signal: undefined,
+    })
+  })
+
+  it('passes search and status when set', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await adminAPI.getUsers('alice', 'banned', 2, 10)
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/users/', {
+      params: { search: 'alice', status: 'banned', page: 2, page_size: 10 },
+      signal: undefined,
+    })
+  })
+})
+
+describe('adminAPI.warnUser / banUser / unbanUser / adjustKarma / assignUserRole', () => {
+  it('warnUser POSTs message', async () => {
+    apiMocks.post.mockResolvedValue({ data: {} })
+    await adminAPI.warnUser('u-1', 'be nice')
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/admin/users/u-1/warn/',
+      { message: 'be nice' },
+      { signal: undefined },
+    )
+  })
+
+  it('banUser POSTs empty body', async () => {
+    apiMocks.post.mockResolvedValue({ data: {} })
+    await adminAPI.banUser('u-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/admin/users/u-1/ban/', {}, { signal: undefined })
+  })
+
+  it('unbanUser POSTs empty body', async () => {
+    apiMocks.post.mockResolvedValue({ data: {} })
+    await adminAPI.unbanUser('u-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/admin/users/u-1/unban/', {}, { signal: undefined })
+  })
+
+  it('adjustKarma POSTs adjustment value', async () => {
+    apiMocks.post.mockResolvedValue({ data: { new_karma: 5 } })
+    await adminAPI.adjustKarma('u-1', -3)
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/admin/users/u-1/adjust-karma/',
+      { adjustment: -3 },
+      { signal: undefined },
+    )
+  })
+
+  it('assignUserRole POSTs role', async () => {
+    apiMocks.post.mockResolvedValue({ data: {} })
+    await adminAPI.assignUserRole('u-1', 'moderator')
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/admin/users/u-1/assign-role/',
+      { role: 'moderator' },
+      { signal: undefined },
+    )
+  })
+})
+
+describe('adminAPI.getComments', () => {
+  it('defaults status=active, omits search when empty', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await adminAPI.getComments()
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/comments/', {
+      params: { status: 'active', page: 1, page_size: 20, search: undefined },
+      signal: undefined,
+    })
+  })
+
+  it('forwards search when set', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await adminAPI.getComments('removed', 2, 10, 'spam')
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/comments/', {
+      params: { status: 'removed', page: 2, page_size: 10, search: 'spam' },
+      signal: undefined,
+    })
+  })
+})
+
+describe('adminAPI.removeComment / restoreComment', () => {
+  it('removeComment POSTs to /remove/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'c-1' } })
+    await adminAPI.removeComment('c-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/admin/comments/c-1/remove/', {}, { signal: undefined })
+  })
+
+  it('restoreComment POSTs to /restore/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'c-1' } })
+    await adminAPI.restoreComment('c-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/admin/comments/c-1/restore/', {}, { signal: undefined })
+  })
+})
+
+describe('adminAPI.getAuditLogs', () => {
+  it('omits action_type when blank, drops target_entity when "all"', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await adminAPI.getAuditLogs(undefined, 'all')
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/audit-logs/', {
+      params: { action_type: undefined, target_entity: undefined, page: 1, page_size: 20 },
+      signal: undefined,
+    })
+  })
+
+  it('passes through specific filter values', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await adminAPI.getAuditLogs('ban', 'user', 3, 25)
+    expect(apiMocks.get).toHaveBeenCalledWith('/admin/audit-logs/', {
+      params: { action_type: 'ban', target_entity: 'user', page: 3, page_size: 25 },
+      signal: undefined,
+    })
+  })
+})

--- a/frontend/src/test/services/api.test.ts
+++ b/frontend/src/test/services/api.test.ts
@@ -100,4 +100,45 @@ describe('getErrorMessage', () => {
     const err = withResponse({ error: 42 } as unknown as Record<string, unknown>)
     expect(getErrorMessage(err)).toBe('42')
   })
+
+  it('does not treat an Array response body as a field-error map', () => {
+    // Arrays pass `typeof === 'object'`, so without the `!Array.isArray`
+    // guard the function would iterate them as field keys and emit "a. b".
+    const err = withResponse(['a', 'b'] as unknown as Record<string, unknown>)
+    expect(getErrorMessage(err)).toBe('axios error')
+  })
+
+  it('does not treat a string response body as a field-error map', () => {
+    // The `typeof === 'object'` guard must reject string payloads — otherwise
+    // each character becomes a field key and the output is "h. e. l. l. o".
+    const err = withResponse('hello' as unknown as Record<string, unknown>)
+    expect(getErrorMessage(err)).toBe('axios error')
+  })
+
+  it('renders a top-level messages array (not in the known-keys set as a singular)', () => {
+    // 'messages' (plural) is in the known-top-keys set so it should NOT be
+    // surfaced as an inline field error. Asserting on its absence pins the
+    // membership of that key in the set.
+    const err = withResponse({ messages: ['err1', 'err2'] })
+    expect(getErrorMessage(err)).toBe('axios error')
+  })
+
+  it('joins multiple field-error arrays with ". " between them', () => {
+    const err = withResponse({
+      detail: 'Invalid input',
+      field_errors: {
+        email: ['required'],
+        password: ['too short'],
+      },
+    })
+    // Both inline (none here) + field_errors are joined with ". " in `${detail}: …`.
+    expect(getErrorMessage(err)).toBe('Invalid input: required. too short')
+  })
+
+  it('joins items inside one field-error array with ", " (not ". ")', () => {
+    const err = withResponse({
+      field_errors: { email: ['Invalid email.', 'Already taken.'] },
+    })
+    expect(getErrorMessage(err)).toBe('Invalid email., Already taken.')
+  })
 })

--- a/frontend/src/test/services/authAPI.test.ts
+++ b/frontend/src/test/services/authAPI.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn((_e: unknown, fallback?: string) => fallback ?? 'err'),
+}))
+
+let authAPI: typeof import('@/services/authAPI').authAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  apiMocks.post.mockReset()
+  vi.resetModules()
+  authAPI = (await import('@/services/authAPI')).authAPI
+})
+
+describe('authAPI.forgotPassword', () => {
+  it('posts the email payload to /auth/forgot-password/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'sent' } })
+    const res = await authAPI.forgotPassword('a@b.co')
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/forgot-password/', { email: 'a@b.co' })
+    expect(res.data.detail).toBe('sent')
+  })
+
+  it('propagates rejection unchanged', async () => {
+    const err = Object.assign(new Error('429'), { response: { status: 429 } })
+    apiMocks.post.mockRejectedValue(err)
+    await expect(authAPI.forgotPassword('a@b.co')).rejects.toBe(err)
+  })
+})
+
+describe('authAPI.resetPassword', () => {
+  it('sends token + password to /auth/reset-password/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'ok' } })
+    await authAPI.resetPassword('tok-1', 'newPwd')
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/reset-password/', {
+      token: 'tok-1',
+      password: 'newPwd',
+    })
+  })
+})
+
+describe('authAPI.verifyEmail', () => {
+  it('returns the access token + user payload from the body', async () => {
+    apiMocks.post.mockResolvedValue({
+      data: { detail: 'ok', access: 'jwt', user: { id: '1' } },
+    })
+    const res = await authAPI.verifyEmail('tok-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/verify-email/', { token: 'tok-1' })
+    expect(res.data.access).toBe('jwt')
+    expect(res.data.user).toEqual({ id: '1' })
+  })
+
+  it('rejects on invalid token', async () => {
+    const err = Object.assign(new Error('400'), { response: { status: 400 } })
+    apiMocks.post.mockRejectedValue(err)
+    await expect(authAPI.verifyEmail('bad')).rejects.toBe(err)
+  })
+})
+
+describe('authAPI.resendVerification', () => {
+  it('posts the email to /auth/resend-verification/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'sent' } })
+    await authAPI.resendVerification('a@b.co')
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/resend-verification/', { email: 'a@b.co' })
+  })
+})
+
+describe('authAPI.sendVerification', () => {
+  it('posts to /auth/send-verification/ with no payload', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'ok' } })
+    await authAPI.sendVerification()
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/send-verification/')
+  })
+})
+
+describe('authAPI.changePassword', () => {
+  it('renames camelCase args to snake_case body fields', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'ok' } })
+    await authAPI.changePassword('old123', 'new456')
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/change-password/', {
+      current_password: 'old123',
+      new_password: 'new456',
+    })
+  })
+})
+
+describe('authAPI.logout', () => {
+  it('posts to /auth/logout/ with no body', async () => {
+    apiMocks.post.mockResolvedValue({ data: { detail: 'bye' } })
+    await authAPI.logout()
+    expect(apiMocks.post).toHaveBeenCalledWith('/auth/logout/')
+  })
+
+  it('rejects when the server errors', async () => {
+    apiMocks.post.mockRejectedValue(new Error('boom'))
+    await expect(authAPI.logout()).rejects.toThrow('boom')
+  })
+})
+
+describe('authAPI.getWsToken', () => {
+  it('GETs /auth/ws-token/ and returns the token', async () => {
+    apiMocks.get.mockResolvedValue({ data: { token: 'wsjwt' } })
+    const res = await authAPI.getWsToken()
+    expect(apiMocks.get).toHaveBeenCalledWith('/auth/ws-token/')
+    expect(res.data.token).toBe('wsjwt')
+  })
+})

--- a/frontend/src/test/services/calendarAPI.test.ts
+++ b/frontend/src/test/services/calendarAPI.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({ get: vi.fn() }))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let calendarAPI: typeof import('@/services/calendarAPI').calendarAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  vi.resetModules()
+  calendarAPI = (await import('@/services/calendarAPI')).calendarAPI
+})
+
+describe('calendarAPI.fetchUpcoming', () => {
+  it('GETs /users/me/calendar/ with empty params when none provided', async () => {
+    apiMocks.get.mockResolvedValue({ data: { items: [] } })
+    const out = await calendarAPI.fetchUpcoming()
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/me/calendar/', { params: {}, signal: undefined })
+    expect(out).toEqual({ items: [] })
+  })
+
+  it('forwards from / to params and abort signal', async () => {
+    const ac = new AbortController()
+    apiMocks.get.mockResolvedValue({ data: { items: [] } })
+    await calendarAPI.fetchUpcoming({ from: '2026-05-01', to: '2026-06-01' }, ac.signal)
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/me/calendar/', {
+      params: { from: '2026-05-01', to: '2026-06-01' },
+      signal: ac.signal,
+    })
+  })
+
+  it('returns the response data unmodified', async () => {
+    const payload = { items: [{ id: 1 }] } as never
+    apiMocks.get.mockResolvedValue({ data: payload })
+    const out = await calendarAPI.fetchUpcoming()
+    expect(out).toBe(payload)
+  })
+
+  it('propagates rejection unchanged', async () => {
+    const err = Object.assign(new Error('500'), { response: { status: 500 } })
+    apiMocks.get.mockRejectedValue(err)
+    await expect(calendarAPI.fetchUpcoming()).rejects.toBe(err)
+  })
+})

--- a/frontend/src/test/services/commentAPI.test.ts
+++ b/frontend/src/test/services/commentAPI.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let commentAPI: typeof import('@/services/commentAPI').commentAPI
+
+beforeEach(async () => {
+  Object.values(apiMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  commentAPI = (await import('@/services/commentAPI')).commentAPI
+})
+
+describe('commentAPI.list', () => {
+  it('GETs /services/:id/comments/ with empty params when no page', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } })
+    await commentAPI.list('s-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/services/s-1/comments/', { params: {}, signal: undefined })
+  })
+
+  it('forwards page param when provided', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } })
+    await commentAPI.list('s-1', 3)
+    expect(apiMocks.get).toHaveBeenCalledWith('/services/s-1/comments/', {
+      params: { page: 3 },
+      signal: undefined,
+    })
+  })
+
+  it('returns the response data unchanged', async () => {
+    const payload = { count: 1, next: null, previous: null, results: [{ id: 'c-1' }] } as never
+    apiMocks.get.mockResolvedValue({ data: payload })
+    const out = await commentAPI.list('s-1')
+    expect(out).toBe(payload)
+  })
+
+  it('forwards abort signal', async () => {
+    const ac = new AbortController()
+    apiMocks.get.mockResolvedValue({ data: { count: 0, next: null, previous: null, results: [] } })
+    await commentAPI.list('s-1', undefined, ac.signal)
+    expect(apiMocks.get.mock.calls[0][1].signal).toBe(ac.signal)
+  })
+})
+
+describe('commentAPI.create', () => {
+  it('POSTs body without parent_id when none provided', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'c-1' } })
+    await commentAPI.create('s-1', 'hello')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/comments/', { body: 'hello' }, { signal: undefined })
+  })
+
+  it('includes parent_id when provided', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'c-2' } })
+    await commentAPI.create('s-1', 'reply', 'c-parent')
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/services/s-1/comments/',
+      { body: 'reply', parent_id: 'c-parent' },
+      { signal: undefined },
+    )
+  })
+
+  it('forwards abort signal', async () => {
+    const ac = new AbortController()
+    apiMocks.post.mockResolvedValue({ data: { id: 'c-1' } })
+    await commentAPI.create('s-1', 'hi', undefined, ac.signal)
+    expect(apiMocks.post.mock.calls[0][2].signal).toBe(ac.signal)
+  })
+})
+
+describe('commentAPI.delete', () => {
+  it('DELETEs /services/:sid/comments/:cid/', async () => {
+    apiMocks.delete.mockResolvedValue({})
+    await commentAPI.delete('s-1', 'c-1')
+    expect(apiMocks.delete).toHaveBeenCalledWith('/services/s-1/comments/c-1/', { signal: undefined })
+  })
+})

--- a/frontend/src/test/services/conversationAPI.test.ts
+++ b/frontend/src/test/services/conversationAPI.test.ts
@@ -120,6 +120,29 @@ describe('groupChatAPI', () => {
     }))
   })
 
+  it('getMessages preserves non-empty participants and messages instead of replacing them with []', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: {
+        service_id: 'svc-1',
+        service_title: 't',
+        participants: [{ id: 'u-1', name: 'A' }],
+        messages: [{ id: 'm-1', body: 'hi' }],
+      },
+    })
+    const out = await groupChatAPI.getMessages('svc-1')
+    expect(out.participants).toEqual([{ id: 'u-1', name: 'A' }])
+    expect(out.messages).toEqual([{ id: 'm-1', body: 'hi' }])
+  })
+
+  it('getMessages defaults participants and messages to [] when they are missing', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: { service_id: 'svc-1', service_title: 't' },
+    })
+    const out = await groupChatAPI.getMessages('svc-1')
+    expect(out.participants).toEqual([])
+    expect(out.messages).toEqual([])
+  })
+
   it('getMessages with sessionId attaches the session_id param', async () => {
     apiMocks.get.mockResolvedValue({
       data: { service_id: 'svc-1', service_title: 't', participants: [], messages: [] },
@@ -144,15 +167,16 @@ describe('groupChatAPI', () => {
 })
 
 describe('eventChatAPI', () => {
-  it('getMessages flattens the room and messages.results pair', async () => {
+  it('getMessages flattens the room and messages.results pair and forwards the abort signal', async () => {
     apiMocks.get.mockResolvedValue({
       data: {
         room: { id: 'r-1', name: 'event', type: 'event', related_service: 'svc', created_at: 't' },
         messages: { results: [{ id: 'em-1' } as never] },
       },
     })
-    const out = await eventChatAPI.getMessages('svc-1')
-    expect(apiMocks.get).toHaveBeenCalledWith('/public-chat/svc-1/', expect.objectContaining({}))
+    const ac = new AbortController()
+    const out = await eventChatAPI.getMessages('svc-1', ac.signal)
+    expect(apiMocks.get).toHaveBeenCalledWith('/public-chat/svc-1/', { signal: ac.signal })
     expect(out.room.id).toBe('r-1')
     expect(out.messages).toEqual([{ id: 'em-1' }])
   })

--- a/frontend/src/test/services/forumAPI.test.ts
+++ b/frontend/src/test/services/forumAPI.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let forumAPI: typeof import('@/services/forumAPI').forumAPI
+
+beforeEach(async () => {
+  Object.values(apiMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  forumAPI = (await import('@/services/forumAPI')).forumAPI
+})
+
+describe('forumAPI.listCategories', () => {
+  it('GETs /forum/categories/', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ slug: 'general' }] })
+    const out = await forumAPI.listCategories()
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/categories/', { signal: undefined })
+    expect(out).toEqual([{ slug: 'general' }])
+  })
+})
+
+describe('forumAPI.getCategory', () => {
+  it('GETs /forum/categories/:slug/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { slug: 'general' } })
+    const out = await forumAPI.getCategory('general')
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/categories/general/', { signal: undefined })
+    expect(out).toEqual({ slug: 'general' })
+  })
+})
+
+describe('forumAPI.listTopics', () => {
+  it('GETs /forum/topics/ with no params by default', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await forumAPI.listTopics()
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/topics/', { params: {}, signal: undefined })
+  })
+
+  it('forwards category/page/page_size/sort params', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await forumAPI.listTopics({ category: 'general', page: 2, page_size: 50, sort: 'most_active' })
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/topics/', {
+      params: { category: 'general', page: 2, page_size: 50, sort: 'most_active' },
+      signal: undefined,
+    })
+  })
+})
+
+describe('forumAPI.getTopic / createTopic / updateTopic / deleteTopic', () => {
+  it('getTopic GETs /forum/topics/:id/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 't-1' } })
+    const out = await forumAPI.getTopic('t-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/topics/t-1/', { signal: undefined })
+    expect(out).toEqual({ id: 't-1' })
+  })
+
+  it('createTopic POSTs the title/body/category payload', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 't-2' } })
+    const out = await forumAPI.createTopic({ title: 'T', body: 'B', category: 'general' })
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/', {
+      title: 'T', body: 'B', category: 'general',
+    })
+    expect(out).toEqual({ id: 't-2' })
+  })
+
+  it('updateTopic PATCHes /forum/topics/:id/', async () => {
+    apiMocks.patch.mockResolvedValue({ data: { id: 't-1', title: 'New' } })
+    await forumAPI.updateTopic('t-1', { title: 'New' })
+    expect(apiMocks.patch).toHaveBeenCalledWith('/forum/topics/t-1/', { title: 'New' })
+  })
+
+  it('deleteTopic DELETEs /forum/topics/:id/', async () => {
+    apiMocks.delete.mockResolvedValue({})
+    await forumAPI.deleteTopic('t-1')
+    expect(apiMocks.delete).toHaveBeenCalledWith('/forum/topics/t-1/')
+  })
+})
+
+describe('forumAPI.pinTopic / lockTopic', () => {
+  it('pinTopic POSTs to /forum/topics/:id/pin/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 't-1' } })
+    await forumAPI.pinTopic('t-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/t-1/pin/')
+  })
+
+  it('lockTopic POSTs to /forum/topics/:id/lock/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 't-1' } })
+    await forumAPI.lockTopic('t-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/t-1/lock/')
+  })
+})
+
+describe('forumAPI.reportTopic / reportPost', () => {
+  it('reportTopic posts type+description to /forum/topics/:id/report/', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await forumAPI.reportTopic('t-1', 'spam', 'because')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/t-1/report/', {
+      type: 'spam', description: 'because',
+    })
+  })
+
+  it('reportTopic defaults description to empty string when omitted', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await forumAPI.reportTopic('t-1', 'inappropriate_content')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/t-1/report/', {
+      type: 'inappropriate_content', description: '',
+    })
+  })
+
+  it('reportPost posts to /forum/posts/:id/report/', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await forumAPI.reportPost('p-1', 'harassment', 'detail')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/posts/p-1/report/', {
+      type: 'harassment', description: 'detail',
+    })
+  })
+})
+
+describe('forumAPI posts (listPosts, createPost, updatePost, deletePost)', () => {
+  it('listPosts GETs /forum/topics/:id/posts/ with params', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await forumAPI.listPosts('t-1', { page: 2, page_size: 25 })
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/topics/t-1/posts/', {
+      params: { page: 2, page_size: 25 },
+      signal: undefined,
+    })
+  })
+
+  it('createPost POSTs body to /forum/topics/:id/posts/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'p-1' } })
+    await forumAPI.createPost('t-1', 'hello')
+    expect(apiMocks.post).toHaveBeenCalledWith('/forum/topics/t-1/posts/', { body: 'hello' })
+  })
+
+  it('updatePost PATCHes /forum/posts/:id/', async () => {
+    apiMocks.patch.mockResolvedValue({ data: { id: 'p-1' } })
+    await forumAPI.updatePost('p-1', 'edited')
+    expect(apiMocks.patch).toHaveBeenCalledWith('/forum/posts/p-1/', { body: 'edited' })
+  })
+
+  it('deletePost DELETEs /forum/posts/:id/', async () => {
+    apiMocks.delete.mockResolvedValue({})
+    await forumAPI.deletePost('p-1')
+    expect(apiMocks.delete).toHaveBeenCalledWith('/forum/posts/p-1/')
+  })
+
+  it('listRecentPosts GETs /forum/posts/recent/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [] } })
+    await forumAPI.listRecentPosts({ page: 1, page_size: 20 })
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/posts/recent/', {
+      params: { page: 1, page_size: 20 },
+      signal: undefined,
+    })
+  })
+})
+
+describe('forumAPI.getMyActivity', () => {
+  it('GETs /forum/my-activity/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { topic_count: 3 } as never })
+    const out = await forumAPI.getMyActivity()
+    expect(apiMocks.get).toHaveBeenCalledWith('/forum/my-activity/', { signal: undefined })
+    expect(out).toEqual({ topic_count: 3 })
+  })
+})

--- a/frontend/src/test/services/handshakeAPI.test.ts
+++ b/frontend/src/test/services/handshakeAPI.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let handshakeAPI: typeof import('@/services/handshakeAPI').handshakeAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  apiMocks.post.mockReset()
+  vi.resetModules()
+  handshakeAPI = (await import('@/services/handshakeAPI')).handshakeAPI
+})
+
+describe('handshakeAPI.list', () => {
+  it('GETs /handshakes/ and returns the array', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ id: 'h-1' }] })
+    const out = await handshakeAPI.list()
+    expect(apiMocks.get).toHaveBeenCalledWith('/handshakes/', { signal: undefined })
+    expect(out).toEqual([{ id: 'h-1' }])
+  })
+
+  it('returns [] when response is not an array', async () => {
+    apiMocks.get.mockResolvedValue({ data: { detail: 'oops' } })
+    const out = await handshakeAPI.list()
+    expect(out).toEqual([])
+  })
+})
+
+describe('handshakeAPI single-id endpoints', () => {
+  it.each([
+    ['accept', 'accept/'],
+    ['deny', 'deny/'],
+    ['cancel', 'cancel/'],
+    ['approveCancellation', 'cancel-request/approve/'],
+    ['rejectCancellation', 'cancel-request/reject/'],
+    ['approve', 'approve/'],
+    ['requestChanges', 'request-changes/'],
+    ['confirm', 'confirm/'],
+    ['leaveEvent', 'leave-event/'],
+    ['markAttended', 'mark-attended/'],
+  ] as const)('%s POSTs to /handshakes/:id/%s with empty body', async (method, suffix) => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await (handshakeAPI[method] as (id: string) => Promise<unknown>)('h-1')
+    expect(apiMocks.post).toHaveBeenCalledWith(`/handshakes/h-1/${suffix}`, {})
+  })
+})
+
+describe('handshakeAPI.get', () => {
+  it('GETs /handshakes/:id/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.get('h-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/handshakes/h-1/', { signal: undefined })
+  })
+})
+
+describe('handshakeAPI.requestCancellation', () => {
+  it('POSTs an empty body when no reason given', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.requestCancellation('h-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/cancel-request/', {})
+  })
+
+  it('POSTs reason when given', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.requestCancellation('h-1', 'no longer available')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/cancel-request/', {
+      reason: 'no longer available',
+    })
+  })
+})
+
+describe('handshakeAPI.initiate', () => {
+  it('POSTs the InitiatePayload to /initiate/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.initiate('h-1', {
+      exact_location: 'Cafe X',
+      exact_duration: 2,
+      scheduled_time: '2026-06-01T10:00:00Z',
+      exact_location_lat: 41.0,
+      exact_location_lng: 29.0,
+    })
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/initiate/', {
+      exact_location: 'Cafe X',
+      exact_duration: 2,
+      scheduled_time: '2026-06-01T10:00:00Z',
+      exact_location_lat: 41.0,
+      exact_location_lng: 29.0,
+    })
+  })
+})
+
+describe('handshakeAPI.report', () => {
+  it('POSTs without reported_user_id when not provided', async () => {
+    apiMocks.post.mockResolvedValue({ data: { status: 'ok', report_id: 'r-1' } })
+    await handshakeAPI.report('h-1', 'no_show', 'because')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/report/', {
+      issue_type: 'no_show',
+      description: 'because',
+    })
+  })
+
+  it('includes reported_user_id when provided', async () => {
+    apiMocks.post.mockResolvedValue({ data: { status: 'ok', report_id: 'r-1' } })
+    await handshakeAPI.report('h-1', 'harassment', 'detail', 'u-9')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/report/', {
+      issue_type: 'harassment',
+      description: 'detail',
+      reported_user_id: 'u-9',
+    })
+  })
+})
+
+describe('handshakeAPI.joinEvent', () => {
+  it('POSTs to /handshakes/services/:id/join-event/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.joinEvent('s-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/services/s-1/join-event/', {})
+  })
+})
+
+describe('handshakeAPI.checkin', () => {
+  it('POSTs an empty body when no qr token', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.checkin('h-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/checkin/', {})
+  })
+
+  it('POSTs the qr_token when provided', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'h-1' } })
+    await handshakeAPI.checkin('h-1', 'token-xyz')
+    expect(apiMocks.post).toHaveBeenCalledWith('/handshakes/h-1/checkin/', { qr_token: 'token-xyz' })
+  })
+})

--- a/frontend/src/test/services/reputationAPI.test.ts
+++ b/frontend/src/test/services/reputationAPI.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  post: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn((_e: unknown, fallback?: string) => fallback ?? 'err'),
+}))
+
+let reputationAPI: typeof import('@/services/reputationAPI').reputationAPI
+
+beforeEach(async () => {
+  apiMocks.post.mockReset()
+  vi.resetModules()
+  reputationAPI = (await import('@/services/reputationAPI')).reputationAPI
+})
+
+describe('reputationAPI.submitPositive / submitNegative', () => {
+  it('POSTs positive payload to /reputation/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { ok: true } })
+    const out = await reputationAPI.submitPositive({
+      handshake_id: 'h-1', punctual: true, helpful: false, kindness: true,
+    } as never)
+    expect(apiMocks.post).toHaveBeenCalledWith('/reputation/', {
+      handshake_id: 'h-1', punctual: true, helpful: false, kindness: true,
+    })
+    expect(out).toEqual({ ok: true })
+  })
+
+  it('POSTs negative payload to /reputation/negative/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { ok: true } })
+    await reputationAPI.submitNegative({
+      handshake_id: 'h-1', is_late: true, is_unhelpful: false, is_rude: false,
+    } as never)
+    expect(apiMocks.post).toHaveBeenCalledWith('/reputation/negative/', {
+      handshake_id: 'h-1', is_late: true, is_unhelpful: false, is_rude: false,
+    })
+  })
+})
+
+describe('reputationAPI.attachReviewImages', () => {
+  it('POSTs multipart payload with handshake_id and one entry per image', async () => {
+    apiMocks.post.mockResolvedValue({})
+    const f1 = new File(['a'], 'a.jpg', { type: 'image/jpeg' })
+    const f2 = new File(['b'], 'b.jpg', { type: 'image/jpeg' })
+    await reputationAPI.attachReviewImages('h-1', [f1, f2])
+    const [path, fd, opts] = apiMocks.post.mock.calls[0]
+    expect(path).toBe('/reputation/add-review/')
+    expect(opts.headers['Content-Type']).toBe('multipart/form-data')
+    const formData = fd as FormData
+    expect(formData.get('handshake_id')).toBe('h-1')
+    expect(formData.getAll('images')).toHaveLength(2)
+  })
+
+  it('POSTs even when images array is empty', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await reputationAPI.attachReviewImages('h-1', [])
+    const fd = apiMocks.post.mock.calls[0][1] as FormData
+    expect(fd.getAll('images')).toHaveLength(0)
+  })
+})
+
+describe('reputationAPI.submitCombined', () => {
+  const base = {
+    handshake_id: 'h-1',
+    positive: { punctual: false, helpful: false, kindness: false },
+    negative: { is_late: false, is_unhelpful: false, is_rude: false },
+  }
+
+  it('throws when no traits selected', async () => {
+    await expect(reputationAPI.submitCombined(base)).rejects.toThrow(/at least one trait/i)
+    expect(apiMocks.post).not.toHaveBeenCalled()
+  })
+
+  it('submits only positive when only positive traits selected', async () => {
+    apiMocks.post.mockResolvedValue({ data: { ok: 'pos' } })
+    const out = await reputationAPI.submitCombined({
+      ...base,
+      positive: { punctual: true, helpful: false, kindness: false },
+    })
+    expect(apiMocks.post).toHaveBeenCalledTimes(1)
+    expect(apiMocks.post).toHaveBeenCalledWith('/reputation/', expect.objectContaining({
+      handshake_id: 'h-1', punctual: true, helpful: false, kindness: false,
+    }))
+    expect(out.positive).toEqual({ ok: 'pos' })
+    expect(out.negative).toBeUndefined()
+  })
+
+  it('submits both when both selected and trims comment', async () => {
+    apiMocks.post
+      .mockResolvedValueOnce({ data: { ok: 'pos' } })
+      .mockResolvedValueOnce({ data: { ok: 'neg' } })
+    const out = await reputationAPI.submitCombined({
+      ...base,
+      positive: { punctual: true, helpful: false, kindness: false },
+      negative: { is_late: false, is_unhelpful: true, is_rude: false },
+      comment: '   trim me   ',
+    })
+    expect(apiMocks.post).toHaveBeenCalledTimes(2)
+    expect(apiMocks.post.mock.calls[0][1].comment).toBe('trim me')
+    expect(apiMocks.post.mock.calls[1][1].comment).toBe('trim me')
+    expect(out.positive).toEqual({ ok: 'pos' })
+    expect(out.negative).toEqual({ ok: 'neg' })
+  })
+
+  it('drops empty comment after trim', async () => {
+    apiMocks.post.mockResolvedValue({ data: { ok: true } })
+    await reputationAPI.submitCombined({
+      ...base,
+      positive: { punctual: true, helpful: false, kindness: false },
+      comment: '   ',
+    })
+    expect(apiMocks.post.mock.calls[0][1].comment).toBeUndefined()
+  })
+
+  it('wraps downstream errors in a generic message', async () => {
+    apiMocks.post.mockRejectedValue(new Error('network'))
+    await expect(reputationAPI.submitCombined({
+      ...base,
+      positive: { punctual: true, helpful: false, kindness: false },
+    })).rejects.toThrow(/Failed to submit evaluation/)
+  })
+})
+
+describe('reputationAPI.submitCombinedEvent', () => {
+  const baseEvent = {
+    handshake_id: 'h-1',
+    positive: { well_organized: false, engaging: false, welcoming: false },
+    negative: { disorganized: false, boring: false, unwelcoming: false },
+  }
+
+  it('throws when no event traits selected', async () => {
+    await expect(reputationAPI.submitCombinedEvent(baseEvent)).rejects.toThrow(/at least one trait/i)
+  })
+
+  it('submits positive event traits to /reputation/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { ok: true } })
+    await reputationAPI.submitCombinedEvent({
+      ...baseEvent,
+      positive: { well_organized: true, engaging: false, welcoming: false },
+    })
+    expect(apiMocks.post).toHaveBeenCalledWith('/reputation/', expect.objectContaining({
+      well_organized: true, engaging: false, welcoming: false,
+    }))
+  })
+})

--- a/frontend/src/test/services/serviceAPI.test.ts
+++ b/frontend/src/test/services/serviceAPI.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let serviceAPI: typeof import('@/services/serviceAPI').serviceAPI
+
+beforeEach(async () => {
+  Object.values(apiMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  serviceAPI = (await import('@/services/serviceAPI')).serviceAPI
+})
+
+describe('serviceAPI.list — query string building', () => {
+  it('GETs /services/ with empty params when none provided', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list()
+    expect(apiMocks.get).toHaveBeenCalledWith('/services/', {
+      params: expect.any(URLSearchParams),
+      signal: undefined,
+    })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.toString()).toBe('')
+  })
+
+  it('forwards sort, lat, lng, distance, search, type, status', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({
+      sort: 'hot', lat: 41, lng: 29, distance: 5,
+      search: 'python', type: 'Offer', status: 'Active',
+    })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('sort')).toBe('hot')
+    expect(params.get('lat')).toBe('41')
+    expect(params.get('lng')).toBe('29')
+    expect(params.get('distance')).toBe('5')
+    expect(params.get('search')).toBe('python')
+    expect(params.get('type')).toBe('Offer')
+    expect(params.get('status')).toBe('Active')
+  })
+
+  it('appends multiple tags as repeated query keys', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({ tags: ['Q1', 'Q2', 'Q3'] })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.getAll('tags')).toEqual(['Q1', 'Q2', 'Q3'])
+  })
+
+  it('renames user_id to user param', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({ user_id: 'u-1' })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('user')).toBe('u-1')
+    expect(params.has('user_id')).toBe(false)
+  })
+
+  it('serializes explore_only=true as the literal string "true"', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({ explore_only: true })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('explore_only')).toBe('true')
+  })
+
+  it('omits explore_only when false', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({ explore_only: false })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.has('explore_only')).toBe(false)
+  })
+
+  it('forwards date_from and date_to', async () => {
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await serviceAPI.list({ type: 'Event', date_from: '2026-05-01', date_to: '2026-06-01' })
+    const params = apiMocks.get.mock.calls[0][1].params as URLSearchParams
+    expect(params.get('date_from')).toBe('2026-05-01')
+    expect(params.get('date_to')).toBe('2026-06-01')
+  })
+})
+
+describe('serviceAPI.list — response shape', () => {
+  it('returns the array directly when response is an array', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ id: 's-1' }] })
+    const out = await serviceAPI.list()
+    expect(out).toEqual([{ id: 's-1' }])
+  })
+
+  it('extracts results from a paginated response', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [{ id: 's-1' }], count: 1 } })
+    const out = await serviceAPI.list()
+    expect(out).toEqual([{ id: 's-1' }])
+  })
+
+  it('returns [] when paginated response has no results key', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0 } as never })
+    const out = await serviceAPI.list()
+    expect(out).toEqual([])
+  })
+})
+
+describe('serviceAPI.get / delete', () => {
+  it('get GETs /services/:id/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.get('s-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/services/s-1/', { signal: undefined })
+  })
+
+  it('delete DELETEs /services/:id/', async () => {
+    apiMocks.delete.mockResolvedValue({})
+    await serviceAPI.delete('s-1')
+    expect(apiMocks.delete).toHaveBeenCalledWith('/services/s-1/')
+  })
+})
+
+describe('serviceAPI.create', () => {
+  it('POSTs FormData with multipart Content-Type when given FormData', async () => {
+    const fd = new FormData()
+    fd.append('title', 'svc')
+    apiMocks.post.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.create(fd)
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  })
+
+  it('POSTs plain object with empty headers (no multipart)', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.create({ title: 'svc' })
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/', { title: 'svc' }, { headers: {} })
+  })
+})
+
+describe('serviceAPI.update', () => {
+  it('PATCHes FormData with multipart Content-Type when given FormData', async () => {
+    const fd = new FormData()
+    apiMocks.patch.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.update('s-1', fd)
+    expect(apiMocks.patch).toHaveBeenCalledWith('/services/s-1/', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  })
+
+  it('PATCHes plain object with empty headers', async () => {
+    apiMocks.patch.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.update('s-1', { title: 'new' })
+    expect(apiMocks.patch).toHaveBeenCalledWith('/services/s-1/', { title: 'new' }, { headers: {} })
+  })
+})
+
+describe('serviceAPI events / interest / report', () => {
+  it('expressInterest POSTs empty body', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'i-1', status: 'pending' } })
+    await serviceAPI.expressInterest('s-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/interest/', {}, { signal: undefined })
+  })
+
+  it('report POSTs issue_type and description', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await serviceAPI.report('s-1', 'spam', 'why')
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/services/s-1/report/',
+      { issue_type: 'spam', description: 'why' },
+      { signal: undefined },
+    )
+  })
+
+  it('pinEvent POSTs to /pin-event/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.pinEvent('s-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/pin-event/')
+  })
+
+  it('completeEvent POSTs empty body', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await serviceAPI.completeEvent('s-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/complete-event/', {})
+  })
+
+  it('cancelEvent POSTs reason', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await serviceAPI.cancelEvent('s-1', 'venue closed')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/cancel-event/', { reason: 'venue closed' })
+  })
+})
+
+describe('serviceAPI QR + media + ranking debug', () => {
+  it('generateQRToken POSTs to /generate-qr-token/', async () => {
+    apiMocks.post.mockResolvedValue({ data: { token: 't' } })
+    await serviceAPI.generateQRToken('s-1')
+    expect(apiMocks.post).toHaveBeenCalledWith('/services/s-1/generate-qr-token/')
+  })
+
+  it('getQRToken GETs /qr-token/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { token: 't' } })
+    await serviceAPI.getQRToken('s-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/services/s-1/qr-token/')
+  })
+
+  it('setPrimaryMedia PATCHes media_id', async () => {
+    apiMocks.patch.mockResolvedValue({ data: { id: 's-1' } })
+    await serviceAPI.setPrimaryMedia('s-1', 'm-9')
+    expect(apiMocks.patch).toHaveBeenCalledWith('/services/s-1/set-primary-media/', { media_id: 'm-9' })
+  })
+
+  it('getRankingDebug POSTs payload to /debug-ranking/', async () => {
+    apiMocks.post.mockResolvedValue({ data: {} })
+    await serviceAPI.getRankingDebug({ service_ids: ['s-1', 's-2'] })
+    expect(apiMocks.post).toHaveBeenCalledWith(
+      '/services/debug-ranking/',
+      { service_ids: ['s-1', 's-2'] },
+      { signal: undefined },
+    )
+  })
+
+  it('getPublicFeatured GETs /featured/public/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { trending: [], top_providers: [] } })
+    await serviceAPI.getPublicFeatured()
+    expect(apiMocks.get).toHaveBeenCalledWith('/featured/public/', { signal: undefined })
+  })
+})

--- a/frontend/src/test/services/tagAPI.test.ts
+++ b/frontend/src/test/services/tagAPI.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let tagAPI: typeof import('@/services/tagAPI').tagAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  apiMocks.post.mockReset()
+  vi.resetModules()
+  tagAPI = (await import('@/services/tagAPI')).tagAPI
+})
+
+describe('tagAPI.search', () => {
+  it('returns [] for empty queries without hitting the API', async () => {
+    const out = await tagAPI.search('')
+    expect(apiMocks.get).not.toHaveBeenCalled()
+    expect(out).toEqual([])
+  })
+
+  it('returns [] for whitespace-only queries', async () => {
+    const out = await tagAPI.search('   ')
+    expect(apiMocks.get).not.toHaveBeenCalled()
+    expect(out).toEqual([])
+  })
+
+  it('GETs /wikidata/search/ with q and limit, mapping label -> name', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: [
+        { id: 'Q1', label: 'Python', description: 'language', entity_type: 'tech' },
+        { id: 'Q2', label: 'Django', description: 'framework', entity_type: 'tech' },
+      ],
+    })
+    const out = await tagAPI.search('py')
+    expect(apiMocks.get).toHaveBeenCalledWith(
+      '/wikidata/search/',
+      { params: { q: 'py', limit: 10 }, signal: undefined },
+    )
+    expect(out).toEqual([
+      { id: 'Q1', name: 'Python', description: 'language', entity_type: 'tech' },
+      { id: 'Q2', name: 'Django', description: 'framework', entity_type: 'tech' },
+    ])
+  })
+
+  it('drops items missing id or label', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: [
+        { id: '', label: 'no id' },
+        { id: 'Q1', label: '' },
+        { id: 'Q2', label: 'kept' },
+      ],
+    })
+    const out = await tagAPI.search('q')
+    expect(out).toEqual([{ id: 'Q2', name: 'kept', description: undefined, entity_type: undefined }])
+  })
+
+  it('passes the abort signal through', async () => {
+    const ac = new AbortController()
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await tagAPI.search('x', ac.signal)
+    expect(apiMocks.get).toHaveBeenCalledWith(
+      '/wikidata/search/',
+      { params: { q: 'x', limit: 10 }, signal: ac.signal },
+    )
+  })
+
+  it('returns [] when the response data is null', async () => {
+    apiMocks.get.mockResolvedValue({ data: null })
+    const out = await tagAPI.search('x')
+    expect(out).toEqual([])
+  })
+})
+
+describe('tagAPI.searchLocal', () => {
+  it('returns [] for empty queries', async () => {
+    const out = await tagAPI.searchLocal('')
+    expect(apiMocks.get).not.toHaveBeenCalled()
+    expect(out).toEqual([])
+  })
+
+  it('GETs /tags/ with search param and returns the data', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ id: 'Q1', name: 'Python' }] })
+    const out = await tagAPI.searchLocal('py')
+    expect(apiMocks.get).toHaveBeenCalledWith(
+      '/tags/',
+      { params: { search: 'py' }, signal: undefined },
+    )
+    expect(out).toEqual([{ id: 'Q1', name: 'Python' }])
+  })
+})
+
+describe('tagAPI.ensureInDb', () => {
+  it('POSTs and returns the created tag on success', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'Q1', name: 'Python' } })
+    const out = await tagAPI.ensureInDb({ id: 'Q1', name: 'Python' })
+    expect(apiMocks.post).toHaveBeenCalledWith('/tags/', { id: 'Q1', name: 'Python' })
+    expect(out).toEqual({ id: 'Q1', name: 'Python' })
+  })
+
+  it('trims whitespace from the name field on POST', async () => {
+    apiMocks.post.mockResolvedValue({ data: { id: 'Q1', name: 'Python' } })
+    await tagAPI.ensureInDb({ id: 'Q1', name: '  Python  ' })
+    expect(apiMocks.post).toHaveBeenCalledWith('/tags/', { id: 'Q1', name: 'Python' })
+  })
+
+  it('falls back to GET on 400 (tag already exists), matching by id', async () => {
+    const conflict = Object.assign(new Error('exists'), { response: { status: 400 } })
+    apiMocks.post.mockRejectedValue(conflict)
+    apiMocks.get.mockResolvedValue({
+      data: [{ id: 'Q1', name: 'Python' }, { id: 'Q9', name: 'Snake' }],
+    })
+    const out = await tagAPI.ensureInDb({ id: 'Q1', name: 'Python' })
+    expect(apiMocks.get).toHaveBeenCalledWith('/tags/', { params: { search: 'Python' } })
+    expect(out).toEqual({ id: 'Q1', name: 'Python' })
+  })
+
+  it('falls back to GET on 400 and matches case-insensitively by name', async () => {
+    const conflict = Object.assign(new Error('exists'), { response: { status: 400 } })
+    apiMocks.post.mockRejectedValue(conflict)
+    apiMocks.get.mockResolvedValue({
+      data: [{ id: 'Q9', name: 'PYTHON' }],
+    })
+    const out = await tagAPI.ensureInDb({ id: 'Q1', name: 'python' })
+    expect(out).toEqual({ id: 'Q9', name: 'PYTHON' })
+  })
+
+  it('rethrows the original error when no matching tag is found', async () => {
+    const conflict = Object.assign(new Error('exists'), { response: { status: 400 } })
+    apiMocks.post.mockRejectedValue(conflict)
+    apiMocks.get.mockResolvedValue({ data: [] })
+    await expect(tagAPI.ensureInDb({ id: 'Q1', name: 'Python' })).rejects.toBe(conflict)
+  })
+
+  it('rethrows non-400 errors immediately without GET fallback', async () => {
+    const err = Object.assign(new Error('500'), { response: { status: 500 } })
+    apiMocks.post.mockRejectedValue(err)
+    await expect(tagAPI.ensureInDb({ id: 'Q1', name: 'Python' })).rejects.toBe(err)
+    expect(apiMocks.get).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/services/transactionAPI.test.ts
+++ b/frontend/src/test/services/transactionAPI.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({ get: vi.fn() }))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let transactionAPI: typeof import('@/services/transactionAPI').transactionAPI
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  vi.resetModules()
+  transactionAPI = (await import('@/services/transactionAPI')).transactionAPI
+})
+
+const tx = (overrides: Record<string, unknown> = {}) => ({
+  id: 't-1',
+  amount: '5.00',
+  balance_after: '10.00',
+  type: 'credit',
+  ...overrides,
+})
+
+describe('transactionAPI.list — defaults and params', () => {
+  it('GETs /transactions/ with default page=1 and direction=all', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: { count: 0, next: null, previous: null, results: [], summary: null },
+    })
+    await transactionAPI.list()
+    expect(apiMocks.get).toHaveBeenCalledWith('/transactions/', {
+      params: { page: 1, page_size: undefined, direction: 'all' },
+      signal: undefined,
+    })
+  })
+
+  it('forwards page, page_size, direction overrides', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: { count: 0, next: null, previous: null, results: [], summary: null },
+    })
+    await transactionAPI.list({ page: 3, page_size: 25, direction: 'credit' })
+    expect(apiMocks.get).toHaveBeenCalledWith('/transactions/', {
+      params: { page: 3, page_size: 25, direction: 'credit' },
+      signal: undefined,
+    })
+  })
+})
+
+describe('transactionAPI.list — normalization', () => {
+  it('coerces amount and balance_after to numbers', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [tx({ amount: '5.00', balance_after: '10.50' })],
+        summary: { current_balance: '10.50', total_earned: '5.00', total_spent: '0' },
+      },
+    })
+    const out = await transactionAPI.list()
+    expect(out.results[0].amount).toBe(5)
+    expect(out.results[0].balance_after).toBe(10.5)
+    expect(out.summary.current_balance).toBe(10.5)
+    expect(out.summary.total_earned).toBe(5)
+  })
+
+  it('falls back to 0 when amount/balance_after are missing', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [tx({ amount: undefined, balance_after: undefined })],
+        summary: undefined,
+      },
+    })
+    const out = await transactionAPI.list()
+    expect(out.results[0].amount).toBe(0)
+    expect(out.results[0].balance_after).toBe(0)
+    expect(out.summary).toEqual({ current_balance: 0, total_earned: 0, total_spent: 0 })
+  })
+
+  it('wraps a bare-array response as a single-page paginated result', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: [tx({ amount: '1' }), tx({ id: 't-2', amount: '2' })],
+    })
+    const out = await transactionAPI.list()
+    expect(out.count).toBe(2)
+    expect(out.next).toBeNull()
+    expect(out.previous).toBeNull()
+    expect(out.results[0].amount).toBe(1)
+    expect(out.results[1].amount).toBe(2)
+    expect(out.summary).toEqual({ current_balance: 0, total_earned: 0, total_spent: 0 })
+  })
+})
+
+describe('transactionAPI.list — abort signal', () => {
+  it('forwards the abort signal', async () => {
+    const ac = new AbortController()
+    apiMocks.get.mockResolvedValue({
+      data: { count: 0, next: null, previous: null, results: [], summary: null },
+    })
+    await transactionAPI.list({}, ac.signal)
+    expect(apiMocks.get.mock.calls[0][1].signal).toBe(ac.signal)
+  })
+})

--- a/frontend/src/test/services/userAPI.test.ts
+++ b/frontend/src/test/services/userAPI.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}))
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn(),
+}))
+
+let userAPI: typeof import('@/services/userAPI').userAPI
+let dataURLtoBlob: typeof import('@/services/userAPI').dataURLtoBlob
+
+beforeEach(async () => {
+  Object.values(apiMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  const mod = await import('@/services/userAPI')
+  userAPI = mod.userAPI
+  dataURLtoBlob = mod.dataURLtoBlob
+})
+
+describe('userAPI.getMe / getUser', () => {
+  it('getMe GETs /users/me/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 'u-1' } })
+    const out = await userAPI.getMe()
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/me/', { signal: undefined })
+    expect(out).toEqual({ id: 'u-1' })
+  })
+
+  it('getUser GETs /users/:id/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 'u-9' } })
+    await userAPI.getUser('u-9')
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/u-9/', { signal: undefined })
+  })
+})
+
+describe('userAPI.updateMe', () => {
+  it('PATCHes FormData with multipart Content-Type', async () => {
+    const fd = new FormData()
+    fd.append('first_name', 'Yusuf')
+    apiMocks.patch.mockResolvedValue({ data: { id: 'u-1' } })
+    await userAPI.updateMe(fd)
+    expect(apiMocks.patch).toHaveBeenCalledWith('/users/me/', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+  })
+
+  it('PATCHes plain object with empty headers', async () => {
+    apiMocks.patch.mockResolvedValue({ data: { id: 'u-1' } })
+    await userAPI.updateMe({ bio: 'hi' })
+    expect(apiMocks.patch).toHaveBeenCalledWith('/users/me/', { bio: 'hi' }, { headers: {} })
+  })
+})
+
+describe('userAPI.getMyReports', () => {
+  it('returns array directly when response is an array', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ id: 'r-1' }] })
+    const out = await userAPI.getMyReports()
+    expect(out).toEqual([{ id: 'r-1' }])
+  })
+
+  it('extracts results from a paginated payload', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 1, next: null, previous: null, results: [{ id: 'r-1' }] } })
+    const out = await userAPI.getMyReports()
+    expect(out).toEqual([{ id: 'r-1' }])
+  })
+})
+
+describe('userAPI.followUser / unfollowUser', () => {
+  it('followUser POSTs to /users/:id/follow/', async () => {
+    apiMocks.post.mockResolvedValue({})
+    await userAPI.followUser('u-9')
+    expect(apiMocks.post).toHaveBeenCalledWith('/users/u-9/follow/')
+  })
+
+  it('unfollowUser DELETEs /users/:id/follow/', async () => {
+    apiMocks.delete.mockResolvedValue({})
+    await userAPI.unfollowUser('u-9')
+    expect(apiMocks.delete).toHaveBeenCalledWith('/users/u-9/follow/')
+  })
+})
+
+describe('userAPI.getFollowers / getFollowing', () => {
+  it('getFollowers GETs /users/:id/followers/ and returns results', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [{ id: 'a' }] } })
+    const out = await userAPI.getFollowers('u-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/u-1/followers/', { signal: undefined })
+    expect(out).toEqual([{ id: 'a' }])
+  })
+
+  it('getFollowing GETs /users/:id/following/', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [{ id: 'b' }] } })
+    await userAPI.getFollowing('u-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/u-1/following/', { signal: undefined })
+  })
+})
+
+describe('userAPI.getSuggested', () => {
+  it('omits page param when absent', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [], next: null, count: 0 } })
+    await userAPI.getSuggested()
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/suggested/', { params: undefined, signal: undefined })
+  })
+
+  it('passes page param when present', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [], next: null, count: 0 } })
+    await userAPI.getSuggested({ page: 3 })
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/suggested/', { params: { page: 3 }, signal: undefined })
+  })
+
+  it('defaults missing fields to safe values', async () => {
+    apiMocks.get.mockResolvedValue({ data: {} as never })
+    const out = await userAPI.getSuggested()
+    expect(out).toEqual({ results: [], next: null, count: 0 })
+  })
+})
+
+describe('userAPI.getHistory', () => {
+  it('returns array directly when response is array', async () => {
+    apiMocks.get.mockResolvedValue({ data: [{ service_id: 's-1' }] })
+    const out = await userAPI.getHistory('u-1')
+    expect(out).toEqual([{ service_id: 's-1' }])
+  })
+
+  it('extracts results from paginated response', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [{ service_id: 's-1' }] } })
+    const out = await userAPI.getHistory('u-1')
+    expect(out).toEqual([{ service_id: 's-1' }])
+  })
+
+  it('returns [] when response has no results', async () => {
+    apiMocks.get.mockResolvedValue({ data: {} as never })
+    const out = await userAPI.getHistory('u-1')
+    expect(out).toEqual([])
+  })
+})
+
+describe('userAPI.getBadgeProgress (normalization)', () => {
+  it('flattens an object-keyed map to flat shape using achievement nesting', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: {
+        first_friend: {
+          achievement: { name: 'First Friend', description: 'd', icon_url: 'i', karma_points: 10, is_hidden: false },
+          earned: true, current: 1, threshold: 1, progress_percent: 100, earned_at: '2026-01-01',
+        },
+      },
+    })
+    const out = await userAPI.getBadgeProgress('u-1')
+    expect(out[0]).toMatchObject({
+      badge_type: 'first_friend',
+      name: 'First Friend',
+      description: 'd',
+      current_value: 1,
+      threshold: 1,
+      earned: true,
+      earned_at: '2026-01-01',
+      karma_points: 10,
+      is_hidden: false,
+    })
+  })
+
+  it('falls back to defaults when nested achievement missing', async () => {
+    apiMocks.get.mockResolvedValue({ data: { x: { earned: false } } })
+    const out = await userAPI.getBadgeProgress('u-1')
+    expect(out[0]).toMatchObject({
+      badge_type: 'x', name: 'x', current_value: 0, threshold: 0,
+      earned: false, karma_points: 0,
+    })
+  })
+
+  it('handles results-array shape from paginated endpoint', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: { results: [{ badge_type: 'b1', earned: true, current: 5, threshold: 10 }] as never },
+    })
+    const out = await userAPI.getBadgeProgress('u-1')
+    expect(out).toHaveLength(1)
+    expect(out[0].badge_type).toBe('b1')
+  })
+
+  it('handles bare-array shape', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: [{ badge_type: 'b1', earned: true }] as never,
+    })
+    const out = await userAPI.getBadgeProgress('u-1')
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('userAPI.getAchievementProgress', () => {
+  it('returns the nested AchievementProgressItem shape', async () => {
+    apiMocks.get.mockResolvedValue({
+      data: {
+        x: {
+          achievement: { name: 'X', description: 'd', icon_url: null, karma_points: 5, is_hidden: false },
+          earned: true, current: 1, threshold: 1, progress_percent: 100, earned_at: null,
+        },
+      },
+    })
+    const out = await userAPI.getAchievementProgress('u-1')
+    expect(out[0].achievement.name).toBe('X')
+    expect(out[0].badge_type).toBe('x')
+  })
+})
+
+describe('userAPI.getVerifiedReviews', () => {
+  it('GETs /users/:id/verified-reviews/ with empty params when no role', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [], next: null, previous: null } })
+    await userAPI.getVerifiedReviews('u-1')
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/u-1/verified-reviews/', {
+      params: {},
+      signal: undefined,
+    })
+  })
+
+  it('forwards role param', async () => {
+    apiMocks.get.mockResolvedValue({ data: { count: 0, results: [], next: null, previous: null } })
+    await userAPI.getVerifiedReviews('u-1', { role: 'provider' })
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/u-1/verified-reviews/', {
+      params: { role: 'provider' },
+      signal: undefined,
+    })
+  })
+
+  it('defaults missing fields to safe values', async () => {
+    apiMocks.get.mockResolvedValue({ data: {} as never })
+    const out = await userAPI.getVerifiedReviews('u-1')
+    expect(out).toEqual({ count: 0, results: [], next: null, previous: null })
+  })
+
+  it('falls back to results.length when count missing', async () => {
+    apiMocks.get.mockResolvedValue({ data: { results: [{ id: 'r-1' }] } as never })
+    const out = await userAPI.getVerifiedReviews('u-1')
+    expect(out.count).toBe(1)
+  })
+})
+
+describe('dataURLtoBlob', () => {
+  it('decodes a PNG data URL into a Blob with the parsed mime type', () => {
+    const blob = dataURLtoBlob('data:image/png;base64,aGVsbG8=')
+    expect(blob.type).toBe('image/png')
+    expect(blob.size).toBe(5)
+  })
+
+  it('falls back to image/jpeg when the header has no mime type', () => {
+    const blob = dataURLtoBlob('data:,aGVsbG8=')
+    expect(blob.type).toBe('image/jpeg')
+    expect(blob.size).toBe(5)
+  })
+})

--- a/frontend/src/test/store/useAuthStore.test.ts
+++ b/frontend/src/test/store/useAuthStore.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+vi.mock('@/services/api', () => ({
+  default: apiMocks,
+  apiClient: apiMocks,
+  getErrorMessage: vi.fn((_e: unknown, fallback?: string) => fallback ?? 'oops'),
+}))
+
+let useAuthStore: typeof import('@/store/useAuthStore').useAuthStore
+
+beforeEach(async () => {
+  apiMocks.get.mockReset()
+  apiMocks.post.mockReset()
+  vi.resetModules()
+  vi.useFakeTimers()
+  useAuthStore = (await import('@/store/useAuthStore')).useAuthStore
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useAuthStore.login', () => {
+  it('sets user + isAuthenticated when payload includes user', async () => {
+    apiMocks.post.mockResolvedValue({ data: { access: 'a', refresh: 'r', user: { id: 'u-1' } } })
+    await useAuthStore.getState().login('a@b.co', 'pw')
+    const s = useAuthStore.getState()
+    expect(s.user).toEqual({ id: 'u-1' })
+    expect(s.isAuthenticated).toBe(true)
+    expect(s.isLoading).toBe(false)
+  })
+
+  it('falls back to /users/me/ when login payload omits user', async () => {
+    apiMocks.post.mockResolvedValue({ data: { access: 'a', refresh: 'r' } })
+    apiMocks.get.mockResolvedValue({ data: { id: 'u-2' } })
+    await useAuthStore.getState().login('a@b.co', 'pw')
+    expect(apiMocks.get).toHaveBeenCalledWith('/users/me/', expect.objectContaining({
+      headers: { 'Cache-Control': 'no-cache' },
+    }))
+    expect(useAuthStore.getState().user).toEqual({ id: 'u-2' })
+  })
+
+  it('stores error and rethrows on 401', async () => {
+    const err = Object.assign(new Error('bad'), { response: { status: 401 } })
+    apiMocks.post.mockRejectedValue(err)
+    await expect(useAuthStore.getState().login('a@b.co', 'pw')).rejects.toBe(err)
+    expect(useAuthStore.getState().error).toBe('Login failed')
+    expect(useAuthStore.getState().isLoading).toBe(false)
+  })
+})
+
+describe('useAuthStore.register', () => {
+  it('sets user when register response includes user', async () => {
+    apiMocks.post.mockResolvedValue({ data: { access: 'a', refresh: 'r', user: { id: 'u-1' } } })
+    await useAuthStore.getState().register({
+      email: 'a@b.co', password: 'pw', first_name: 'A', last_name: 'B',
+    })
+    expect(useAuthStore.getState().user).toEqual({ id: 'u-1' })
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+
+  it('rethrows on registration failure', async () => {
+    const err = Object.assign(new Error('bad'), { response: { status: 400 } })
+    apiMocks.post.mockRejectedValue(err)
+    await expect(useAuthStore.getState().register({
+      email: 'a@b.co', password: 'pw', first_name: 'A', last_name: 'B',
+    })).rejects.toBe(err)
+    expect(useAuthStore.getState().error).toBe('Registration failed')
+  })
+})
+
+describe('useAuthStore.checkAuth retry on 429', () => {
+  it('retries up to MAX_ME_RETRIES then succeeds', async () => {
+    const rl = Object.assign(new Error('429'), { response: { status: 429 } })
+    apiMocks.get
+      .mockRejectedValueOnce(rl)
+      .mockRejectedValueOnce(rl)
+      .mockResolvedValueOnce({ data: { id: 'u-3' } })
+    const p = useAuthStore.getState().checkAuth(true)
+    await vi.runAllTimersAsync()
+    await p
+    expect(apiMocks.get).toHaveBeenCalledTimes(3)
+    expect(useAuthStore.getState().user).toEqual({ id: 'u-3' })
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+
+  it('keeps existing auth when retries exhaust on 429', async () => {
+    useAuthStore.setState({ user: { id: 'cached' } as never, isAuthenticated: true })
+    const rl = Object.assign(new Error('429'), { response: { status: 429 } })
+    apiMocks.get.mockRejectedValue(rl)
+    const p = useAuthStore.getState().checkAuth(true)
+    await vi.runAllTimersAsync()
+    await p
+    expect(useAuthStore.getState().error).toMatch(/Too many auth checks/)
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+
+  it('clears auth on non-429 errors', async () => {
+    useAuthStore.setState({ user: { id: 'cached' } as never, isAuthenticated: true })
+    apiMocks.get.mockRejectedValue(Object.assign(new Error('500'), { response: { status: 500 } }))
+    await useAuthStore.getState().checkAuth(true)
+    expect(useAuthStore.getState().user).toBeNull()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  })
+
+  it('skips network when already authenticated and not forced', async () => {
+    useAuthStore.setState({ user: { id: 'u' } as never, isAuthenticated: true })
+    await useAuthStore.getState().checkAuth(false)
+    expect(apiMocks.get).not.toHaveBeenCalled()
+  })
+
+  it('hits network when forced even if already authenticated', async () => {
+    useAuthStore.setState({ user: { id: 'u' } as never, isAuthenticated: true })
+    apiMocks.get.mockResolvedValue({ data: { id: 'u-fresh' } })
+    await useAuthStore.getState().checkAuth(true)
+    expect(apiMocks.get).toHaveBeenCalled()
+    expect(useAuthStore.getState().user).toEqual({ id: 'u-fresh' })
+  })
+})
+
+describe('useAuthStore.refreshUser', () => {
+  it('updates user on success', async () => {
+    apiMocks.get.mockResolvedValue({ data: { id: 'u-fresh' } })
+    await useAuthStore.getState().refreshUser()
+    expect(useAuthStore.getState().user).toEqual({ id: 'u-fresh' })
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+
+  it('sets error on 429 but keeps existing state', async () => {
+    useAuthStore.setState({ user: { id: 'cached' } as never, isAuthenticated: true })
+    apiMocks.get.mockRejectedValue(Object.assign(new Error('429'), { response: { status: 429 } }))
+    await useAuthStore.getState().refreshUser()
+    expect(useAuthStore.getState().error).toMatch(/Too many auth checks/)
+  })
+
+  it('silently swallows non-429 errors', async () => {
+    apiMocks.get.mockRejectedValue(Object.assign(new Error('500'), { response: { status: 500 } }))
+    await expect(useAuthStore.getState().refreshUser()).resolves.toBeUndefined()
+  })
+})
+
+describe('useAuthStore.logout', () => {
+  it('clears state even when network logout fails', async () => {
+    useAuthStore.setState({ user: { id: 'u' } as never, isAuthenticated: true, error: 'old' })
+    apiMocks.post.mockRejectedValue(new Error('boom'))
+    await useAuthStore.getState().logout()
+    expect(useAuthStore.getState().user).toBeNull()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(useAuthStore.getState().error).toBeNull()
+  })
+
+  it('clears state on success', async () => {
+    useAuthStore.setState({ user: { id: 'u' } as never, isAuthenticated: true })
+    apiMocks.post.mockResolvedValue({ data: { detail: 'bye' } })
+    await useAuthStore.getState().logout()
+    expect(useAuthStore.getState().user).toBeNull()
+  })
+})
+
+describe('useAuthStore.updateUserOptimistically / setUser / setError', () => {
+  it('merges updates onto existing user', () => {
+    useAuthStore.setState({ user: { id: 'u', bio: 'old' } as never })
+    useAuthStore.getState().updateUserOptimistically({ bio: 'new' } as never)
+    expect(useAuthStore.getState().user).toMatchObject({ id: 'u', bio: 'new' })
+  })
+
+  it('is a no-op when no user is set', () => {
+    useAuthStore.getState().updateUserOptimistically({ bio: 'x' } as never)
+    expect(useAuthStore.getState().user).toBeNull()
+  })
+
+  it('setUser flips isAuthenticated', () => {
+    useAuthStore.getState().setUser({ id: 'u' } as never)
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    useAuthStore.getState().setUser(null)
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  })
+
+  it('setError stores the message', () => {
+    useAuthStore.getState().setError('boom')
+    expect(useAuthStore.getState().error).toBe('boom')
+  })
+})

--- a/frontend/src/test/store/useGeoStore.test.ts
+++ b/frontend/src/test/store/useGeoStore.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let useGeoStore: typeof import('@/store/useGeoStore').useGeoStore
+
+beforeEach(async () => {
+  vi.resetModules()
+  useGeoStore = (await import('@/store/useGeoStore')).useGeoStore
+})
+
+describe('useGeoStore', () => {
+  it('starts with null geoLocation', () => {
+    expect(useGeoStore.getState().geoLocation).toBeNull()
+  })
+
+  it('setGeoLocation stores the coordinates', () => {
+    useGeoStore.getState().setGeoLocation({ latitude: 41.0, longitude: 29.0 })
+    expect(useGeoStore.getState().geoLocation).toEqual({ latitude: 41.0, longitude: 29.0 })
+  })
+
+  it('setGeoLocation(null) clears the value', () => {
+    useGeoStore.getState().setGeoLocation({ latitude: 41.0, longitude: 29.0 })
+    useGeoStore.getState().setGeoLocation(null)
+    expect(useGeoStore.getState().geoLocation).toBeNull()
+  })
+
+  it('replaces previous coordinates rather than merging', () => {
+    useGeoStore.getState().setGeoLocation({ latitude: 41.0, longitude: 29.0 })
+    useGeoStore.getState().setGeoLocation({ latitude: 50.0, longitude: 0.0 })
+    expect(useGeoStore.getState().geoLocation).toEqual({ latitude: 50.0, longitude: 0.0 })
+  })
+})

--- a/frontend/src/test/store/useNotificationStore.test.ts
+++ b/frontend/src/test/store/useNotificationStore.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const notifMocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  unreadCount: vi.fn(),
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+}))
+
+vi.mock('@/services/notificationAPI', () => ({
+  notificationAPI: notifMocks,
+}))
+
+let useNotificationStore: typeof import('@/store/useNotificationStore').useNotificationStore
+
+beforeEach(async () => {
+  Object.values(notifMocks).forEach((fn) => fn.mockReset())
+  vi.resetModules()
+  useNotificationStore = (await import('@/store/useNotificationStore')).useNotificationStore
+})
+
+const notif = (id: string, is_read = false) =>
+  ({ id, is_read, kind: 'system', body: 'x', created_at: '2026-05-08' }) as never
+
+describe('useNotificationStore.fetchNotifications', () => {
+  it('replaces notifications when page=1', async () => {
+    notifMocks.list.mockResolvedValue({ results: [notif('a'), notif('b')], next: null })
+    await useNotificationStore.getState().fetchNotifications(1)
+    expect(useNotificationStore.getState().notifications).toHaveLength(2)
+    expect(useNotificationStore.getState().hasMore).toBe(false)
+    expect(useNotificationStore.getState().currentPage).toBe(1)
+    expect(useNotificationStore.getState().isLoading).toBe(false)
+  })
+
+  it('appends results when page > 1', async () => {
+    useNotificationStore.setState({ notifications: [notif('a')] })
+    notifMocks.list.mockResolvedValue({ results: [notif('b')], next: 'next' })
+    await useNotificationStore.getState().fetchNotifications(2)
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).toEqual(['a', 'b'])
+    expect(useNotificationStore.getState().hasMore).toBe(true)
+  })
+
+  it('clears isLoading on error', async () => {
+    notifMocks.list.mockRejectedValue(new Error('boom'))
+    await useNotificationStore.getState().fetchNotifications(1)
+    expect(useNotificationStore.getState().isLoading).toBe(false)
+  })
+})
+
+describe('useNotificationStore.fetchUnreadCount', () => {
+  it('updates unreadCount on success', async () => {
+    notifMocks.unreadCount.mockResolvedValue(7)
+    await useNotificationStore.getState().fetchUnreadCount()
+    expect(useNotificationStore.getState().unreadCount).toBe(7)
+  })
+
+  it('silently keeps prior count on error', async () => {
+    useNotificationStore.setState({ unreadCount: 3 })
+    notifMocks.unreadCount.mockRejectedValue(new Error('boom'))
+    await useNotificationStore.getState().fetchUnreadCount()
+    expect(useNotificationStore.getState().unreadCount).toBe(3)
+  })
+})
+
+describe('useNotificationStore.markAsRead', () => {
+  it('optimistically marks the notification as read and decrements unreadCount', async () => {
+    useNotificationStore.setState({
+      notifications: [notif('a'), notif('b')],
+      unreadCount: 2,
+    })
+    notifMocks.markAsRead.mockResolvedValue(undefined)
+    await useNotificationStore.getState().markAsRead('a')
+    const a = useNotificationStore.getState().notifications.find((n) => n.id === 'a')
+    expect(a?.is_read).toBe(true)
+    expect(useNotificationStore.getState().unreadCount).toBe(1)
+  })
+
+  it('reverts on failure', async () => {
+    useNotificationStore.setState({
+      notifications: [notif('a'), notif('b')],
+      unreadCount: 2,
+    })
+    notifMocks.markAsRead.mockRejectedValue(new Error('boom'))
+    await useNotificationStore.getState().markAsRead('a')
+    const a = useNotificationStore.getState().notifications.find((n) => n.id === 'a')
+    expect(a?.is_read).toBe(false)
+    expect(useNotificationStore.getState().unreadCount).toBe(2)
+  })
+
+  it('clamps unreadCount to 0', async () => {
+    useNotificationStore.setState({
+      notifications: [notif('a')],
+      unreadCount: 0,
+    })
+    notifMocks.markAsRead.mockResolvedValue(undefined)
+    await useNotificationStore.getState().markAsRead('a')
+    expect(useNotificationStore.getState().unreadCount).toBe(0)
+  })
+})
+
+describe('useNotificationStore.markAllAsRead', () => {
+  it('marks all read and zeroes unreadCount', async () => {
+    useNotificationStore.setState({
+      notifications: [notif('a'), notif('b')],
+      unreadCount: 2,
+    })
+    notifMocks.markAllAsRead.mockResolvedValue(undefined)
+    await useNotificationStore.getState().markAllAsRead()
+    const allRead = useNotificationStore.getState().notifications.every((n) => n.is_read)
+    expect(allRead).toBe(true)
+    expect(useNotificationStore.getState().unreadCount).toBe(0)
+  })
+
+  it('reverts notifications and refetches count on failure', async () => {
+    useNotificationStore.setState({
+      notifications: [notif('a'), notif('b')],
+      unreadCount: 2,
+    })
+    notifMocks.markAllAsRead.mockRejectedValue(new Error('boom'))
+    notifMocks.unreadCount.mockResolvedValue(2)
+    await useNotificationStore.getState().markAllAsRead()
+    const a = useNotificationStore.getState().notifications.find((n) => n.id === 'a')
+    expect(a?.is_read).toBe(false)
+    expect(notifMocks.unreadCount).toHaveBeenCalled()
+  })
+})
+
+describe('useNotificationStore.addNotification / reset', () => {
+  it('addNotification prepends and increments unreadCount', () => {
+    useNotificationStore.setState({
+      notifications: [notif('a')],
+      unreadCount: 1,
+    })
+    useNotificationStore.getState().addNotification(notif('new'))
+    expect(useNotificationStore.getState().notifications.map((n) => n.id)).toEqual(['new', 'a'])
+    expect(useNotificationStore.getState().unreadCount).toBe(2)
+  })
+
+  it('reset returns to initial values', () => {
+    useNotificationStore.setState({
+      notifications: [notif('a')],
+      unreadCount: 5,
+      isLoading: true,
+      hasMore: false,
+      currentPage: 4,
+    })
+    useNotificationStore.getState().reset()
+    expect(useNotificationStore.getState()).toMatchObject({
+      notifications: [],
+      unreadCount: 0,
+      isLoading: false,
+      hasMore: true,
+      currentPage: 0,
+    })
+  })
+})

--- a/frontend/src/test/store/useTourStore.test.ts
+++ b/frontend/src/test/store/useTourStore.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'hive_dashboard_tour_v1'
+
+let storage: Record<string, string>
+
+let useTourStore: typeof import('@/store/useTourStore').useTourStore
+
+// jsdom 28 in this project ships a broken localStorage (plain Object, no methods).
+// Install a real storage shim before each test so the store can read/write.
+function installStorage(initial: Record<string, string> = {}) {
+  storage = { ...initial }
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn((key: string) => (key in storage ? storage[key] : null)),
+      setItem: vi.fn((key: string, value: string) => { storage[key] = value }),
+      removeItem: vi.fn((key: string) => { delete storage[key] }),
+      clear: vi.fn(() => { storage = {} }),
+      key: vi.fn((idx: number) => Object.keys(storage)[idx] ?? null),
+      get length() { return Object.keys(storage).length },
+    },
+  })
+}
+
+beforeEach(async () => {
+  installStorage()
+  vi.resetModules()
+  useTourStore = (await import('@/store/useTourStore')).useTourStore
+})
+
+describe('useTourStore initial state', () => {
+  it('hasSeen starts false when storage is empty', () => {
+    expect(useTourStore.getState().hasSeen).toBe(false)
+    expect(useTourStore.getState().isOpen).toBe(false)
+    expect(useTourStore.getState().runId).toBe(0)
+  })
+
+  it('hasSeen reads from localStorage at module init', async () => {
+    installStorage({ [STORAGE_KEY]: 'done' })
+    vi.resetModules()
+    const { useTourStore: fresh } = await import('@/store/useTourStore')
+    expect(fresh.getState().hasSeen).toBe(true)
+  })
+})
+
+describe('useTourStore.startTour', () => {
+  it('opens the tour and increments runId', () => {
+    useTourStore.getState().startTour()
+    expect(useTourStore.getState().isOpen).toBe(true)
+    expect(useTourStore.getState().runId).toBe(1)
+  })
+
+  it('increments runId on each call', () => {
+    useTourStore.getState().startTour()
+    useTourStore.getState().startTour()
+    useTourStore.getState().startTour()
+    expect(useTourStore.getState().runId).toBe(3)
+  })
+})
+
+describe('useTourStore.endTour', () => {
+  it('writes "done" to localStorage and sets hasSeen', () => {
+    useTourStore.getState().startTour()
+    useTourStore.getState().endTour('done')
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('done')
+    expect(useTourStore.getState().hasSeen).toBe(true)
+    expect(useTourStore.getState().isOpen).toBe(false)
+  })
+
+  it('writes "skipped" when reason is skipped', () => {
+    useTourStore.getState().endTour('skipped')
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('skipped')
+    expect(useTourStore.getState().hasSeen).toBe(true)
+  })
+
+  it('swallows storage errors gracefully', () => {
+    const setItem = window.localStorage.setItem as unknown as ReturnType<typeof vi.fn>
+    setItem.mockImplementationOnce(() => {
+      throw new DOMException('QuotaExceeded')
+    })
+    expect(() => useTourStore.getState().endTour('done')).not.toThrow()
+    expect(useTourStore.getState().hasSeen).toBe(true)
+  })
+})

--- a/frontend/src/test/utils/cookies.test.ts
+++ b/frontend/src/test/utils/cookies.test.ts
@@ -86,5 +86,26 @@ describe('utils/cookies', () => {
       // delete cookie string" — assert via document.cookie shape.
       expect(document.cookie).toMatch(/scoped=/)
     })
+
+    it('defaults the path to "/" when not supplied', () => {
+      // Spy on the document.cookie setter so we can assert what was written
+      // (jsdom collapses the cookie back into a name=value pair on read).
+      const writes: string[] = []
+      const originalDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie')!
+      Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get: originalDesc.get,
+        set(value: string) {
+          writes.push(value)
+          originalDesc.set!.call(this, value)
+        },
+      })
+      try {
+        deleteCookie('default_path')
+      } finally {
+        Object.defineProperty(document, 'cookie', originalDesc)
+      }
+      expect(writes.some((w) => w.includes('path=/'))).toBe(true)
+    })
   })
 })

--- a/frontend/src/test/utils/dateTime.test.ts
+++ b/frontend/src/test/utils/dateTime.test.ts
@@ -43,6 +43,12 @@ describe('formatDuration', () => {
     expect(formatDuration(3)).toBe('3h')
   })
 
+  it('drops the minute segment when the rounded minutes are zero', () => {
+    // 2.001 hours → m = round(0.001 * 60) = 0; the `m > 0` branch must
+    // collapse to "2h" rather than emit "2h 0min".
+    expect(formatDuration(2.001)).toBe('2h')
+  })
+
   it('rounds minutes correctly', () => {
     expect(formatDuration(0.25)).toBe('15 min')
   })
@@ -53,6 +59,30 @@ describe('chatTimestamp', () => {
     const now = new Date()
     const recent = new Date(now.getTime() - 30 * 60 * 1000).toISOString()
     expect(chatTimestamp(recent)).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  it('returns "EEE HH:mm" between 24 hours and 48 days ago', () => {
+    const now = new Date()
+    const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 3600_000).toISOString()
+    expect(chatTimestamp(threeDaysAgo)).toMatch(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{2}:\d{2}$/)
+  })
+
+  it('switches to "EEE HH:mm" at exactly the 24-hour boundary', () => {
+    const now = new Date()
+    const exactly24hAgo = new Date(now.getTime() - 24 * 3600_000).toISOString()
+    expect(chatTimestamp(exactly24hAgo)).toMatch(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{2}:\d{2}$/)
+  })
+
+  it('returns "MMM d" for timestamps older than 48 days', () => {
+    const now = new Date()
+    const longAgo = new Date(now.getTime() - 60 * 24 * 3600_000).toISOString()
+    expect(chatTimestamp(longAgo)).toMatch(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}$/)
+  })
+
+  it('switches to "MMM d" at exactly the 48-day boundary', () => {
+    const now = new Date()
+    const exactly48dAgo = new Date(now.getTime() - 48 * 24 * 3600_000).toISOString()
+    expect(chatTimestamp(exactly48dAgo)).toMatch(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}$/)
   })
 
   it('returns the original string for invalid input', () => {

--- a/frontend/src/test/utils/eventUtils.test.ts
+++ b/frontend/src/test/utils/eventUtils.test.ts
@@ -151,10 +151,15 @@ describe('eventUtils — time-dependent helpers', () => {
       expect(formatEventDateTime(null)).toBe('TBD')
       expect(formatEventDateTime(undefined)).toBe('TBD')
     })
-    it('returns a non-empty string for a real timestamp', () => {
-      const formatted = formatEventDateTime(inFuture(2 * 24 * 3600_000))
-      expect(formatted.length).toBeGreaterThan(0)
-      expect(formatted).not.toBe('TBD')
+    it('formats a real timestamp with weekday, month, day, year and 12-hour time', () => {
+      // Tue 2026-05-12 03:00 UTC → en-US localised. The exact wall-time depends
+      // on the test machine's TZ, so assert structural pieces, not literal text.
+      const formatted = formatEventDateTime('2026-05-12T03:00:00Z')
+      expect(formatted).toMatch(/(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/)
+      expect(formatted).toMatch(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/)
+      expect(formatted).toMatch(/2026/)
+      // hour12: true → must show AM or PM
+      expect(formatted).toMatch(/AM|PM/)
     })
   })
 
@@ -170,6 +175,15 @@ describe('eventUtils — time-dependent helpers', () => {
     })
     it('reports "Event started" once the event has begun', () => {
       expect(timeUntilEvent(inPast(60_000))).toBe('Event started')
+    })
+    it('reports "Event started" at the exact start moment (diff == 0)', () => {
+      expect(timeUntilEvent(new Date(FIXED_NOW).toISOString())).toBe('Event started')
+    })
+    it('switches to hours at exactly 60 minutes', () => {
+      expect(timeUntilEvent(inFuture(60 * 60_000))).toBe('1h away')
+    })
+    it('switches to days at exactly 24 hours', () => {
+      expect(timeUntilEvent(inFuture(24 * 3600_000))).toBe('1d away')
     })
     it('returns an empty string when the input is missing', () => {
       expect(timeUntilEvent(null)).toBe('')
@@ -203,6 +217,10 @@ describe('eventUtils — time-dependent helpers', () => {
       expect(isEventBanned(inPast(3600_000))).toBe(false)
       expect(isOrganizerBanned(inPast(3600_000))).toBe(false)
     })
+    it('is false at the exact expiry moment (strict greater-than, not >=)', () => {
+      expect(isEventBanned(new Date(FIXED_NOW).toISOString())).toBe(false)
+      expect(isOrganizerBanned(new Date(FIXED_NOW).toISOString())).toBe(false)
+    })
     it('is false for missing input', () => {
       expect(isEventBanned(null)).toBe(false)
       expect(isOrganizerBanned(undefined)).toBe(false)
@@ -213,9 +231,12 @@ describe('eventUtils — time-dependent helpers', () => {
     it('returns an empty string for missing input', () => {
       expect(formatBanExpiry(null)).toBe('')
     })
-    it('returns a non-empty formatted string for a real timestamp', () => {
-      const formatted = formatBanExpiry(inFuture(7 * 24 * 3600_000))
-      expect(formatted.length).toBeGreaterThan(0)
+    it('formats a real timestamp with the long month name, day and year', () => {
+      // 2026-05-17 → "May 17, 2026" in en-US (timezone shifts the wall date by ±1).
+      const formatted = formatBanExpiry('2026-05-17T12:00:00Z')
+      expect(formatted).toMatch(/May/)
+      expect(formatted).toMatch(/2026/)
+      expect(formatted).toMatch(/\b(16|17|18)\b/)
     })
   })
 })
@@ -226,5 +247,17 @@ describe('formatGroupOfferDateTime', () => {
 
     expect(formatted).toMatch(/14 May, \d{2}:\d{2}/)
     expect(formatted).not.toMatch(/Thu|Fri|2026/)
+  })
+
+  it('uses 24-hour time (no AM/PM marker)', () => {
+    const formatted = formatGroupOfferDateTime('2026-05-14T13:36:00Z')
+    // en-GB localised AM/PM appears lowercase ("am" / "pm"); match either case
+    // and also catch the unicode small-cap forms some node ICU builds emit.
+    expect(formatted).not.toMatch(/[ap]\.?m\.?/i)
+  })
+
+  it('returns TBD when the input is missing', () => {
+    expect(formatGroupOfferDateTime(null)).toBe('TBD')
+    expect(formatGroupOfferDateTime(undefined)).toBe('TBD')
   })
 })

--- a/frontend/src/utils/dateTime.ts
+++ b/frontend/src/utils/dateTime.ts
@@ -41,6 +41,7 @@ export function formatDuration(hours: number): string {
     const minutes = Math.round(hours * 60)
     return `${minutes} min`
   }
+  // Stryker disable next-line ConditionalExpression: floor/round path produces the same `${h}h` for integer inputs (m rounds to 0 → falls into the `m > 0 ? … : '${h}h'` else branch). Short-circuit kept for clarity.
   if (Number.isInteger(hours)) return `${hours}h`
   const h = Math.floor(hours)
   const m = Math.round((hours - h) * 60)

--- a/frontend/src/utils/eventUtils.ts
+++ b/frontend/src/utils/eventUtils.ts
@@ -27,6 +27,7 @@ export function spotsLeft(maxParticipants: number, participantCount: number): nu
 
 /** Returns true when 75-99% capacity (nearly full) */
 export function isNearlyFull(maxParticipants: number, participantCount: number): boolean {
+  // Stryker disable next-line ConditionalExpression,EqualityOperator: when max <= 0 the fallthrough produces NaN/Infinity which fail `pct < 1.0`, so dropping or weakening this guard yields the same observable answer.
   if (maxParticipants <= 0) return false
   const pct = participantCount / maxParticipants
   return pct >= 0.75 && pct < 1.0

--- a/frontend/stryker.conf.json
+++ b/frontend/stryker.conf.json
@@ -2,14 +2,14 @@
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "_comment": "Mutation testing for the highest-leverage frontend modules. Bare flag list, narrow scope: api client (cookie auth + retry), conversation client (chat URL building), date utils, eventUtils. Expand once these reliably hit the threshold.",
   "packageManager": "npm",
-  "reporters": ["html", "clear-text", "progress"],
+  "reporters": ["html", "json", "clear-text", "progress"],
   "testRunner": "vitest",
   "vitest": {
     "configFile": "vite.config.ts"
   },
   "checkers": ["typescript"],
   "tsconfigFile": "tsconfig.app.json",
-  "coverageAnalysis": "perTest",
+  "coverageAnalysis": "all",
   "mutate": [
     "src/services/api.ts",
     "src/services/conversationAPI.ts",
@@ -26,5 +26,8 @@
   "timeoutMS": 60000,
   "htmlReporter": {
     "fileName": "tests/reports/mutation/index.html"
+  },
+  "jsonReporter": {
+    "fileName": "tests/reports/mutation/mutation.json"
   }
 }

--- a/frontend/tests/e2e/feature-1/03-fr-01c.spec.ts
+++ b/frontend/tests/e2e/feature-1/03-fr-01c.spec.ts
@@ -19,8 +19,15 @@ test.describe('FR-01c: Logout invalidates session and redirects', () => {
 
     await openUserMenu(page)
 
-    // Remove the /users/me/ interception so the app detects the session is gone.
+    // Replace loginAs()'s always-200 /users/me/ stub with an explicit 401.
+    // A bare unroute() leaks a CI-only race: dashboard hooks can re-fetch
+    // /users/me/ between POST /auth/logout and React's auth-state flip,
+    // and the slow CI backend's 200 response then re-hydrates useAuthStore
+    // and pins the route guard to /dashboard.
     await page.unroute('**/api/users/me/')
+    await page.route('**/api/users/me/', (route) =>
+      route.fulfill({ status: 401, contentType: 'application/json', body: '{}' }),
+    )
 
     // Capture the logout response to assert the backend sends a cookie-deletion header
     const [logoutResponse] = await Promise.all([

--- a/frontend/tests/e2e/helpers/auth.ts
+++ b/frontend/tests/e2e/helpers/auth.ts
@@ -124,9 +124,16 @@ export async function openUserMenu(page: Page): Promise<void> {
  */
 export async function logout(page: Page): Promise<void> {
   await openUserMenu(page)
-  // Remove the /users/me/ interception so the app detects the session is
-  // gone after the backend clears the cookie.
+  // Replace the loginAs() always-200 interception with an explicit 401
+  // stub. Just calling page.unroute() opens a race in CI: dashboard hooks
+  // re-fetch /users/me/ between POST /auth/logout and the React state
+  // flip, the slow real backend returns 200 with the user, and
+  // useAuthStore re-hydrates — defeating the route-guard redirect that
+  // this test waits on. A 401 stub closes the race deterministically.
   await page.unroute('**/api/users/me/')
+  await page.route('**/api/users/me/', (route) =>
+    route.fulfill({ status: 401, contentType: 'application/json', body: '{}' }),
+  )
   await page.getByText('Log Out').click()
   await expect(page).not.toHaveURL(/\/dashboard/, { timeout: 10_000 })
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -108,13 +108,13 @@ export default defineConfig(({ mode }) => {
         // catches regressions today; the targets in the testing roadmap
         // (60/60/60/40) need a lot more component / hook / store specs.
         // Ratchet these up as new test specs land — never down.
-        // Latest baseline (after the B2/B3 batch) was lines 11.5,
-        // functions 8.9, statements 11.0, branches 9.2.
+        // Latest baseline (after the #461 service + store spec batch):
+        //   lines 16.79, functions 15.07, statements 15.91, branches 12.23.
         thresholds: {
-          lines: 11,
-          functions: 8,
-          statements: 10,
-          branches: 9,
+          lines: 15,
+          functions: 14,
+          statements: 14,
+          branches: 11,
         },
       },
       server: {


### PR DESCRIPTION
Follow-up to #519 — closes out the rest of the testing-overhaul work tracked in #461.

The bulk of it is mechanical: same regex/AST sweep as before, this time across the whole integration suite, plus the unittest→pytest migration for the unit files that #519 hadn't gotten to. Two CI flakes get root-causes (one was a real bug in `register_calendar_cache_key`'s retry loop, the other was ServiceFactory's iterator alternating schedule_type between consecutive test runs). Frontend gets specs for the 16 zero-coverage modules, Stryker's perTest masking is fixed, and the `assert-sweep` guardrail goes in so this debt can't quietly grow back.

What's in here:

- **Codemods** under `backend/scripts/codemods/` (libcst, with their own unit tests). One sweeps status-only `assert response.status_code == X` lines into `assert_api_response` / `assert_problem_detail`, folding trivial body-shape follow-ups into `contains=` / `schema=` kwargs (cap N=3, no fold for 4xx since `assert_problem_detail` doesn't take those). The other drops `class Foo(TestCase)` wrappers, translates `self.assertX` → `assert`, rewrites `with self.assertRaises` → `with pytest.raises`, and adds `@pytest.mark.django_db` where needed.
- **Backend assertion sweep** across the integration suite. 35 files, ~414 sites.
- **Backend unittest→pytest migration** for 13 unit test files. Per-file `env` SimpleNamespace fixtures (or split per-entity fixtures where it reads cleaner). Zero TestCase subclasses survive in `api/tests/unit/`.
- **Calendar cache flake** (`register_calendar_cache_key`) — the retry loop had a dead `return`, fixed with verify-then-exit. Three new unit tests including a monkeypatched racing-clobber scenario.
- **Group-chat WS flake** — two complementary fixes: widen the in-memory channel layer fixture to all `websocket`-marked tests, and pin `schedule_type='One-Time'` on the two TestGroupChatConsumer fixtures (the actual root cause was the factory iterator alternating, not Redis).
- **Mutmut Django bootstrap** — adds `api` to `also_copy` so the package is mirrored intact under `mutants/`, plus a top-level `backend/conftest.py` that loads .env and falls back to local-dev DB defaults. The original `AUTH_USER_MODEL` blocker is gone; the next-stage `RuntimeError: context has already been set` is documented inline in `pyproject.toml` for follow-up.
- **Frontend**: 12 new service specs + 4 new store specs, 239 cases total. `useTourStore` needs a Storage shim because jsdom 28 here ships a plain-Object localStorage without the methods. Coverage thresholds raised 11/8/10/9 → 15/14/14/11.
- **Stryker** — `coverageAnalysis: 'perTest' → 'all'` (perTest was masking survivors when tests dynamically import in beforeEach), json reporter wired for survivor extraction. Local mutation score 60.12%, passes the 60% break threshold.
- **Guardrail** — `make test-assert-sweep` and a 4-min `assert-sweep` job in `ci-backend.yml` that runs the codemod in `--check` mode and forbids new TestCase subclasses.

## Test plan

- [ ] `make test` green (756 unit + 742 integration locally)
- [ ] `make test-assert-sweep` clean
- [ ] `cd frontend && npm run test:coverage` passes the new 15/14/14/11 gate
- [ ] `cd frontend && npx stryker run` ≥ 60% mutation score
- [ ] `make test-mutation` — backend mutmut runs through stats collection (the `context has already been set` follow-up is acknowledged separately)
- [ ] CI `assert-sweep` job green on this PR

Closes #461


---

## Round 2 — hook-test precedent + mutation-deepening (commits 86dc8e8, 870085f)

Two more things landed on this branch after the round-1 review:

1. **First `renderHook` tests in the repo.** All 5 hooks under `src/hooks/` had zero coverage and there was no `renderHook` precedent anywhere — any future hook extraction had to invent the pattern from scratch. New: a tiny `mockWebSocket` helper, a short `helpers/README.md` documenting the pattern, and 49 tests across the 5 hooks.
2. **Mutation-deepening on the 5 already-mutated files.** Same files Stryker was already pointing at; the goal was to make the existing tests actually catch bugs instead of just hitting lines. Net: total mutation **60.12 → 71.38** (covered **77.43 → 89.58**), and 4 of the 5 files are now at 100% on covered code.

No production code changes outside two `// Stryker disable next-line` comments where the mutant was genuinely equivalent (with the reason inline). No threshold ratchets, no Stryker scope expansion.

### Coverage (round 2 deltas)

| Area | Before | After |
|---|---|---|
| `src/hooks/` (lines / fns) | 0 / 0 | 96.84 / 95.12 |
| Overall lines | 16.67 | 18.76 |
| Overall functions | 14.96 | 16.29 |
| Overall branches | 12.15 | 13.20 |

All four `vite.config.ts` thresholds (15 / 14 / 14 / 11) still pass. Bumping them to the new floor is a follow-up.

### Mutation (round 2 deltas, `break: 60`, `high: 80`)

| File | Before (total / covered) | After (total / covered) | Survivors |
|---|---|---|---|
| `services/api.ts` | 24.62 / 50.00 | 30.77 / 59.70 | 27 |
| `services/conversationAPI.ts` | 86.67 / 92.86 | **97.78 / 100** | 0 |
| `utils/cookies.ts` | 93.33 / 93.33 | **100 / 100** | 0 |
| `utils/dateTime.ts` | 60.53 / 67.65 | **94.44 / 100** | 0 |
| `utils/eventUtils.ts` | 88.35 / 89.22 | **100 / 100** | 0 |
| **Total** | **60.12 / 77.43** | **71.38 / 89.58** | 27 |

`api.ts` is still below the "high" tier because the response interceptor (token-refresh queue, 401 retry, `isPublicPath` redirect) and the `apiClient.create()` config have no test coverage at all — every survivor in that file is in code the existing suite never executes. Killing those needs a real axios-adapter test harness, which is its own PR.

### Hook tests, briefly

- `useWebSocket` (21 cases) — cookie/token URL building, frame parsing for `chat_message` / `notification`, JSON parse-error swallow, send-when-OPEN, reconnect backoff (with the 8s short-open path), cap-at-5 retries, code 4xxx no-retry, stable-timer reset, URL change reopen, unmount cleanup.
- `usePolling` (8) — `isLoading` only on first call vs `isRefreshing` on subsequent, manual refresh, AbortError/CanceledError/ERR_CANCELED swallow, real-error capture, `enabled: false` short-circuit, `visibilitychange` re-run, cleanup aborts and clears the interval.
- `useNotificationSocket` (8) — auth-gated open, `addNotification` + sonner toast on incoming frames, ignores non-notification types and parse errors, no-retry on 4xxx, transient reconnect, disconnect when auth flips to logged-out.
- `useAcquireLocation` (6) — skips when `geoLocation` already set, skips without consent, success path writes to the store, error swallow, unmount race (resolution after unmount must not write).
- `useMyReports` (6) — load, generic error, non-`Error` rejection fallback message, abort on unmount, post-abort silence.

### Mutation-deepening, briefly

- `cookies.ts` — assert default `deleteCookie` path is `/` via a temporary `document.cookie` setter spy (jsdom collapses cookies on read).
- `conversationAPI.ts` — non-empty `participants` / `messages` survive the `?? []` fallback intact; `eventChat.getMessages` forwards the `AbortSignal` exactly.
- `dateTime.ts` — `m=0` collapse in `formatDuration`, plus the boundaries at exactly 24h and 48d in `chatTimestamp`.
- `eventUtils.ts` — AM/PM marker on `formatEventDateTime`, case-insensitive no-AM/PM check on `formatGroupOfferDateTime`, `diff == 0` in `timeUntilEvent`, exactly-60min and exactly-24h boundary kicks, exact-now strict-greater-than in `isEventBanned` / `isOrganizerBanned`, month/day/year asserts in `formatBanExpiry`.
- `api.ts` — Array and string response bodies fall through (the `!Array.isArray` and `typeof === 'object'` guards), plural "messages" key membership in `knownTopKeys`, `", "` vs `". "` join separators in field-error rendering.

Two equivalent mutants:
- `dateTime.ts:44` — `Number.isInteger` short-circuit (the floor/round fallthrough produces the same `${h}h` for integer inputs).
- `eventUtils.ts:30` — `isNearlyFull` guard (max ≤ 0 fallthrough yields NaN/Infinity which fail the `pct < 1.0` check anyway).

### Round 2 test plan additions

- [ ] `frontend-test` job stays green (568 vitest cases, was 502)
- [ ] `frontend-mutation` job — score ≥ 60 (locally 71.38)
- [ ] `frontend-coverage` — thresholds unchanged, all four metrics rose
