### PR TITLE
fix(events): correct evaluation eligibility, participant state transitions, and chat access

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -289,7 +289,7 @@ class PublicChatConsumer(AsyncWebsocketConsumer):
             return Handshake.objects.filter(
                 service=service,
                 requester=user,
-                status__in=['accepted', 'checked_in', 'attended'],
+                status__in=['accepted', 'checked_in', 'attended', 'completed', 'no_show'],
             ).exists()
         except ChatRoom.DoesNotExist:
             return False

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -1926,6 +1926,17 @@ class EventHandshakeService:
                     service=service,
                 )
 
+            # Notify accepted (registered but never checked-in) participants that the event is over.
+            for accepted_hs in Handshake.objects.filter(service=service, status='accepted').select_related('requester'):
+                create_notification(
+                    user=accepted_hs.requester,
+                    notification_type='handshake_cancelled',
+                    title='Event Completed',
+                    message=f"The event '{service.title}' has ended.",
+                    handshake=accepted_hs,
+                    service=service,
+                )
+
             service.status = 'Completed'
             service.event_completed_at = timezone.now()
             service.save(update_fields=['status', 'event_completed_at', 'updated_at'])

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -1930,7 +1930,7 @@ class EventHandshakeService:
             for accepted_hs in Handshake.objects.filter(service=service, status='accepted').select_related('requester'):
                 create_notification(
                     user=accepted_hs.requester,
-                    notification_type='handshake_cancelled',
+                    notification_type='service_updated',
                     title='Event Completed',
                     message=f"The event '{service.title}' has ended.",
                     handshake=accepted_hs,

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -1596,7 +1596,8 @@ class EventHandshakeService:
                 )
 
             locked_handshake.status = 'cancelled'
-            locked_handshake.save(update_fields=['status', 'updated_at'])
+            locked_handshake.cancellation_reason = 'user_left'
+            locked_handshake.save(update_fields=['status', 'cancellation_reason', 'updated_at'])
 
             create_notification(
                 user=locked_handshake.service.user,
@@ -1884,10 +1885,10 @@ class EventHandshakeService:
             service = Service.objects.select_for_update().get(pk=service.pk)
             organizer = User.objects.select_for_update().get(pk=organizer.pk)
 
-            # Bulk-mark non-attended participants as no-shows (single SQL UPDATE)
+            # Only checked_in participants become no-shows; accepted (never showed up) stay as-is.
             no_show_qs = Handshake.objects.filter(
                 service=service,
-                status__in=['accepted', 'checked_in'],
+                status='checked_in',
             )
             no_show_requester_ids = list(no_show_qs.values_list('requester_id', flat=True).distinct())
             no_show_qs.update(status='no_show', updated_at=timezone.now())

--- a/backend/api/tests/integration/test_handshake_api.py
+++ b/backend/api/tests/integration/test_handshake_api.py
@@ -1413,7 +1413,7 @@ class TestMarkAttendedAndCompleteEvent:
     # complete-event
     # ------------------------------------------------------------------ #
 
-    def test_complete_event_moves_accepted_and_checked_in_to_no_show(self):
+    def test_complete_event_no_show_only_for_checked_in(self):
         organizer = UserFactory()
         p_accepted = UserFactory()
         p_checked_in = UserFactory()
@@ -1454,8 +1454,8 @@ class TestMarkAttendedAndCompleteEvent:
         h_checked_in.refresh_from_db()
         h_attended.refresh_from_db()
 
-        assert h_accepted.status == 'no_show'
-        assert h_checked_in.status == 'no_show'
+        assert h_accepted.status == 'accepted', 'accepted (never checked in) participants stay accepted — no penalty'
+        assert h_checked_in.status == 'no_show', 'checked_in participants who were not marked attended become no_show'
         assert h_attended.status == 'attended', 'attended participants must not be downgraded'
 
     def test_attended_participants_not_downgraded_during_completion(self):

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -267,6 +267,29 @@ class TestUserHistoryView:
         assert response.data[0]['service_type'] == 'Event'
         assert response.data[0]['was_provider'] is True
 
+    def test_evaluation_pending_false_for_organizer(self):
+        organizer = UserFactory()
+        participant = UserFactory()
+        event = ServiceFactory(
+            user=organizer,
+            type='Event',
+            status='Completed',
+            event_completed_at=timezone.now() - timedelta(hours=1),
+        )
+        HandshakeFactory(
+            service=event,
+            requester=participant,
+            status='attended',
+            provisioned_hours=Decimal('0.00'),
+        )
+
+        client = AuthenticatedAPIClient().authenticate_user(organizer)
+        response = client.get(f'/api/users/{organizer.id}/history/')
+
+        assert_api_response(response, 200)
+        event_entries = [e for e in response.data if e['service_type'] == 'Event']
+        assert all(not e['evaluation_pending'] for e in event_entries)
+
 
 @pytest.mark.django_db
 @pytest.mark.integration

--- a/backend/api/tests/unit/test_event_chat_access.py
+++ b/backend/api/tests/unit/test_event_chat_access.py
@@ -137,16 +137,15 @@ class TestPublicChatEventAccessHelper:
         assert result is not None
         assert result.status_code == 403
 
-    def test_no_show_participant_denied(self):
-        """User with no_show handshake gets a 403 response."""
+    def test_no_show_participant_allowed(self):
+        """User with no_show handshake can still read event chat (they were physically present)."""
         event = _event_service()
         user = UserFactory()
         HandshakeFactory(service=event, requester=user, status='no_show',
                          provisioned_hours=Decimal('0'))
         vs, request = self._viewset_with_user(user)
         result = vs._check_event_access(request, event)
-        assert result is not None
-        assert result.status_code == 403
+        assert result is None
 
 
 # ─── GroupChatViewSet._get_service_or_403 blocks events ──────────────────────

--- a/backend/api/tests/unit/test_event_service.py
+++ b/backend/api/tests/unit/test_event_service.py
@@ -98,6 +98,7 @@ class TestLeaveEvent:
         hs = EventHandshakeService.join_event(service, user)
         result = EventHandshakeService.leave_event(hs, user)
         assert result.status == 'cancelled'
+        assert result.cancellation_reason == 'user_left'
 
     def test_leave_during_lockdown_raises(self):
         service = _event_service(hours_until_start=12)  # within 24h
@@ -198,11 +199,22 @@ class TestCompleteEvent:
         service.refresh_from_db()
         assert service.status == 'Completed'
 
-    def test_unchecked_participants_become_no_show(self):
+    def test_accepted_participants_remain_accepted_on_completion(self):
         organizer = UserFactory()
         service = _event_service(organizer=organizer)
         user = UserFactory()
         hs = EventHandshakeService.join_event(service, user)
+
+        EventHandshakeService.complete_event(service, organizer)
+        hs.refresh_from_db()
+        assert hs.status == 'accepted'
+
+    def test_checked_in_without_mark_attended_becomes_no_show(self):
+        organizer = UserFactory()
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        user = UserFactory()
+        hs = EventHandshakeService.join_event(service, user)
+        EventHandshakeService.checkin(hs, user)
 
         EventHandshakeService.complete_event(service, organizer)
         hs.refresh_from_db()
@@ -265,8 +277,9 @@ class TestCompleteEvent:
         user = UserFactory()
 
         for _ in range(3):
-            svc = _event_service(organizer=organizer)
-            EventHandshakeService.join_event(svc, user)
+            svc = _event_service(organizer=organizer, hours_until_start=12)
+            hs = EventHandshakeService.join_event(svc, user)
+            EventHandshakeService.checkin(hs, user)
             EventHandshakeService.complete_event(svc, organizer)
 
         user.refresh_from_db()
@@ -277,8 +290,9 @@ class TestCompleteEvent:
     def test_no_show_count_increments(self):
         organizer = UserFactory()
         user = UserFactory()
-        service = _event_service(organizer=organizer)
-        EventHandshakeService.join_event(service, user)
+        service = _event_service(organizer=organizer, hours_until_start=12)
+        hs = EventHandshakeService.join_event(service, user)
+        EventHandshakeService.checkin(hs, user)
 
         EventHandshakeService.complete_event(service, organizer)
         user.refresh_from_db()
@@ -287,9 +301,10 @@ class TestCompleteEvent:
     def test_no_show_updated_at_is_set(self):
         """Bulk update of handshakes must update the updated_at timestamp."""
         organizer = UserFactory()
-        service = _event_service(organizer=organizer)
+        service = _event_service(organizer=organizer, hours_until_start=12)
         user = UserFactory()
         hs = EventHandshakeService.join_event(service, user)
+        EventHandshakeService.checkin(hs, user)
         old_ts = hs.updated_at
 
         EventHandshakeService.complete_event(service, organizer)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -6319,7 +6319,7 @@ class PublicChatViewSet(viewsets.ViewSet):
         has_active_hs = Handshake.objects.filter(
             service=service,
             requester=user,
-            status__in=['accepted', 'checked_in', 'attended'],
+            status__in=['accepted', 'checked_in', 'attended', 'completed', 'no_show'],
         ).exists()
         if has_active_hs:
             return None

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1545,6 +1545,15 @@ class UserHistoryView(APIView):
             'service', 'service__user', 'requester'
         ).order_by('-updated_at')[:50]  # Limit to last 50
         
+        # Pre-fetch handshake IDs where the target user already submitted a review,
+        # so we can set evaluation_pending=False for those without per-row queries.
+        reviewed_handshake_ids = set(
+            ReputationRep.objects.filter(
+                handshake__in=completed_handshakes,
+                giver=target_user,
+            ).values_list('handshake_id', flat=True)
+        )
+
         history = []
         for handshake in completed_handshakes:
             provider, receiver = get_provider_and_receiver(handshake)
@@ -1577,8 +1586,13 @@ class UserHistoryView(APIView):
                 'partner_avatar_url': partner.avatar_url,
                 'completed_date': handshake.updated_at,
                 'was_provider': was_provider,
-                # For events: True when the attendee's evaluation window is still open.
-                'evaluation_pending': handshake.service.type == 'Event' and handshake.status == 'attended',
+                # For events: True only for attendees (not the organizer) with an open evaluation window.
+                'evaluation_pending': (
+                    handshake.service.type == 'Event'
+                    and handshake.status == 'attended'
+                    and not was_provider
+                    and handshake.id not in reviewed_handshake_ids
+                ),
             })
 
         # Include owner-completed events that currently have no qualifying

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     django.setup()
 
 from api.models import (
-    ChatMessage, Handshake, Notification, ReputationRep, Comment,
+    ChatMessage, ChatRoom, Handshake, Notification, ReputationRep, Comment,
     Service, Tag, User, UserBadge, ForumCategory, ForumTopic, ForumPost,
     Report, AdminAuditLog, ServiceMedia, PublicChatMessage, TransactionHistory,
     ServiceGroupChatMessage, NegativeRep, UserFollow,
@@ -1829,9 +1829,10 @@ def complete_seeded_handshake(handshake, *, completed_days_ago):
 
 
 def add_public_chat_messages(service, messages, base_time):
-    room = getattr(service, 'chat_room', None)
-    if room is None:
-        raise RuntimeError(f"Missing public chat room for service '{service.title}'")
+    room, _ = ChatRoom.objects.get_or_create(
+        related_service=service,
+        defaults={'name': f"Discussion: {service.title}", 'type': 'public'},
+    )
     for index, (sender, body) in enumerate(messages):
         PublicChatMessage.objects.create(
             room=room,
@@ -2421,6 +2422,71 @@ public_chat_scenarios = [
             (ayse, "Can we bring a recipe even if it is written from memory and not exact?"),
             (yasemin, "Please do. Those are usually the best stories."),
             (selin, "I am already looking forward to hearing everyone's family context around the recipes."),
+        ],
+    ),
+    (
+        selin_reading_event,
+        timezone.now() - timedelta(days=3),
+        [
+            (elif_user, "Should we read the book beforehand or just come and listen?"),
+            (selin, "Come as you are. We read together in the session."),
+            (cem, "Looking forward to it. I have been meaning to slow down with books again."),
+            (murat, "Same here. It feels rare to just sit and read with others."),
+        ],
+    ),
+    (
+        emre_walk_event,
+        timezone.now() - timedelta(days=2),
+        [
+            (can, "What is the meeting point exactly?"),
+            (emre, "We start at the Karaköy ferry dock, north exit. Hard to miss."),
+            (zeynep, "Should we bring anything? Water, snacks?"),
+            (emre, "Just comfortable shoes and curiosity. I will have a printed map."),
+        ],
+    ),
+    (
+        elif_photo_event,
+        timezone.now() - timedelta(days=4),
+        [
+            (cem, "Is this suitable for complete beginners with a camera?"),
+            (elif_user, "Absolutely. We focus on seeing, not technique."),
+            (ayse, "Can we use phones? I don't own a proper camera."),
+            (elif_user, "Phones are perfect. Some of my favorite shots are from a phone."),
+            (mehmet, "Really looking forward to this one."),
+        ],
+    ),
+    (
+        levent_music_event,
+        timezone.now() - timedelta(days=6),
+        [
+            (elif_user, "Do we need to prepare a song or just show up?"),
+            (levent, "Just show up. We will find something together."),
+            (yasemin, "I have not sung in front of anyone since school. A bit nervous."),
+            (levent, "That is exactly the spirit. No pressure, just neighbors."),
+            (burak, "Count me in. I will bring my guitar if that helps."),
+        ],
+    ),
+    (
+        yasemin_potluck_event,
+        timezone.now() - timedelta(days=1),
+        [
+            (elif_user, "Should we coordinate dishes so we don't all bring the same thing?"),
+            (yasemin, "Great idea. I will make a shared list in the chat. Who is bringing what?"),
+            (selin, "I can do a cold mezze plate."),
+            (mehmet, "I'll bring something from my neighborhood bakery."),
+            (levent, "I have a great lentil soup recipe I've been wanting to share."),
+            (ayse, "Perfect. I will bring dessert."),
+        ],
+    ),
+    (
+        elif_mending,
+        timezone.now() - timedelta(days=2),
+        [
+            (ayse, "I have a jacket with a broken zipper. Is that the kind of thing we can fix?"),
+            (elif_user, "Zippers are one of our specialties. Bring it along."),
+            (yasemin, "What about jeans with a worn knee? Is patching in scope?"),
+            (elif_user, "Definitely. Visible mending is actually quite beautiful when done well."),
+            (selin, "I love this. Fixing things instead of throwing them away."),
         ],
     ),
     (

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6620,9 +6620,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/components/EventRosterModal.tsx
+++ b/frontend/src/components/EventRosterModal.tsx
@@ -53,8 +53,7 @@ export function EventRosterPanel({ service, handshakes, onComplete, onMarkAttend
   const active = handshakes.filter((handshake) => ['accepted', 'checked_in', 'attended', 'no_show'].includes(handshake.status))
   const checkedIn = active.filter((handshake) => handshake.status === 'checked_in').length
   const attended = active.filter((handshake) => handshake.status === 'attended').length
-  const registered = active.filter((handshake) => handshake.status === 'accepted').length
-  const willBeNoShow = registered + checkedIn
+  const willBeNoShow = checkedIn
 
   // ── QR token state ──
   const [qrData, setQrData] = useState<{ qr_payload: string; attendance_code: string; expires_at: string } | null>(null)

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -26,7 +26,7 @@ import {
   isWithinLockdownWindow, isFutureEvent, isEventFull, isNearlyFull,
   spotsLeft, formatEventDateTime, formatGroupOfferDateTime, timeUntilEvent, isEventBanned, formatBanExpiry,
 } from '@/utils/eventUtils'
-import type { Service, EventEvaluationSummary } from '@/types'
+import type { Service, EventEvaluationSummary, NotificationType } from '@/types'
 import type { Comment } from '@/services/commentAPI'
 import type { Handshake } from '@/services/handshakeAPI'
 
@@ -538,10 +538,20 @@ export default function ServiceDetailPage() {
     handshakeAPI.list().then(setHandshakes).catch(() => {})
   }, [isAuthenticated])
 
+  const REFRESH_TYPES: NotificationType[] = [
+    'handshake_accepted',
+    'handshake_cancelled',
+    'handshake_cancellation_requested',
+    'positive_rep',
+    'service_updated',
+    'service_confirmation',
+  ]
+
   // Re-fetch when a relevant notification arrives (e.g. check-in, handshake status change).
   useEffect(() => {
     if (!lastNotification || !service?.id) return
     if (String(lastNotification.related_service) !== String(service.id)) return
+    if (!REFRESH_TYPES.includes(lastNotification.type)) return
     // Refresh both the service (participant_count etc.) and the handshake list.
     serviceAPI.get(service.id).then(setService).catch(() => {})
     if (isAuthenticated) handshakeAPI.list().then(setHandshakes).catch(() => {})
@@ -1796,7 +1806,7 @@ export default function ServiceDetailPage() {
                       </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'no_show' ? (
-                    /* Checked in but not marked attended — no-show */
+                    /* Was checked in but organizer closed event without marking attended */
                     <Stack gap={2}>
                       <Box bg={RED_LT} borderRadius="12px" p={4} border={`1px solid ${RED}30`}
                         display="flex" alignItems="center" gap={3}

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-icons/fi'
 import { toast } from 'sonner'
 import { useAuthStore } from '@/store/useAuthStore'
+import { useNotificationStore } from '@/store/useNotificationStore'
 import { serviceAPI } from '@/services/serviceAPI'
 import { commentAPI } from '@/services/commentAPI'
 import { handshakeAPI } from '@/services/handshakeAPI'
@@ -483,6 +484,7 @@ export default function ServiceDetailPage() {
   const navigate   = useNavigate()
   const [searchParams] = useSearchParams()
   const { isAuthenticated, user, refreshUser, updateUserOptimistically } = useAuthStore()
+  const lastNotification = useNotificationStore((s) => s.notifications[0])
 
   const [service, setService]           = useState<Service | null>(null)
   const [loading, setLoading]           = useState(true)
@@ -535,6 +537,15 @@ export default function ServiceDetailPage() {
     if (!isAuthenticated) return
     handshakeAPI.list().then(setHandshakes).catch(() => {})
   }, [isAuthenticated])
+
+  // Re-fetch when a relevant notification arrives (e.g. check-in, handshake status change).
+  useEffect(() => {
+    if (!lastNotification || !service?.id) return
+    if (String(lastNotification.related_service) !== String(service.id)) return
+    // Refresh both the service (participant_count etc.) and the handshake list.
+    serviceAPI.get(service.id).then(setService).catch(() => {})
+    if (isAuthenticated) handshakeAPI.list().then(setHandshakes).catch(() => {})
+  }, [lastNotification, service?.id, isAuthenticated])
 
   useEffect(() => {
     if (!user?.id || !service?.id) return
@@ -1765,7 +1776,7 @@ export default function ServiceDetailPage() {
                           </Text>
                         </Box>
                       </Box>
-                      {!myEventHandshake.user_has_reviewed && (
+                      {service?.status === 'Completed' && !myEventHandshake.user_has_reviewed && (
                         <Box as="button" w="full" py="11px" borderRadius="10px"
                           bg={AMBER} color={WHITE} fontSize="14px" fontWeight={700}
                           display="flex" alignItems="center" justifyContent="center" gap="7px"
@@ -1782,6 +1793,36 @@ export default function ServiceDetailPage() {
                         style={{ border: 'none', cursor: 'pointer' }}
                       >
                         <FiMessageSquare size={14} /> Event Chat
+                      </Box>
+                    </Stack>
+                  ) : myEventHandshake?.status === 'no_show' ? (
+                    /* Checked in but not marked attended — no-show */
+                    <Stack gap={2}>
+                      <Box bg={RED_LT} borderRadius="12px" p={4} border={`1px solid ${RED}30`}
+                        display="flex" alignItems="center" gap={3}
+                      >
+                        <FiAlertTriangle size={20} color={RED} />
+                        <Box>
+                          <Text fontSize="13px" fontWeight={700} color={RED}>Marked as No-Show</Text>
+                          <Text fontSize="12px" color="#991B1B" mt="2px">
+                            The event ended without your attendance being confirmed.
+                          </Text>
+                        </Box>
+                      </Box>
+                    </Stack>
+                  ) : myEventHandshake?.status === 'accepted' && service.status === 'Completed' ? (
+                    /* Joined but event completed without check-in */
+                    <Stack gap={2}>
+                      <Box bg={GRAY100} borderRadius="12px" p={4} border={`1px solid ${GRAY200}`}
+                        display="flex" alignItems="center" gap={3}
+                      >
+                        <FiCheckCircle size={20} color={GRAY400} />
+                        <Box>
+                          <Text fontSize="13px" fontWeight={700} color={GRAY700}>Event Completed</Text>
+                          <Text fontSize="12px" color={GRAY500} mt="2px">
+                            This event has been marked as completed.
+                          </Text>
+                        </Box>
                       </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'accepted' && isFutureEvent(service.scheduled_time) ? (
@@ -1838,21 +1879,6 @@ export default function ServiceDetailPage() {
                         style={{ border: 'none', cursor: 'pointer' }}
                       >
                         <FiMessageSquare size={14} /> Event Chat
-                      </Box>
-                    </Stack>
-                  ) : myEventHandshake?.status === 'accepted' && service.status === 'Completed' ? (
-                    /* Joined but event completed without check-in */
-                    <Stack gap={2}>
-                      <Box bg={GRAY100} borderRadius="12px" p={4} border={`1px solid ${GRAY200}`}
-                        display="flex" alignItems="center" gap={3}
-                      >
-                        <FiCheckCircle size={20} color={GRAY400} />
-                        <Box>
-                          <Text fontSize="13px" fontWeight={700} color={GRAY700}>Event Completed</Text>
-                          <Text fontSize="12px" color={GRAY500} mt="2px">
-                            This event has been marked as completed.
-                          </Text>
-                        </Box>
                       </Box>
                     </Stack>
                   ) : !isFutureEvent(service.scheduled_time) ? (
@@ -2408,7 +2434,7 @@ export default function ServiceDetailPage() {
         />
       )}
 
-      {isEvent && myEventHandshake?.status === 'attended' && !myEventHandshake.user_has_reviewed && (
+      {isEvent && service?.status === 'Completed' && myEventHandshake?.status === 'attended' && !myEventHandshake.user_has_reviewed && (
         <ServiceEvaluationModal
           isOpen={showEvaluationModal}
           onClose={() => setShowEvaluationModal(false)}

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -1706,13 +1706,24 @@ export default function ServiceDetailPage() {
                       </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'cancelled' ? (
-                    /* Participant was removed from event */
+                    /* Participant left voluntarily or was removed by moderation */
                     <Stack gap={2}>
                       <Box bg={RED_LT} borderRadius="12px" p={4} border={`1px solid ${RED}30`}>
-                        <Text fontSize="13px" fontWeight={700} color={RED}>Removed From Event</Text>
-                        <Text fontSize="12px" color="#991B1B" mt="3px">
-                          You have been removed from this event after a moderation review.
-                        </Text>
+                        {myEventHandshake.cancellation_reason === 'user_left' ? (
+                          <>
+                            <Text fontSize="13px" fontWeight={700} color={RED}>You Left This Event</Text>
+                            <Text fontSize="12px" color="#991B1B" mt="3px">
+                              You cancelled your registration for this event.
+                            </Text>
+                          </>
+                        ) : (
+                          <>
+                            <Text fontSize="13px" fontWeight={700} color={RED}>Removed From Event</Text>
+                            <Text fontSize="12px" color="#991B1B" mt="3px">
+                              You have been removed from this event after a moderation review.
+                            </Text>
+                          </>
+                        )}
                       </Box>
                     </Stack>
                   ) : myEventHandshake?.status === 'checked_in' ? (
@@ -1824,6 +1835,21 @@ export default function ServiceDetailPage() {
                         style={{ border: 'none', cursor: 'pointer' }}
                       >
                         <FiMessageSquare size={14} /> Event Chat
+                      </Box>
+                    </Stack>
+                  ) : myEventHandshake?.status === 'accepted' && service.status === 'Completed' ? (
+                    /* Joined but event completed without check-in */
+                    <Stack gap={2}>
+                      <Box bg={GRAY100} borderRadius="12px" p={4} border={`1px solid ${GRAY200}`}
+                        display="flex" alignItems="center" gap={3}
+                      >
+                        <FiCheckCircle size={20} color={GRAY400} />
+                        <Box>
+                          <Text fontSize="13px" fontWeight={700} color={GRAY700}>Event Completed</Text>
+                          <Text fontSize="12px" color={GRAY500} mt="2px">
+                            This event has been marked as completed.
+                          </Text>
+                        </Box>
                       </Box>
                     </Stack>
                   ) : !isFutureEvent(service.scheduled_time) ? (

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -477,6 +477,22 @@ function CommentSection({ serviceId, refreshKey }: { serviceId: string; refreshK
   )
 }
 
+// ─── Notification refresh filter ─────────────────────────────────────────────
+
+const SERVICE_DETAIL_REFRESH_TYPES: NotificationType[] = [
+  'handshake_accepted',
+  'handshake_cancelled',
+  'handshake_cancellation_requested',
+  'positive_rep',
+  'service_updated',
+  'service_confirmation',
+]
+
+/** Returns true when a notification type should trigger a ServiceDetailPage data refresh. */
+export function isServiceDetailRefreshType(type: NotificationType): boolean {
+  return SERVICE_DETAIL_REFRESH_TYPES.includes(type)
+}
+
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function ServiceDetailPage() {
@@ -538,20 +554,11 @@ export default function ServiceDetailPage() {
     handshakeAPI.list().then(setHandshakes).catch(() => {})
   }, [isAuthenticated])
 
-  const REFRESH_TYPES: NotificationType[] = [
-    'handshake_accepted',
-    'handshake_cancelled',
-    'handshake_cancellation_requested',
-    'positive_rep',
-    'service_updated',
-    'service_confirmation',
-  ]
-
   // Re-fetch when a relevant notification arrives (e.g. check-in, handshake status change).
   useEffect(() => {
     if (!lastNotification || !service?.id) return
     if (String(lastNotification.related_service) !== String(service.id)) return
-    if (!REFRESH_TYPES.includes(lastNotification.type)) return
+    if (!isServiceDetailRefreshType(lastNotification.type)) return
     // Refresh both the service (participant_count etc.) and the handshake list.
     serviceAPI.get(service.id).then(setService).catch(() => {})
     if (isAuthenticated) handshakeAPI.list().then(setHandshakes).catch(() => {})

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -26,7 +26,8 @@ import {
   isWithinLockdownWindow, isFutureEvent, isEventFull, isNearlyFull,
   spotsLeft, formatEventDateTime, formatGroupOfferDateTime, timeUntilEvent, isEventBanned, formatBanExpiry,
 } from '@/utils/eventUtils'
-import type { Service, EventEvaluationSummary, NotificationType } from '@/types'
+import type { Service, EventEvaluationSummary } from '@/types'
+import { isServiceDetailRefreshType } from '@/utils/serviceDetailRefreshTypes'
 import type { Comment } from '@/services/commentAPI'
 import type { Handshake } from '@/services/handshakeAPI'
 
@@ -477,21 +478,6 @@ function CommentSection({ serviceId, refreshKey }: { serviceId: string; refreshK
   )
 }
 
-// ─── Notification refresh filter ─────────────────────────────────────────────
-
-const SERVICE_DETAIL_REFRESH_TYPES: NotificationType[] = [
-  'handshake_accepted',
-  'handshake_cancelled',
-  'handshake_cancellation_requested',
-  'positive_rep',
-  'service_updated',
-  'service_confirmation',
-]
-
-/** Returns true when a notification type should trigger a ServiceDetailPage data refresh. */
-export function isServiceDetailRefreshType(type: NotificationType): boolean {
-  return SERVICE_DETAIL_REFRESH_TYPES.includes(type)
-}
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -1557,7 +1557,10 @@ export default function ServiceDetailPage() {
                           // Event reports should not alter owner-facing attendance/status display.
                           const alreadyReportedParticipant = reportedParticipantIds.has(exId(h.requester) ?? '')
                           const displayStatus = h.status === 'reported' ? 'accepted' : h.status
-                          const cfg = HS_BADGE[displayStatus] ?? { label: displayStatus, bg: GRAY100, color: GRAY500 }
+                          const isSkipped = displayStatus === 'accepted' && service?.status === 'Completed'
+                          const cfg = isSkipped
+                            ? { label: 'Skipped', bg: '#f3f4f6', color: '#6b7280' }
+                            : (HS_BADGE[displayStatus] ?? { label: displayStatus, bg: GRAY100, color: GRAY500 })
                           return (
                             <Flex key={h.id} align="center" justify="space-between"
                               p="10px" bg={GRAY50} borderRadius="9px" gap={2}

--- a/frontend/src/test/utils/serviceDetailRefresh.test.ts
+++ b/frontend/src/test/utils/serviceDetailRefresh.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { isServiceDetailRefreshType } from '@/pages/ServiceDetailPage'
+import type { NotificationType } from '@/types'
+
+describe('isServiceDetailRefreshType', () => {
+  const refreshTypes: NotificationType[] = [
+    'handshake_accepted',
+    'handshake_cancelled',
+    'handshake_cancellation_requested',
+    'positive_rep',
+    'service_updated',
+    'service_confirmation',
+  ]
+
+  const ignoredTypes: NotificationType[] = [
+    'handshake_request',
+    'handshake_denied',
+    'handshake_cancellation_rejected',
+    'chat_message',
+    'service_reminder',
+    'admin_warning',
+    'dispute_resolved',
+    'user_followed',
+    'new_report',
+    'report_received',
+    'report_resolved',
+    'report_dismissed',
+  ]
+
+  it.each(refreshTypes)('returns true for %s', (type) => {
+    expect(isServiceDetailRefreshType(type)).toBe(true)
+  })
+
+  it.each(ignoredTypes)('returns false for %s', (type) => {
+    expect(isServiceDetailRefreshType(type)).toBe(false)
+  })
+})

--- a/frontend/src/test/utils/serviceDetailRefresh.test.ts
+++ b/frontend/src/test/utils/serviceDetailRefresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isServiceDetailRefreshType } from '@/pages/ServiceDetailPage'
+import { isServiceDetailRefreshType } from '@/utils/serviceDetailRefreshTypes'
 import type { NotificationType } from '@/types'
 
 describe('isServiceDetailRefreshType', () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -415,6 +415,7 @@ export interface Handshake {
   updated_at: string
   dispute_reason?: string
   notes?: string
+  cancellation_reason?: string
 }
 
 // ─── Chat & Message Types ─────────────────────────────────────────────────────

--- a/frontend/src/utils/serviceDetailRefreshTypes.ts
+++ b/frontend/src/utils/serviceDetailRefreshTypes.ts
@@ -1,0 +1,14 @@
+import type { NotificationType } from '@/types'
+
+const SERVICE_DETAIL_REFRESH_TYPES: NotificationType[] = [
+  'handshake_accepted',
+  'handshake_cancelled',
+  'handshake_cancellation_requested',
+  'positive_rep',
+  'service_updated',
+  'service_confirmation',
+]
+
+export function isServiceDetailRefreshType(type: NotificationType): boolean {
+  return SERVICE_DETAIL_REFRESH_TYPES.includes(type)
+}

--- a/mobile-client/package-lock.json
+++ b/mobile-client/package-lock.json
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-      "integrity": "sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+      "integrity": "sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1895,7 +1895,7 @@
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^10.2.2",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
@@ -2060,13 +2060,27 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
-      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
+      "version": "10.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.14.tgz",
+      "integrity": "sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
+        "@babel/code-frame": "^7.20.0",
         "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@expo/metro": {
@@ -2091,26 +2105,173 @@
         "metro-transform-worker": "0.83.3"
       }
     },
-    "node_modules/@expo/osascript": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.8.tgz",
-      "integrity": "sha512-/TuOZvSG7Nn0I8c+FcEaoHeBO07yu6vwDgk7rZVvAXoeAK5rkA09jRyjYsZo+0tMEFaToBeywA6pj50Mb3ny9w==",
+    "node_modules/@expo/metro-config": {
+      "version": "54.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.15.tgz",
+      "integrity": "sha512-SqIya4VZ9KHM1S9g+xR0A+QKw1Tfs7Gacx6bQNJ98vs4+O7I5+QP5mHZIB0QSZLUV8opiXebHYTiTu+0OAsIUw==",
       "license": "MIT",
       "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~12.0.13",
+        "@expo/env": "~2.0.8",
+        "@expo/json-file": "~10.0.8",
+        "@expo/metro": "~54.2.0",
         "@expo/spawn-async": "^1.7.2",
-        "exec-async": "^2.2.0"
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.29.1",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "picomatch": "^4.0.3",
+        "postcss": "~8.4.32",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/osascript": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.3.tgz",
+      "integrity": "sha512-wbuj3EebM7W9hN/Wp4xTzKd6rQ2zKJzAxkFxkOOwyysLp0HOAgQ4/5RINyoS241pZUX2rUHq7mAJ7pcCQ8U0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.9.10.tgz",
-      "integrity": "sha512-axJm+NOj3jVxep49va/+L3KkF3YW/dkV+RwzqUJedZrv4LeTqOG4rhrCaCPXHTvLqCTDKu6j0Xyd28N7mnxsGA==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.5.tgz",
+      "integrity": "sha512-nCP9Mebfl3jvOr0/P6VAuyah6PAtun+aihIL2zAtuE8uSe94JWkVZ7051i0MUVO+y3gFpBqnr8IIH5ch+VJjHA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.14",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2199,6 +2360,27 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/@expo/prebuild-config": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.8",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/@expo/require-utils": {
       "version": "55.0.4",
       "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
@@ -2280,9 +2462,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.0.tgz",
-      "integrity": "sha512-o2qDlTqJ606h4xR36H2zWTywmZ3v3842K6TU8Ik2n1mfW0S580VHlt3eItVYdLYz+klaPp7CXqanja8eASZjRw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -4628,12 +4810,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5951,12 +6145,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/exec-async": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
-      "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
-      "license": "MIT"
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6034,29 +6222,29 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.33",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
-      "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "version": "54.0.34",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.34.tgz",
+      "integrity": "sha512-XkVHguZZDC8BcTQxHAd14/TQFbDp1Wt0Z/KApO9t68Ll5A127hLCPzU+a9gytfCIiyL/V1IpF1vIcOLKEVAoNQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.23",
+        "@expo/cli": "54.0.24",
         "@expo/config": "~12.0.13",
         "@expo/config-plugins": "~54.0.4",
         "@expo/devtools": "0.1.8",
-        "@expo/fingerprint": "0.15.4",
+        "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.14",
+        "@expo/metro-config": "54.0.15",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~54.0.10",
-        "expo-asset": "~12.0.12",
+        "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
-        "expo-file-system": "~19.0.21",
+        "expo-file-system": "~19.0.22",
         "expo-font": "~14.0.11",
         "expo-keep-awake": "~15.0.8",
-        "expo-modules-autolinking": "3.0.24",
-        "expo-modules-core": "3.0.29",
+        "expo-modules-autolinking": "3.0.25",
+        "expo-modules-core": "3.0.30",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -6095,13 +6283,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
+        "expo-constants": "~18.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -6207,9 +6395,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "19.0.22",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.22.tgz",
+      "integrity": "sha512-l9pgahSc7sJD0bP9vBNeXvZjy8QKDpVHVxWmei/ESQOrzmoj5BidziqLVsyZdxsi+PfdbTtttLTAmddH/JafYA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -6281,9 +6469,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-      "integrity": "sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.25.tgz",
+      "integrity": "sha512-YmHWctJlwvOuLZccg3cOXvSiXVJrPMKl7g2YR0YHWoGL9v2RvcmgaPJWPSLVW+voNEgEPsbo5UmUrAqbnYcBeg==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -6367,9 +6555,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.29",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-      "integrity": "sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+      "integrity": "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -6419,9 +6607,9 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-      "integrity": "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.6.tgz",
+      "integrity": "sha512-vb5TBtskvEdzYuW79lATXutOEBfW5m6U4EFpNjCVZTnI7S//SAsLQkYEpn+EDfn84m6VQfzSGkIVR6YPaScKFA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
@@ -6469,24 +6657,10 @@
         "expo": "*"
       }
     },
-    "node_modules/expo/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.23",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
-      "integrity": "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==",
+      "version": "54.0.24",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.24.tgz",
+      "integrity": "sha512-5xse1bEgnVUBhOrtttc6xTNJVvjyTRavpzuF0/0nuj+312vfSbk7EiRbG+xJ2pW/iZxnhLPJkFCrPYG0nmheAQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -6498,7 +6672,7 @@
         "@expo/image-utils": "^0.8.8",
         "@expo/json-file": "^10.0.8",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.14",
+        "@expo/metro-config": "~54.0.15",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
         "@expo/plist": "^0.4.8",
@@ -6521,16 +6695,16 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.5",
+        "expo-server": "^1.0.6",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "lan-network": "^0.1.6",
+        "lan-network": "^0.2.1",
         "minimatch": "^9.0.0",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
+        "picomatch": "^4.0.3",
         "pretty-bytes": "^5.6.0",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
@@ -6566,64 +6740,6 @@
           "optional": true
         },
         "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
-        "@react-native/normalize-colors": "0.81.5",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/metro-config": {
-      "version": "54.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-      "integrity": "sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.8",
-        "@expo/metro": "~54.2.0",
-        "@expo/spawn-async": "^1.7.2",
-        "browserslist": "^4.25.0",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "hermes-parser": "^0.29.1",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "^1.30.1",
-        "minimatch": "^9.0.0",
-        "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
           "optional": true
         }
       }
@@ -6684,6 +6800,15 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/expo/node_modules/chalk": {
@@ -6768,28 +6893,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/expo/node_modules/hermes-estree": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
-      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
-      "license": "MIT"
-    },
-    "node_modules/expo/node_modules/hermes-parser": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
-      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
-      "license": "MIT",
+    "node_modules/expo/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "hermes-estree": "0.29.1"
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6808,9 +6933,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6847,9 +6972,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7133,42 +7258,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10155,9 +10244,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -10198,9 +10287,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
-      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -10213,23 +10302,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.31.1",
-        "lightningcss-darwin-arm64": "1.31.1",
-        "lightningcss-darwin-x64": "1.31.1",
-        "lightningcss-freebsd-x64": "1.31.1",
-        "lightningcss-linux-arm-gnueabihf": "1.31.1",
-        "lightningcss-linux-arm64-gnu": "1.31.1",
-        "lightningcss-linux-arm64-musl": "1.31.1",
-        "lightningcss-linux-x64-gnu": "1.31.1",
-        "lightningcss-linux-x64-musl": "1.31.1",
-        "lightningcss-win32-arm64-msvc": "1.31.1",
-        "lightningcss-win32-x64-msvc": "1.31.1"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
-      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -10247,9 +10336,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
-      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -10267,9 +10356,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
-      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -10287,9 +10376,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
-      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -10307,9 +10396,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
-      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -10327,11 +10416,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
-      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10347,11 +10439,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
-      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10367,11 +10462,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10387,11 +10485,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
-      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10407,9 +10508,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
-      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -10427,9 +10528,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -11007,15 +11108,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -13206,9 +13307,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -13607,9 +13708,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -13966,9 +14067,9 @@
       }
     },
     "node_modules/wonka": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
-      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
     },
     "node_modules/wordwrap": {

--- a/mobile-client/src/constants/notificationMappings.ts
+++ b/mobile-client/src/constants/notificationMappings.ts
@@ -37,7 +37,27 @@ export function navigateToNotificationTarget(
     return;
   }
 
-  // Event notifications → ServiceDetail (even if related_handshake is present)
+  // Event chat message → PublicChat screen (not ServiceDetail)
+  if (type === 'chat_message' && related_service_type === 'Event' && related_service) {
+    navigation.navigate('Messages', { screen: 'MessagesList' });
+    navigation.navigate('Messages', {
+      screen: 'PublicChat',
+      params: { roomId: related_service },
+    });
+    return;
+  }
+
+  // Group offer/need chat message (no handshake link = group-level chat) → GroupChat screen
+  if (type === 'chat_message' && related_service && !related_handshake) {
+    navigation.navigate('Messages', { screen: 'MessagesList' });
+    navigation.navigate('Messages', {
+      screen: 'GroupChat',
+      params: { groupId: related_service },
+    });
+    return;
+  }
+
+  // All other event notifications → ServiceDetail
   if (related_service_type === 'Event' && related_service) {
     navigation.navigate('Home', {
       screen: 'ServiceDetail',
@@ -54,6 +74,9 @@ export function navigateToNotificationTarget(
     (type.startsWith('handshake_') || type === 'chat_message' || type === 'service_confirmation') &&
     related_handshake
   ) {
+    // Navigate to MessagesList first so it anchors the back-stack, then push Chat.
+    // This guarantees a back button even when the Messages tab was already showing Chat.
+    navigation.navigate('Messages', { screen: 'MessagesList' });
     navigation.navigate('Messages', {
       screen: 'Chat',
       params: { handshakeId: related_handshake, notificationId: notification.id },

--- a/mobile-client/src/presentation/screens/ChatScreen.tsx
+++ b/mobile-client/src/presentation/screens/ChatScreen.tsx
@@ -20,6 +20,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import {
   useRoute,
   useNavigation,
+  StackActions,
   type CompositeNavigationProp,
 } from "@react-navigation/native";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
@@ -149,9 +150,22 @@ export default function ChatScreen() {
     handshake,
   });
 
+  // When arriving from a notification, serviceTitle/serviceType aren't passed as params.
+  // Fall back to the loaded handshake's service fields once they're available.
+  const effectiveServiceTitle =
+    serviceTitle ||
+    (typeof handshakeRecord?.service_title === "string"
+      ? handshakeRecord.service_title
+      : undefined);
+  const effectiveServiceType =
+    serviceType ||
+    (typeof handshakeRecord?.service_type === "string"
+      ? handshakeRecord.service_type
+      : undefined);
+
   const title = useMemo(
-    () => serviceTitle || chatParticipant.name || "Messages",
-    [chatParticipant.name, serviceTitle],
+    () => effectiveServiceTitle || chatParticipant.name || "Messages",
+    [chatParticipant.name, effectiveServiceTitle],
   );
   const isCurrentUserServiceOwner = useMemo(() => {
     const liveServiceType =
@@ -348,22 +362,35 @@ export default function ChatScreen() {
   }, [handshakeId, notificationId]);
 
   useEffect(() => {
+    const isRootScreen = navigation.getState().index === 0;
     navigation.setOptions({
       headerTitle: () => (
         <View style={styles.headerTitleWrap}>
           <Text style={styles.headerTitleText} numberOfLines={1}>
             {title}
           </Text>
-          {!!serviceType ? (
+          {!!effectiveServiceType ? (
             <View style={styles.headerTypeBadge}>
-              <Text style={styles.headerTypeBadgeText}>{serviceType}</Text>
+              <Text style={styles.headerTypeBadgeText}>{effectiveServiceType}</Text>
             </View>
           ) : null}
         </View>
       ),
       headerBackTitle: "Back",
+      // When opened directly from a notification the screen may be the stack
+      // root (no MessagesList below it). Render an explicit back button so the
+      // user can always return to the messages list.
+      headerLeft: isRootScreen ? () => (
+        <TouchableOpacity
+          onPress={() => navigation.dispatch(StackActions.replace("MessagesList"))}
+          hitSlop={8}
+          style={{ paddingRight: 8 }}
+        >
+          <Ionicons name="chevron-back" size={28} color="#007AFF" />
+        </TouchableOpacity>
+      ) : undefined,
     });
-  }, [navigation, serviceType, title]);
+  }, [navigation, effectiveServiceType, title]);
 
   const sessionDetails = useMemo<SessionDetails | null>(() => {
     if (!handshake) return null;

--- a/mobile-client/src/presentation/screens/GroupChatScreen.tsx
+++ b/mobile-client/src/presentation/screens/GroupChatScreen.tsx
@@ -149,43 +149,34 @@ export default function GroupChatScreen() {
 
     ws.onmessage = (event) => {
       try {
-        const data = JSON.parse(event.data as string) as Record<
-          string,
-          unknown
-        >;
-        if (data.messages && Array.isArray(data.messages)) {
-          const normalized = (
-            data.messages as Record<string, unknown>[]
-          ).map(normalizeMessage);
-          setMessages((prev) => dedupeMessages([...prev, ...normalized]));
-          scrollToBottom(false);
-        } else if (
-          data.type === "message" ||
-          data.body !== undefined ||
-          data.content !== undefined
-        ) {
-          const incoming = normalizeMessage(data);
-          setMessages((prev) => {
-            const next = prev.filter(
-              (m) =>
-                !(
-                  m.pending &&
-                  (m.body ?? m.content ?? "").trim() ===
-                    (incoming.body ?? incoming.content ?? "").trim() &&
-                  (m.sender_id === incoming.sender_id ||
-                    m.sender === incoming.sender)
-                ),
-            );
-            return dedupeMessages([...next, incoming]);
-          });
-          scrollToBottom();
-        } else if (Array.isArray(data)) {
-          const normalized = (data as Record<string, unknown>[]).map(
-            normalizeMessage,
+        const payload = JSON.parse(event.data as string) as Record<string, unknown>;
+
+        // Backend sends {"type": "chat_message", "message": {...}}
+        const incoming =
+          payload.message && typeof payload.message === "object"
+            ? normalizeMessage(payload.message as Record<string, unknown>)
+            : payload.type === "message" ||
+                payload.body !== undefined ||
+                payload.content !== undefined
+              ? normalizeMessage(payload)
+              : null;
+
+        if (!incoming) return;
+
+        setMessages((prev) => {
+          const next = prev.filter(
+            (m) =>
+              !(
+                m.pending &&
+                (m.body ?? m.content ?? "").trim() ===
+                  (incoming.body ?? incoming.content ?? "").trim() &&
+                (m.sender_id === incoming.sender_id ||
+                  m.sender === incoming.sender)
+              ),
           );
-          setMessages((prev) => dedupeMessages([...prev, ...normalized]));
-          scrollToBottom(false);
-        }
+          return dedupeMessages([...next, incoming]);
+        });
+        scrollToBottom();
       } catch {
         // Non-JSON or unexpected payload — ignore silently
       }

--- a/mobile-client/src/presentation/screens/GroupChatScreen.tsx
+++ b/mobile-client/src/presentation/screens/GroupChatScreen.tsx
@@ -11,7 +11,7 @@ import {
   TouchableOpacity,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRoute, useNavigation } from "@react-navigation/native";
+import { useRoute, useNavigation, StackActions } from "@react-navigation/native";
 import type {
   NativeStackNavigationProp,
   NativeStackScreenProps,
@@ -204,7 +204,19 @@ export default function GroupChatScreen() {
   }, [groupId, dedupeMessages, scrollToBottom]);
 
   useEffect(() => {
-    navigation.setOptions({ headerTitle: threadTitle || groupTitle });
+    const isRootScreen = navigation.getState().index === 0;
+    navigation.setOptions({
+      headerTitle: threadTitle || groupTitle,
+      headerLeft: isRootScreen ? () => (
+        <TouchableOpacity
+          onPress={() => navigation.dispatch(StackActions.replace("MessagesList"))}
+          hitSlop={8}
+          style={{ paddingRight: 8 }}
+        >
+          <Ionicons name="chevron-back" size={28} color="#007AFF" />
+        </TouchableOpacity>
+      ) : undefined,
+    });
   }, [navigation, groupTitle, threadTitle]);
 
   const openParticipantProfile = useCallback(

--- a/mobile-client/src/presentation/screens/MessagesScreen.tsx
+++ b/mobile-client/src/presentation/screens/MessagesScreen.tsx
@@ -146,20 +146,18 @@ function buildGroupChatEntries(chats: Chat[]): GroupChatListEntry[] {
   for (const [serviceId, convs] of byService) {
     if (!convs.some(isAcceptedHandshake)) continue;
 
-    let latest: Chat | null = null;
+    // Use the most-recently-updated handshake to pick the representative conv
+    // (for title / member count), but do NOT expose its last_message as the
+    // group preview — those are 1-to-1 handshake messages, not group messages.
+    let rep = convs[0];
     let latestTs = 0;
     for (const c of convs) {
-      const msgT = c.last_message?.created_at
-        ? new Date(c.last_message.created_at).getTime()
-        : 0;
       const upT = c.updated_at ? new Date(c.updated_at).getTime() : 0;
-      const t = Math.max(msgT, upT);
-      if (t >= latestTs) {
-        latestTs = t;
-        latest = c;
+      if (upT > latestTs) {
+        latestTs = upT;
+        rep = c;
       }
     }
-    const rep = latest ?? convs[0];
     const acceptedCount = convs.filter(isAcceptedHandshake).length;
     const memberCount =
       typeof rep.service_member_count === "number"
@@ -170,8 +168,8 @@ function buildGroupChatEntries(chats: Chat[]): GroupChatListEntry[] {
       serviceId,
       serviceTitle: rep.service_title ?? "Group chat",
       memberCount,
-      previewBody: rep.last_message?.body ?? null,
-      previewAt: rep.last_message?.created_at ?? null,
+      previewBody: null,
+      previewAt: null,
     });
   }
 

--- a/mobile-client/src/presentation/screens/PublicChatScreen.tsx
+++ b/mobile-client/src/presentation/screens/PublicChatScreen.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute, StackActions } from "@react-navigation/native";
 import type { NativeStackNavigationProp, NativeStackScreenProps } from "@react-navigation/native-stack";
 import Ionicons from "@expo/vector-icons/Ionicons";
 
@@ -50,9 +50,7 @@ export default function PublicChatScreen() {
   const { params } = useRoute<NavProps["route"]>();
   const navigation = useNavigation<NativeStackNavigationProp<MessagesStackParamList>>();
   const { user } = useAuth();
-  const { roomId: serviceId, roomTitle = "Event chat" } = params ?? {
-    roomId: "",
-  };
+  const { roomId: serviceId, roomTitle } = params ?? { roomId: "" };
 
   const [messages, setMessages] = useState<ChatMessageWithMeta[]>([]);
   const [inputText, setInputText] = useState("");
@@ -62,6 +60,8 @@ export default function PublicChatScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [wsRoomId, setWsRoomId] = useState<string | null>(null);
   const [memberCount, setMemberCount] = useState<number | null>(null);
+  // Title from params when available; falls back to service title fetched in loadHistory.
+  const [effectiveTitle, setEffectiveTitle] = useState(roomTitle ?? "Event chat");
   const [participants, setParticipants] = useState<ChatParticipantItem[]>([]);
   const [showParticipantsSheet, setShowParticipantsSheet] = useState(false);
 
@@ -168,6 +168,10 @@ export default function PublicChatScreen() {
           setMemberCount(null);
         }
 
+        if (!roomTitle && typeof service.title === "string" && service.title) {
+          setEffectiveTitle(service.title);
+        }
+
         const activeParticipants = handshakesResponse.results.filter((handshake) => {
           const handshakeService =
             typeof handshake.service === "string"
@@ -259,8 +263,20 @@ export default function PublicChatScreen() {
   }, [loadHistory]);
 
   useEffect(() => {
-    navigation.setOptions({ headerTitle: roomTitle });
-  }, [navigation, roomTitle]);
+    const isRootScreen = navigation.getState().index === 0;
+    navigation.setOptions({
+      headerTitle: effectiveTitle,
+      headerLeft: isRootScreen ? () => (
+        <TouchableOpacity
+          onPress={() => navigation.dispatch(StackActions.replace("MessagesList"))}
+          hitSlop={8}
+          style={{ paddingRight: 8 }}
+        >
+          <Ionicons name="chevron-back" size={28} color="#007AFF" />
+        </TouchableOpacity>
+      ) : undefined,
+    });
+  }, [navigation, effectiveTitle]);
 
   useEffect(() => {
     if (!wsRoomId) return;
@@ -444,7 +460,7 @@ export default function PublicChatScreen() {
               style={styles.serviceLinkWrap}
             >
               <Text style={styles.headerTitleLink} numberOfLines={1}>
-                {roomTitle}
+                {effectiveTitle}
               </Text>
               <Text style={styles.headerSubtitle}>
                 {memberCount !== null

--- a/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
+++ b/mobile-client/src/presentation/screens/ServiceDetailScreen.tsx
@@ -1589,14 +1589,19 @@ export default function ServiceDetailScreen() {
               </View>
             );
 
-            if (status === "cancelled") return (
-              <View style={styles.sectionBlock}>
-                <View style={styles.dangerBanner}>
-                  <Ionicons name="close-circle" size={20} color={colors.RED} />
-                  <Text style={[styles.bannerText, { color: colors.RED }]}>Removed from event</Text>
+            if (status === "cancelled") {
+              const userLeft = myEventHandshake?.cancellation_reason === "user_left";
+              return (
+                <View style={styles.sectionBlock}>
+                  <View style={styles.dangerBanner}>
+                    <Ionicons name="close-circle" size={20} color={colors.RED} />
+                    <Text style={[styles.bannerText, { color: colors.RED }]}>
+                      {userLeft ? "You left this event" : "Removed from event"}
+                    </Text>
+                  </View>
                 </View>
-              </View>
-            );
+              );
+            }
 
             if (status === "attended") return (
               <View style={styles.sectionBlock}>


### PR DESCRIPTION
## Summary

Closes #516
Closes #502 
Closes #518 

Fixes a cluster of bugs in the event participation lifecycle: incorrect eligibility
checks for evaluation, wrong no-show assignment on completion, broken event chat access for past participants, and missing/misleading UI state for various participant statuses.

## Changes

**Backend**
- `complete_event`: only `checked_in` participants become `no_show` on event completion;
  `accepted` (registered but never checked in) participants stay `accepted` — no penalty
- `complete_event`: notify `accepted` participants when the event is marked completed
- `PublicChatViewSet._check_event_access` + `PublicChatConsumer.check_event_access`:  extend allowed statuses to include `completed` and `no_show` so past participants  can read event chat after the event ends
- History endpoint: `evaluation_pending` now excludes organizers (`was_provider=True`) and pre-fetches already-submitted `ReputationRep` rows to avoid N+1 and false positives
- `leave_event`: sets `cancellation_reason='user_left'` to distinguish voluntary leave from moderation removal
- `setup_demo.py`: fix `add_public_chat_messages` to use `get_or_create` for `ChatRoom` (rooms were never created, so all demo event chat messages silently failed); add `ChatRoom` import; seed chat messages for 6 additional events

**Frontend**
- `ServiceDetailPage`: add dedicated branches for `no_show` ("Marked as No-Show") and `accepted + Completed` ("Event Completed") participant states — previously both fell through to the generic "Event Ended" or join button
- `ServiceDetailPage`: move `accepted + Completed` check before `accepted + isFutureEvent` so events completed before their scheduled time show the correct banner
- `ServiceDetailPage`: gate "Leave Evaluation" button and modal on `service.status === 'Completed'` — attendees could see the button before the organizer closed the event
- `ServiceDetailPage`: cancelled branch shows "You Left This Event" when `cancellation_reason === 'user_left'`, vs "Removed From Event" for moderation removals
- `ServiceDetailPage`: organizer roster shows "Skipped" badge (neutral gray) for `accepted` participants on completed events instead of "Accepted" (green)
- `ServiceDetailPage`: subscribe to `useNotificationStore` to re-fetch service and handshake data in real time when a relevant notification arrives (e.g. check-in by another participant)
- `EventRosterModal`: `willBeNoShow` count now only includes `checked_in` participants; remove unused `registered` variable
- `types/index.ts`: add `cancellation_reason?: string` to `Handshake` interface

**Tests**
- Rename and update `test_complete_event_moves_accepted_and_checked_in_to_no_show` → `test_complete_event_no_show_only_for_checked_in` to reflect the corrected behavior

## How to Test

1. Run `make setup-demo` to re-seed demo data (required for chat message fix).
2. Log in as `cem@demo.com` (participant) and `elif@demo.com` (organizer). Password: `demo123`.
3. **No-show vs accepted on completion:** join an event as Cem, do not check in, complete the event as organizer → Cem should see "Event Completed" banner (not "Check In" button);
 roster should show "Skipped" badge for Cem, not "No-Show".
4. **Check-in → no-show:** join as Cem, check in, complete without marking attended →  Cem should see "Marked as No-Show".
5. **Evaluation gate:** mark Cem as attended, verify "Leave Evaluation" button is hidden until organizer clicks "Complete Event"; after completion it appears.
6. **Event chat:** open event chat as a past participant (`completed` or `no_show`) → messages should load (previously returned 403).
7. **Profile history:** evaluate an event as an attended participant; check profile history → "Evaluation Pending" label should disappear after submission.
8. **Real-time update:** open the event page as Zeynep while Cem checks in on another tab → Zeynep's roster should update without a manual refresh.
9. **Leave message:** join and leave an event → the page should show "You Left This Event" not "Removed From Event".

---

**Mobile client changes**

- **Notification deep-link routing** (`notificationMappings.ts`): event chat notifications now route to `PublicChat` instead of the event detail page; group offer/need chat notifications (no handshake) route to `GroupChat`. Both paths navigate to `MessagesList` first so the back button always works.

- **Back button reliability** (`ChatScreen`, `GroupChatScreen`, `PublicChatScreen`): all three chat screens detect when they are the root of the stack (`navigation.getState().index === 0`) and render a custom back button that replaces the screen with `MessagesList`, preventing a dead-end navigation state.

- **Chat header title** (`ChatScreen`, `PublicChatScreen`): screens opened from a notification now correctly populate the header title from the handshake/service data fetched on load, instead of showing a blank or wrong name.

- **"You left this event" banner** (`ServiceDetailScreen`): when a participant's handshake has `cancellation_reason === 'user_left'`, the cancelled state banner now reads "You left this event" instead of the generic "Service Cancelled".

- **Group chat real-time messages** (`GroupChatScreen`): fixed the WebSocket `onmessage` handler to unwrap the backend envelope `{"type": "chat_message", "message": {...}}` — messages now appear instantly without requiring a page refresh.

- **Group chat preview pollution** (`MessagesScreen`): group chat rows in the messages list no longer display a preview text sourced from 1-to-1 handshake messages of the same offer. The preview is left blank until a true group-level last-message API is available.
