### PR TITLE
fix: logout broken on mobile, flickers on web

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -344,6 +344,7 @@ const Navbar = () => {
                 bg={mobileOpen ? GRAY100 : 'transparent'}
                 color={GRAY600}
                 onClick={() => setMobileOpen((v) => !v)}
+                aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
                 style={{ border: 'none', cursor: 'pointer', flexShrink: 0 }}
               >
                 {mobileOpen ? <FiX size={20} /> : <FiMenu size={20} />}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -145,7 +145,10 @@ const Navbar = () => {
   const [mobileOpen, setMobileOpen] = useState(false)
   const mobileRef = useRef<HTMLDivElement>(null)
 
-  const handleLogout = () => { logout(); navigate('/') }
+  const handleLogout = async () => {
+    await logout()
+    navigate('/login', { replace: true })
+  }
 
   // Close mobile menu on route change
   // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -477,7 +480,7 @@ const Navbar = () => {
               display="flex" alignItems="center" gap="10px"
               fontSize="14px" fontWeight={500} color={RED}
               bg="transparent"
-              onClick={() => { handleLogout(); setMobileOpen(false) }}
+              onClick={async () => { setMobileOpen(false); await handleLogout() }}
               _hover={{ bg: RED_LT }} transition="background 0.15s"
             >
               <FiLogOut size={16} /> Log Out

--- a/frontend/src/test/components/Navbar.test.tsx
+++ b/frontend/src/test/components/Navbar.test.tsx
@@ -1,0 +1,111 @@
+import { ChakraProvider } from '@chakra-ui/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import Navbar from '@/components/Navbar'
+import system from '@/theme'
+
+const { navigateMock, logoutMock, startTourMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  logoutMock: vi.fn(),
+  startTourMock: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => ({
+    user: {
+      id: 'u-1',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      email: 'ada@example.com',
+      timebank_balance: 0,
+      role: 'user',
+      is_admin: false,
+    },
+    isAuthenticated: true,
+    logout: logoutMock,
+  }),
+}))
+
+vi.mock('@/store/useTourStore', () => ({
+  useTourStore: (selector: (s: { startTour: () => void }) => unknown) =>
+    selector({ startTour: startTourMock }),
+}))
+
+vi.mock('@/components/NotificationDropdown', () => ({
+  NotificationDropdown: () => null,
+}))
+
+function renderNavbar() {
+  render(
+    <ChakraProvider value={system}>
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    </ChakraProvider>,
+  )
+}
+
+describe('Navbar logout', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('awaits logout before navigating from the desktop user menu', async () => {
+    let resolveLogout: () => void = () => {}
+    logoutMock.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveLogout = resolve }),
+    )
+
+    renderNavbar()
+    fireEvent.click(screen.getByTestId('user-menu-trigger'))
+    fireEvent.click(await screen.findByText('Log Out'))
+
+    // logout() is in flight; navigation MUST NOT have happened yet.
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    resolveLogout()
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })
+    })
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates to /login with replace once logout resolves', async () => {
+    logoutMock.mockResolvedValue(undefined)
+
+    renderNavbar()
+    fireEvent.click(screen.getByTestId('user-menu-trigger'))
+    fireEvent.click(await screen.findByText('Log Out'))
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })
+    })
+  })
+
+  it('awaits logout from the mobile drawer before navigating', async () => {
+    let resolveLogout: () => void = () => {}
+    logoutMock.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveLogout = resolve }),
+    )
+
+    renderNavbar()
+    fireEvent.click(screen.getByLabelText('Open menu'))
+    fireEvent.click(await screen.findByText('Log Out'))
+
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    resolveLogout()
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true })
+    })
+  })
+})

--- a/mobile-client/package.json
+++ b/mobile-client/package.json
@@ -88,7 +88,8 @@
         ],
         "testMatch": [
           "**/components/__tests__/**/*.test.tsx",
-          "**/__tests__/components/**/*.test.tsx"
+          "**/__tests__/components/**/*.test.tsx",
+          "**/context/__tests__/**/*.test.tsx"
         ],
         "transformIgnorePatterns": [
           "node_modules/(?!((jest-)?react-native|@react-native|@react-navigation|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-clone-referenced-element|@react-native-community|sentry-expo|native-base|react-native-svg))"

--- a/mobile-client/src/context/AuthContext.tsx
+++ b/mobile-client/src/context/AuthContext.tsx
@@ -130,9 +130,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = useCallback(async () => {
     const prevId = user?.id ?? null;
-    await authApi.logout();
-    useNotificationStore.getState().reset();
+    // Clear local UI state first so the user is signed out from the app's
+    // perspective even if token/notification teardown throws.
     await clearSessionLocal(prevId);
+    try {
+      useNotificationStore.getState().reset();
+    } catch {
+      /* best-effort */
+    }
+    try {
+      await authApi.logout();
+    } catch {
+      /* in-memory state already cleared */
+    }
   }, [user, clearSessionLocal]);
 
   useEffect(() => {

--- a/mobile-client/src/context/__tests__/AuthContext.test.tsx
+++ b/mobile-client/src/context/__tests__/AuthContext.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * AuthContext logout tests.
+ *
+ * The bug being guarded against: a thrown error in token cleanup or the
+ * notification store reset would short-circuit the callback before
+ * `setUser(null)` ran, leaving the user appearing signed in despite tokens
+ * having been wiped. The fix clears local UI state first; native teardown
+ * runs as best-effort.
+ */
+
+import React from "react";
+import { Text, View } from "react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
+
+const mockAuthApiLogout = jest.fn();
+const mockNotificationReset = jest.fn();
+const mockClearCurrentUser = jest.fn();
+const mockClearAllUserCaches = jest.fn();
+const mockInitConnectivity = jest.fn();
+const mockGetStoredTokens = jest.fn();
+
+jest.mock("../../api/auth", () => ({
+  __esModule: true,
+  login: jest.fn(),
+  register: jest.fn(),
+  refresh: jest.fn(),
+  logout: () => mockAuthApiLogout(),
+}));
+
+jest.mock("../../api/users", () => ({
+  __esModule: true,
+  getMe: jest.fn(),
+}));
+
+jest.mock("../../api/storage", () => ({
+  __esModule: true,
+  getStoredTokens: () => mockGetStoredTokens(),
+}));
+
+jest.mock("../../api/client", () => ({
+  __esModule: true,
+  setAuthTokens: jest.fn(),
+  getRefreshToken: jest.fn().mockReturnValue(null),
+  ApiHttpError: class ApiHttpError extends Error {
+    status = 0;
+    body = "";
+  },
+  ApiNetworkError: class ApiNetworkError extends Error {},
+}));
+
+jest.mock("../../store/useNotificationStore", () => ({
+  __esModule: true,
+  useNotificationStore: {
+    getState: () => ({ reset: mockNotificationReset }),
+  },
+}));
+
+jest.mock("../../store/connectivityStore", () => ({
+  __esModule: true,
+  initConnectivity: () => mockInitConnectivity(),
+}));
+
+jest.mock("../../cache/offlineCache", () => ({
+  __esModule: true,
+  saveCurrentUser: jest.fn(),
+  readCurrentUser: jest.fn().mockResolvedValue(null),
+  clearCurrentUser: () => mockClearCurrentUser(),
+  clearAllUserCaches: (id: string) => mockClearAllUserCaches(id),
+}));
+
+import { AuthProvider, useAuth } from "../AuthContext";
+
+function Probe() {
+  const { user, isAuthenticated, logout } = useAuth();
+  (globalThis as unknown as { __logout?: () => Promise<void> }).__logout = logout;
+  return (
+    <View>
+      <Text testID="user">{user ? user.id : "null"}</Text>
+      <Text testID="auth">{isAuthenticated ? "yes" : "no"}</Text>
+    </View>
+  );
+}
+
+async function renderWithSignedInUser() {
+  const cached = {
+    data: {
+      id: "u-1",
+      first_name: "Ada",
+      last_name: "Lovelace",
+      email: "ada@example.com",
+    },
+    cachedAt: Date.now(),
+  };
+  mockGetStoredTokens.mockResolvedValue({ access: "a", refresh: "r" });
+  // Pull the already-mocked modules via require so we can program their
+  // return values for this render.
+  const offlineCache = jest.requireMock("../../cache/offlineCache");
+  offlineCache.readCurrentUser.mockResolvedValue(cached);
+  const users = jest.requireMock("../../api/users");
+  const { ApiNetworkError } = jest.requireMock("../../api/client");
+  // Force getMe to fail with a network error so the provider keeps the
+  // cached user instead of trying refresh and clearing the session.
+  users.getMe.mockRejectedValue(new ApiNetworkError("offline"));
+
+  const utils = render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>,
+  );
+  await waitFor(() => {
+    expect(utils.getByTestId("user").props.children).toBe("u-1");
+  });
+  return utils;
+}
+
+describe("AuthContext.logout", () => {
+  beforeEach(() => {
+    mockAuthApiLogout.mockReset().mockResolvedValue(undefined);
+    mockNotificationReset.mockReset();
+    mockClearCurrentUser.mockReset();
+    mockClearAllUserCaches.mockReset();
+    mockInitConnectivity.mockReset();
+    mockGetStoredTokens.mockReset();
+  });
+
+  it("clears user state even when authApi.logout throws", async () => {
+    const utils = await renderWithSignedInUser();
+    mockAuthApiLogout.mockRejectedValue(new Error("SecureStore unavailable"));
+
+    await act(async () => {
+      await (globalThis as unknown as { __logout: () => Promise<void> }).__logout();
+    });
+
+    expect(utils.getByTestId("user").props.children).toBe("null");
+    expect(utils.getByTestId("auth").props.children).toBe("no");
+    expect(mockClearCurrentUser).toHaveBeenCalled();
+    expect(mockAuthApiLogout).toHaveBeenCalled();
+  });
+
+  it("clears user state even when notification store reset throws", async () => {
+    const utils = await renderWithSignedInUser();
+    mockNotificationReset.mockImplementation(() => {
+      throw new Error("subscriber blew up");
+    });
+
+    await act(async () => {
+      await (globalThis as unknown as { __logout: () => Promise<void> }).__logout();
+    });
+
+    expect(utils.getByTestId("user").props.children).toBe("null");
+    expect(utils.getByTestId("auth").props.children).toBe("no");
+    expect(mockClearCurrentUser).toHaveBeenCalled();
+    // authApi.logout still runs because the reset error is caught.
+    expect(mockAuthApiLogout).toHaveBeenCalled();
+  });
+
+  it("clears user state on the happy path and runs all teardown", async () => {
+    const utils = await renderWithSignedInUser();
+
+    await act(async () => {
+      await (globalThis as unknown as { __logout: () => Promise<void> }).__logout();
+    });
+
+    expect(utils.getByTestId("user").props.children).toBe("null");
+    expect(utils.getByTestId("auth").props.children).toBe("no");
+    expect(mockClearCurrentUser).toHaveBeenCalled();
+    expect(mockClearAllUserCaches).toHaveBeenCalledWith("u-1");
+    expect(mockNotificationReset).toHaveBeenCalled();
+    expect(mockAuthApiLogout).toHaveBeenCalled();
+  });
+});

--- a/mobile-client/src/context/__tests__/AuthContext.test.tsx
+++ b/mobile-client/src/context/__tests__/AuthContext.test.tsx
@@ -12,6 +12,11 @@ import React from "react";
 import { Text, View } from "react-native";
 import { act, render, waitFor } from "@testing-library/react-native";
 
+// First mount of AuthProvider in CI can take longer than the 5s default
+// (Expo / RN test renderer cold start). Local runs are ~1.6s; give CI
+// headroom.
+jest.setTimeout(20000);
+
 const mockAuthApiLogout = jest.fn();
 const mockNotificationReset = jest.fn();
 const mockClearCurrentUser = jest.fn();


### PR DESCRIPTION
## Summary

Logout was broken on both clients in different ways. Both fixes are surgical (one file each).

### Mobile — user could not sign out
`mobile-client/src/context/AuthContext.tsx`

The `logout` callback awaited `authApi.logout()` (clears SecureStore tokens) and `useNotificationStore.getState().reset()` **before** `clearSessionLocal()` (the call that runs `setUser(null)`). If either earlier step threw — SecureStore failure, keychain locked, a notification-store subscriber error — `setUser(null)` was never reached, so the UI kept rendering the authenticated profile view. Because the call site uses `void logout()`, the error was silent. Tapping "Log out" again repeated the same broken chain.

**Fix:** clear local UI state first, then run notification reset and token cleanup as best-effort. The user is signed out from the UI's perspective the instant they tap, regardless of what native storage does.

### Web — buggy/flickering logout
`frontend/src/components/Navbar.tsx`

`handleLogout` called the async `logout()` without awaiting it, then fired `navigate('/')` synchronously. The router re-rendered while the auth store still said `isAuthenticated=true` (protected routes briefly rendered the dashboard layout); when the `/auth/logout/` POST resolved, state flipped and routes redirected again. That double re-render during a route transition is the visible flicker / "crash."

**Fix:** await `logout()` before navigating, and route straight to `/login` with `replace: true` so the back button doesn't return to the now-unauthenticated layout. The mobile drawer onClick is fixed the same way.

## Test plan
- [ ] Web desktop: avatar → Log Out closes the dropdown cleanly with a single transition to `/login`; no flash of dashboard, no React state-on-unmounted-component warnings in console.
- [ ] Web mobile width: hamburger → Log Out closes the drawer and lands on `/login` in one transition.
- [ ] Web: browser back after logout stays on `/login` (replace).
- [ ] Web: Network tab shows `POST /auth/logout/` still fires (HttpOnly refresh cookie cleared).
- [ ] Mobile: Profile → overflow → Log out swaps the screen to the login/register form immediately.
- [ ] Mobile: temporarily make `clearStoredTokens` throw — user is still signed out from the UI's perspective. Revert the temp change.
- [ ] Mobile: re-login works after a forced-failure logout (no leftover state).