### PR TITLE
feat(timeActivity): fix time activity page ui errors

### DIFF
--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -12,8 +12,11 @@ import { useAuthStore } from '@/store/useAuthStore'
 import type { Transaction, TransactionSummary, User } from '@/types'
 import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 import {
+  completedGroupOfferParticipantCount,
   groupActiveAgreements,
   groupTransactionRows,
+  isTimeActivityParticipantStatus,
+  timeActivityVisibleParticipants,
   transactionGroupDetailParticipants,
   type GroupedTransactionRow,
   type TimeActivityAgreement as ExpectedAgreement,
@@ -332,7 +335,7 @@ function ParticipantAvatarStack({ participants, fallbackName }: {
   participants?: ExpectedAgreement[]
   fallbackName: string
 }) {
-  const visibleParticipants = (participants ?? []).slice(0, 2)
+  const visibleParticipants = timeActivityVisibleParticipants(participants)
 
   if (visibleParticipants.length === 0) {
     return (
@@ -616,7 +619,7 @@ const TransactionHistoryPage = () => {
     const map = new Map<string, ExpectedAgreement[]>()
     for (const handshake of handshakes) {
       if (!isMultiUseHandshake(handshake) || handshake.service_type !== 'Offer') continue
-      if (!['accepted', 'checked_in', 'attended', 'completed'].includes(handshake.status)) continue
+      if (!isTimeActivityParticipantStatus(handshake.status)) continue
 
       const agreement = toExpectedAgreement(handshake, user)
       if (!agreement?.service_id) continue
@@ -662,7 +665,10 @@ const TransactionHistoryPage = () => {
         const completedCount = transaction.service_id
           ? (completedMultiUseByService.get(transaction.service_id)?.length ?? 0)
           : 0
-        return Math.max(participants?.length ?? 0, completedCount)
+        return completedGroupOfferParticipantCount({
+          participantCount: participants?.length,
+          completedCount,
+        })
       },
       participants: (transaction) => {
         return transaction.service_id
@@ -1456,6 +1462,9 @@ const TransactionHistoryPage = () => {
                           : agreement.reserved_delta !== 0
                             ? 'reserved now'
                             : 'no time change'
+                        const participantAvatars = isGroupedAgreement
+                          ? timeActivityVisibleParticipants(agreement.participants)
+                          : []
 
                         return (
                           <Grid
@@ -1527,7 +1536,9 @@ const TransactionHistoryPage = () => {
                               }}
                               style={{ cursor: agreement.counterpart_id ? 'pointer' : 'default' }}
                             >
-                              {agreement.counterpart_avatar_url ? (
+                              {participantAvatars.length > 0 ? (
+                                <ParticipantAvatarStack participants={participantAvatars} fallbackName={agreement.counterpart_name} />
+                              ) : agreement.counterpart_avatar_url ? (
                                 <Avatar.Root size="xs">
                                   <Avatar.Image src={agreement.counterpart_avatar_url} alt={agreement.counterpart_name} />
                                   <Avatar.Fallback name={agreement.counterpart_name} />

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-icons/fi'
 import { transactionAPI, type TransactionDirection } from '@/services/transactionAPI'
 import { handshakeAPI, type Handshake } from '@/services/handshakeAPI'
+import { groupChatAPI, type GroupChatParticipant } from '@/services/conversationAPI'
 import { userAPI, type UserHistoryItem } from '@/services/userAPI'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { Transaction, TransactionSummary, User } from '@/types'
@@ -17,6 +18,7 @@ import {
   groupActiveAgreements,
   groupTransactionRows,
   isTimeActivityParticipantStatus,
+  timeActivityAvatarPreview,
   timeActivityVisibleParticipants,
   transactionGroupDetailParticipants,
   type GroupedTransactionRow,
@@ -240,6 +242,62 @@ function toExpectedAgreement(handshake: Handshake, currentUser?: User | null): E
   }
 }
 
+function eventGroupParticipantToAgreement(
+  participant: GroupChatParticipant,
+  sourceAgreement: ExpectedAgreement,
+  index: number,
+): ExpectedAgreement {
+  return {
+    ...sourceAgreement,
+    id: `event-participant:${sourceAgreement.service_id}:${participant.id}`,
+    counterpart_id: participant.id,
+    counterpart_name: participant.name || 'Unknown user',
+    counterpart_email: '',
+    counterpart_avatar_url: participant.avatar_url ?? null,
+    is_current_user_provider: index === 0,
+    provisioned_hours: 0,
+    reserved_delta: 0,
+    expected_delta: 0,
+    note: index === 0 ? 'Organizer' : 'Attendee',
+    participants: undefined,
+    is_grouped_multi_use: false,
+  }
+}
+
+async function enrichEventAgreementParticipants(
+  agreements: ExpectedAgreement[],
+  signal?: AbortSignal,
+): Promise<ExpectedAgreement[]> {
+  const eventServices = new Map<string, ExpectedAgreement>()
+  for (const agreement of agreements) {
+    if (agreement.service_type === 'Event' && agreement.service_id && !eventServices.has(agreement.service_id)) {
+      eventServices.set(agreement.service_id, agreement)
+    }
+  }
+  if (eventServices.size === 0) return agreements
+
+  const participantEntries = await Promise.all(
+    Array.from(eventServices.entries()).map(async ([serviceId, sourceAgreement]) => {
+      try {
+        const thread = await groupChatAPI.getMessages(serviceId, signal)
+        const participants = (thread.participants ?? []).map((participant, index) =>
+          eventGroupParticipantToAgreement(participant, sourceAgreement, index),
+        )
+        return [serviceId, participants] as const
+      } catch {
+        return [serviceId, [] as ExpectedAgreement[]] as const
+      }
+    }),
+  )
+
+  const participantsByServiceId = new Map(participantEntries)
+  return agreements.map((agreement) => {
+    if (agreement.service_type !== 'Event' || !agreement.service_id) return agreement
+    const participants = participantsByServiceId.get(agreement.service_id)
+    return participants?.length ? { ...agreement, participants } : agreement
+  })
+}
+
 function amountTone(value: number) {
   return value >= 0
     ? { color: GREEN, bg: GREEN_LT }
@@ -336,7 +394,7 @@ function ParticipantAvatarStack({ participants, fallbackName }: {
   participants?: ExpectedAgreement[]
   fallbackName: string
 }) {
-  const visibleParticipants = timeActivityVisibleParticipants(participants)
+  const { visibleParticipants, overflowCount } = timeActivityAvatarPreview(participants)
 
   if (visibleParticipants.length === 0) {
     return (
@@ -361,6 +419,25 @@ function ParticipantAvatarStack({ participants, fallbackName }: {
           <Avatar.Fallback name={participant.counterpart_name || fallbackName} />
         </Avatar.Root>
       ))}
+      {overflowCount > 0 && (
+        <Flex
+          align="center"
+          justify="center"
+          w="24px"
+          h="24px"
+          ml="-10px"
+          border={`2px solid ${WHITE}`}
+          borderRadius="full"
+          bg={GRAY800}
+          color={WHITE}
+          fontSize="9px"
+          fontWeight={900}
+          zIndex={0}
+          boxShadow="0 2px 6px rgba(15,23,42,0.12)"
+        >
+          +{overflowCount}
+        </Flex>
+      )}
     </Flex>
   )
 }
@@ -761,8 +838,10 @@ const TransactionHistoryPage = () => {
         .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
         .map((handshake) => toExpectedAgreement(handshake, user))
         .filter((item): item is ExpectedAgreement => item !== null)
+      const enrichedAgreements = await enrichEventAgreementParticipants(nextAgreements, signal)
+      if (requestId !== agreementRequestIdRef.current) return
 
-      setActiveAgreements(groupActiveAgreements(nextAgreements))
+      setActiveAgreements(groupActiveAgreements(enrichedAgreements))
     } catch (error) {
       const isAbort =
         signal?.aborted ||
@@ -1440,6 +1519,9 @@ const TransactionHistoryPage = () => {
                     (sum, agreement) => sum + (agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
                     0,
                   )
+                  const sectionSummary = section.type === 'Event'
+                    ? `${section.items.length} active`
+                    : `${section.items.length} active · ${formatAmount(sectionTotal)}`
 
                   return (
                     <Box key={section.type} borderTop={sectionIndex === 0 ? 'none' : `1px solid ${GRAY100}`}>
@@ -1463,7 +1545,7 @@ const TransactionHistoryPage = () => {
                         </Flex>
                         <Flex align="center" gap={2}>
                           <Text fontSize="11px" color={sectionTone.color} fontWeight={800}>
-                            {section.items.length} active · {formatAmount(sectionTotal)}
+                            {sectionSummary}
                           </Text>
                           <Text fontSize="13px" color={sectionTone.color} fontWeight={900}>
                             {sectionOpen ? '−' : '+'}
@@ -1478,6 +1560,7 @@ const TransactionHistoryPage = () => {
                         const ownListing = isOwnService(agreement.service_type, agreement.is_current_user_provider)
                         const isGroupedAgreement = agreement.is_grouped_multi_use === true
                         const displayDelta = agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta
+                        const showTimeValue = agreement.service_type !== 'Event' || displayDelta !== 0
                         const timeColor = displayDelta > 0 ? GREEN : displayDelta < 0 ? AMBER : GRAY700
                         const timeBg = displayDelta > 0 ? GREEN_LT : displayDelta < 0 ? AMBER_LT : GRAY100
                         const timeLabel = agreement.expected_delta !== 0
@@ -1554,10 +1637,15 @@ const TransactionHistoryPage = () => {
                               minW={0}
                               textAlign="left"
                               onClick={(event) => {
+                                if (isGroupedAgreement) {
+                                  event.stopPropagation()
+                                  setSelectedActiveAgreementGroup(agreement)
+                                  return
+                                }
                                 event.stopPropagation()
                                 openPublicProfile(agreement.counterpart_id)
                               }}
-                              style={{ cursor: agreement.counterpart_id ? 'pointer' : 'default' }}
+                              style={{ cursor: isGroupedAgreement || agreement.counterpart_id ? 'pointer' : 'default' }}
                             >
                               {participantAvatars.length > 0 ? (
                                 <ParticipantAvatarStack participants={participantAvatars} fallbackName={agreement.counterpart_name} />
@@ -1574,14 +1662,16 @@ const TransactionHistoryPage = () => {
                               </Text>
                             </Flex>
 
-                            <Flex align={{ base: 'center', md: 'flex-end' }} justify="space-between" direction={{ base: 'row', md: 'column' }} gap={1}>
-                              <Box px="10px" py="5px" borderRadius="999px" bg={timeBg} color={timeColor} fontSize="13px" fontWeight={900}>
-                                {displayDelta !== 0 ? formatAmount(displayDelta) : 'No hours'}
-                              </Box>
-                              <Text fontSize="11px" color={GRAY500}>
-                                {timeLabel}
-                              </Text>
-                            </Flex>
+                            {showTimeValue ? (
+                              <Flex align={{ base: 'center', md: 'flex-end' }} justify="space-between" direction={{ base: 'row', md: 'column' }} gap={1}>
+                                <Box px="10px" py="5px" borderRadius="999px" bg={timeBg} color={timeColor} fontSize="13px" fontWeight={900}>
+                                  {displayDelta !== 0 ? formatAmount(displayDelta) : 'No hours'}
+                                </Box>
+                                <Text fontSize="11px" color={GRAY500}>
+                                  {timeLabel}
+                                </Text>
+                              </Flex>
+                            ) : <Box />}
                           </Grid>
                         )
                       })}
@@ -1610,7 +1700,7 @@ const TransactionHistoryPage = () => {
               {eventHistory.slice(0, 5).map((event, index) => (
                 <Grid
                   key={`${event.service_id}-${event.completed_date}-${index}`}
-                  templateColumns={{ base: '1fr', md: 'minmax(260px, 1fr) 220px 140px' }}
+                  templateColumns={{ base: '1fr', md: 'minmax(260px, 1fr) 220px' }}
                   gap={{ base: 3, md: 4 }}
                   alignItems="center"
                   px={{ base: 4, md: 5 }}
@@ -1672,14 +1762,6 @@ const TransactionHistoryPage = () => {
                     </Text>
                   </Flex>
 
-                  <Box textAlign={{ base: 'left', md: 'right' }}>
-                    <Text fontSize="13px" fontWeight={800} color={GRAY800}>
-                      {formatHours(Number(event.duration))}
-                    </Text>
-                    <Text fontSize="11px" color={GRAY500}>
-                      {formatDate(event.completed_date)}
-                    </Text>
-                  </Box>
                 </Grid>
               ))}
             </Box>
@@ -2056,20 +2138,27 @@ const TransactionHistoryPage = () => {
         isOpen={!!selectedActiveAgreementGroup}
         title={selectedActiveAgreementGroup?.service_title ?? 'Group session'}
         subtitle={selectedActiveAgreementGroup
-          ? `${selectedActiveAgreementGroup.participant_count ?? 0} active participants in this group offer.`
+          ? selectedActiveAgreementGroup.service_type === 'Event'
+            ? `${selectedActiveAgreementGroup.participant_count ?? 0} organizers and attendees in this event.`
+            : `${selectedActiveAgreementGroup.participant_count ?? 0} active participants in this group offer.`
           : undefined}
         onClose={() => setSelectedActiveAgreementGroup(null)}
-        items={(selectedActiveAgreementGroup?.participants ?? []).map((agreement) => ({
-          id: agreement.id,
-          title: agreement.counterpart_name,
-          subtitle: activeHandshakeLabel(agreement.status),
-          meta: agreement.note,
-          value: formatAmount(agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
-          avatarUrl: agreement.counterpart_avatar_url ?? null,
-          onClick: agreement.counterpart_id
-            ? () => openPublicProfile(agreement.counterpart_id)
-            : undefined,
-        }))}
+        items={(selectedActiveAgreementGroup?.participants ?? []).map((agreement) => {
+          const isEventParticipant = selectedActiveAgreementGroup?.service_type === 'Event' || agreement.service_type === 'Event'
+          return {
+            id: agreement.id,
+            title: agreement.counterpart_name,
+            subtitle: isEventParticipant ? agreement.note : activeHandshakeLabel(agreement.status),
+            meta: isEventParticipant ? undefined : agreement.note,
+            value: isEventParticipant
+              ? undefined
+              : formatAmount(agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
+            avatarUrl: agreement.counterpart_avatar_url ?? null,
+            onClick: agreement.counterpart_id
+              ? () => openPublicProfile(agreement.counterpart_id)
+              : undefined,
+          }
+        })}
         emptyMessage="No participants to show yet."
       />
     </Box>

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -12,6 +12,13 @@ import { useAuthStore } from '@/store/useAuthStore'
 import type { Transaction, TransactionSummary, User } from '@/types'
 import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 import {
+  groupActiveAgreements,
+  groupTransactionRows,
+  transactionGroupDetailParticipants,
+  type GroupedTransactionRow,
+  type TimeActivityAgreement as ExpectedAgreement,
+} from '@/utils/timeActivityGrouping'
+import {
   AMBER, AMBER_LT, BLUE, BLUE_LT, GRAY100, GRAY200, GRAY400,
   GRAY50, GRAY500, GRAY600, GRAY700, GRAY800, GRAY900, GREEN, GREEN_LT,
   PURPLE, PURPLE_LT, RED, RED_LT, WHITE,
@@ -31,43 +38,11 @@ const FILTERS: { key: TransactionDirection; label: string }[] = [
   { key: 'debit', label: 'Used' },
 ]
 
-const ACTIVE_HANDSHAKE_STATUSES = new Set(['accepted', 'checked_in', 'attended'])
+const ACTIVE_HANDSHAKE_STATUSES = new Set<Handshake['status']>(['accepted', 'checked_in', 'attended'])
 const INSIGHT_SERVICE_TYPES = ['Offer', 'Need', 'Event'] as const
-
-interface ExpectedAgreement {
-  id: string
-  service_id?: string | null
-  service_title: string
-  service_type?: Handshake['service_type']
-  is_current_user_provider: boolean
-  counterpart_id?: string | null
-  counterpart_name: string
-  counterpart_email: string
-  counterpart_avatar_url?: string | null
-  status: Handshake['status']
-  provisioned_hours: number
-  reserved_delta: number
-  expected_delta: number
-  note: string
-}
 
 type EventHistoryItem = UserHistoryItem & {
   event_status: 'completed' | 'attended'
-}
-
-interface GroupedTransactionRow {
-  key: string
-  serviceId?: string | null
-  primary: Transaction
-  items: Transaction[]
-  amount: number
-  balanceAfter: number
-  createdAt: string
-  counterpartLabel: string
-  counterpartId?: string | null
-  counterpartAvatarUrl?: string | null
-  description: string
-  isMultiUse: boolean
 }
 
 function formatHours(value: number): string {
@@ -194,16 +169,6 @@ function isMultiUseHandshake(handshake: Handshake) {
   return handshake.schedule_type === 'One-Time' && (handshake.max_participants ?? 0) > 1
 }
 
-function isMultiUseTransaction(transaction: Transaction, completedCount: number) {
-  return (
-    transaction.transaction_type === 'transfer'
-    && transaction.is_current_user_provider === true
-    && transaction.schedule_type === 'One-Time'
-    && (transaction.max_participants ?? 0) > 1
-    && completedCount > 1
-  )
-}
-
 function handshakeCounterpartName(handshake: Handshake, currentUserName?: string): string {
   const counterpart = handshake.counterpart
   const fullName = counterpart
@@ -251,6 +216,9 @@ function toExpectedAgreement(handshake: Handshake, currentUser?: User | null): E
     service_id: handshake.service_id ?? null,
     service_title: handshake.service_title,
     service_type: handshake.service_type,
+    schedule_type: handshake.schedule_type,
+    max_participants: handshake.max_participants,
+    scheduled_time: handshake.scheduled_time,
     is_current_user_provider: isProvider,
     counterpart_id: handshake.counterpart?.id ?? null,
     counterpart_name: counterpartName,
@@ -360,6 +328,39 @@ function EmptyLedgerIllustration() {
   )
 }
 
+function ParticipantAvatarStack({ participants, fallbackName }: {
+  participants?: ExpectedAgreement[]
+  fallbackName: string
+}) {
+  const visibleParticipants = (participants ?? []).slice(0, 2)
+
+  if (visibleParticipants.length === 0) {
+    return (
+      <Box p="5px" borderRadius="full" bg={GRAY100} color={GRAY500}>
+        <FiUser size={12} />
+      </Box>
+    )
+  }
+
+  return (
+    <Flex align="center" minW="34px">
+      {visibleParticipants.map((participant, index) => (
+        <Avatar.Root
+          key={participant.id}
+          size="xs"
+          border={`2px solid ${WHITE}`}
+          ml={index === 0 ? 0 : '-10px'}
+          zIndex={visibleParticipants.length - index}
+          boxShadow="0 2px 6px rgba(15,23,42,0.12)"
+        >
+          <Avatar.Image src={participant.counterpart_avatar_url ?? undefined} alt={participant.counterpart_name} />
+          <Avatar.Fallback name={participant.counterpart_name || fallbackName} />
+        </Avatar.Root>
+      ))}
+    </Flex>
+  )
+}
+
 const TransactionHistoryPage = () => {
   const navigate = useNavigate()
   const user = useAuthStore((state) => state.user)
@@ -378,6 +379,7 @@ const TransactionHistoryPage = () => {
   const [isExporting, setIsExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedTransactionGroup, setSelectedTransactionGroup] = useState<GroupedTransactionRow | null>(null)
+  const [selectedActiveAgreementGroup, setSelectedActiveAgreementGroup] = useState<ExpectedAgreement | null>(null)
   const [showActiveAgreements, setShowActiveAgreements] = useState(false)
   const [openActiveAgreementSections, setOpenActiveAgreementSections] = useState<Record<string, boolean>>({})
 
@@ -610,6 +612,19 @@ const TransactionHistoryPage = () => {
     return map
   }, [activeAgreements])
 
+  const groupOfferParticipantsByServiceId = useMemo(() => {
+    const map = new Map<string, ExpectedAgreement[]>()
+    for (const handshake of handshakes) {
+      if (!isMultiUseHandshake(handshake) || handshake.service_type !== 'Offer') continue
+      if (!['accepted', 'checked_in', 'attended', 'completed'].includes(handshake.status)) continue
+
+      const agreement = toExpectedAgreement(handshake, user)
+      if (!agreement?.service_id) continue
+      map.set(agreement.service_id, [...(map.get(agreement.service_id) ?? []), agreement])
+    }
+    return map
+  }, [handshakes, user])
+
   const activeAgreementSections = useMemo(() => {
     return INSIGHT_SERVICE_TYPES
       .map((type) => ({
@@ -620,55 +635,42 @@ const TransactionHistoryPage = () => {
   }, [activeAgreements])
 
   const groupedTransactions = useMemo(() => {
-    const groups = new Map<string, GroupedTransactionRow>()
-
-    for (const transaction of transactions) {
+    return groupTransactionRows<Transaction>(transactions, {
+      counterpartLabel: (transaction) => {
       const matchingAgreement = transaction.service_id && isServiceLevelNeedTransaction(transaction)
         ? activeAgreementByServiceId.get(transaction.service_id)
         : undefined
-      const completedCount = transaction.service_id
-        ? (completedMultiUseByService.get(transaction.service_id)?.length ?? 0)
-        : 0
-      const shouldGroup = isMultiUseTransaction(transaction, completedCount)
-      const key = shouldGroup ? `${transaction.transaction_type}:${transaction.service_id}` : transaction.id
-      const existing = groups.get(key)
-
-      if (existing) {
-        existing.items.push(transaction)
-        existing.createdAt = new Date(transaction.created_at).getTime() > new Date(existing.createdAt).getTime()
-          ? transaction.created_at
-          : existing.createdAt
-        existing.balanceAfter = transaction.balance_after
-        existing.amount = Math.max(existing.amount, transaction.amount)
-        continue
-      }
-
-      const label = shouldGroup
-        ? `${completedCount} members`
-        : matchingAgreement?.counterpart_name ?? counterpartName(transaction, user?.id)
-
-      groups.set(key, {
-        key,
-        serviceId: transaction.service_id,
-        primary: transaction,
-        items: [transaction],
-        amount: transaction.amount,
-        balanceAfter: transaction.balance_after,
-        createdAt: transaction.created_at,
-        counterpartLabel: label,
-        counterpartId: matchingAgreement?.counterpart_id ?? transaction.counterpart?.id ?? null,
-        counterpartAvatarUrl: shouldGroup ? null : (matchingAgreement?.counterpart_avatar_url ?? transaction.counterpart?.avatar_url ?? null),
-        description: shouldGroup
-          ? `Settled once for ${completedCount} participants. Open details to view everyone in this session.`
-          : transactionFriendlyDescription(transaction),
-        isMultiUse: shouldGroup,
-      })
-    }
-
-    return Array.from(groups.values()).sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    )
-  }, [activeAgreementByServiceId, completedMultiUseByService, transactions, user?.id])
+        return matchingAgreement?.counterpart_name ?? counterpartName(transaction, user?.id)
+      },
+      counterpartId: (transaction) => {
+        const matchingAgreement = transaction.service_id && isServiceLevelNeedTransaction(transaction)
+          ? activeAgreementByServiceId.get(transaction.service_id)
+          : undefined
+        return matchingAgreement?.counterpart_id ?? transaction.counterpart?.id ?? null
+      },
+      counterpartAvatarUrl: (transaction) => {
+        const matchingAgreement = transaction.service_id && isServiceLevelNeedTransaction(transaction)
+          ? activeAgreementByServiceId.get(transaction.service_id)
+          : undefined
+        return matchingAgreement?.counterpart_avatar_url ?? transaction.counterpart?.avatar_url ?? null
+      },
+      description: transactionFriendlyDescription,
+      participantCount: (transaction) => {
+        const participants = transaction.service_id
+          ? groupOfferParticipantsByServiceId.get(transaction.service_id)
+          : undefined
+        const completedCount = transaction.service_id
+          ? (completedMultiUseByService.get(transaction.service_id)?.length ?? 0)
+          : 0
+        return Math.max(participants?.length ?? 0, completedCount)
+      },
+      participants: (transaction) => {
+        return transaction.service_id
+          ? groupOfferParticipantsByServiceId.get(transaction.service_id)
+          : undefined
+      },
+    })
+  }, [activeAgreementByServiceId, completedMultiUseByService, groupOfferParticipantsByServiceId, transactions, user?.id])
 
   const fetchTransactions = useCallback(async (signal?: AbortSignal) => {
     const requestId = ++requestIdRef.current
@@ -731,7 +733,7 @@ const TransactionHistoryPage = () => {
         .map((handshake) => toExpectedAgreement(handshake, user))
         .filter((item): item is ExpectedAgreement => item !== null)
 
-      setActiveAgreements(nextAgreements)
+      setActiveAgreements(groupActiveAgreements(nextAgreements))
     } catch (error) {
       const isAbort =
         signal?.aborted ||
@@ -1445,6 +1447,7 @@ const TransactionHistoryPage = () => {
                         const Icon = accent.icon
                         const typeTone = typeBadgeTone(agreement.service_type)
                         const ownListing = isOwnService(agreement.service_type, agreement.is_current_user_provider)
+                        const isGroupedAgreement = agreement.is_grouped_multi_use === true
                         const displayDelta = agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta
                         const timeColor = displayDelta > 0 ? GREEN : displayDelta < 0 ? AMBER : GRAY700
                         const timeBg = displayDelta > 0 ? GREEN_LT : displayDelta < 0 ? AMBER_LT : GRAY100
@@ -1463,6 +1466,10 @@ const TransactionHistoryPage = () => {
                             px={{ base: 4, md: 5 }}
                             py={3}
                             borderTop={index === 0 ? 'none' : `1px solid ${GRAY100}`}
+                            onClick={() => {
+                              if (isGroupedAgreement) setSelectedActiveAgreementGroup(agreement)
+                            }}
+                            style={{ cursor: isGroupedAgreement ? 'pointer' : 'default' }}
                           >
                             <Flex align="center" gap={3} minW={0}>
                               <Box p="9px" borderRadius="12px" bg={accent.bg} color={accent.color}>
@@ -1471,7 +1478,10 @@ const TransactionHistoryPage = () => {
                               <Box minW={0}>
                                 <Text
                                   as={agreement.service_id ? 'button' : undefined}
-                                  onClick={() => openServiceDetail(agreement.service_id)}
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    openServiceDetail(agreement.service_id)
+                                  }}
                                   fontSize="13px"
                                   fontWeight={800}
                                   color={agreement.service_id ? GREEN : GRAY800}
@@ -1496,6 +1506,11 @@ const TransactionHistoryPage = () => {
                                   <Box px="7px" py="2px" borderRadius="999px" bg={GRAY100} color={GRAY600} fontSize="10px" fontWeight={800}>
                                     {activeHandshakeLabel(agreement.status)}
                                   </Box>
+                                  {isGroupedAgreement && (
+                                    <Box px="7px" py="2px" borderRadius="999px" bg={GREEN_LT} color={GREEN} fontSize="10px" fontWeight={800}>
+                                      {agreement.participant_count} members
+                                    </Box>
+                                  )}
                                 </Flex>
                               </Box>
                             </Flex>
@@ -1506,7 +1521,10 @@ const TransactionHistoryPage = () => {
                               gap={2}
                               minW={0}
                               textAlign="left"
-                              onClick={() => openPublicProfile(agreement.counterpart_id)}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                openPublicProfile(agreement.counterpart_id)
+                              }}
                               style={{ cursor: agreement.counterpart_id ? 'pointer' : 'default' }}
                             >
                               {agreement.counterpart_avatar_url ? (
@@ -1726,6 +1744,7 @@ const TransactionHistoryPage = () => {
                 const isClickable = row.isMultiUse
                 const typeTone = typeBadgeTone(row.primary.service_type)
                 const ownListing = isOwnService(row.primary.service_type, row.primary.is_current_user_provider)
+                const participantAvatars = row.isMultiUse ? row.participants : undefined
 
                 return (
                   <Box
@@ -1790,7 +1809,9 @@ const TransactionHistoryPage = () => {
                             }}
                             style={{ cursor: row.counterpartId ? 'pointer' : 'default' }}
                           >
-                            {row.counterpartAvatarUrl ? (
+                            {participantAvatars?.length ? (
+                              <ParticipantAvatarStack participants={participantAvatars} fallbackName={name} />
+                            ) : row.counterpartAvatarUrl ? (
                               <Avatar.Root size="xs">
                                 <Avatar.Image src={row.counterpartAvatarUrl ?? undefined} alt={name} />
                                 <Avatar.Fallback name={name} />
@@ -1832,7 +1853,9 @@ const TransactionHistoryPage = () => {
                           }}
                           style={{ cursor: row.counterpartId ? 'pointer' : 'default' }}
                         >
-                          {row.counterpartAvatarUrl ? (
+                          {participantAvatars?.length ? (
+                            <ParticipantAvatarStack participants={participantAvatars} fallbackName={name} />
+                          ) : row.counterpartAvatarUrl ? (
                             <Avatar.Root size="xs">
                               <Avatar.Image src={row.counterpartAvatarUrl ?? undefined} alt={name} />
                               <Avatar.Fallback name={name} />
@@ -1852,7 +1875,7 @@ const TransactionHistoryPage = () => {
                               {name}
                             </Text>
                             <Text fontSize="11px" color={GRAY500}>
-                              {row.isMultiUse ? `${row.items.length} linked records` : counterpartSubtitle(row.primary, user?.id)}
+                              {row.isMultiUse ? `${row.participantCount} members` : counterpartSubtitle(row.primary, user?.id)}
                             </Text>
                           </Box>
                         </Flex>
@@ -1964,23 +1987,56 @@ const TransactionHistoryPage = () => {
         isOpen={!!selectedTransactionGroup}
         title={selectedTransactionGroup?.primary.service_title ?? 'Session details'}
         subtitle={selectedTransactionGroup
-          ? `${completedMultiUseByService.get(selectedTransactionGroup.serviceId ?? '')?.length ?? 0} participants completed this one-time session.`
+          ? `${selectedTransactionGroup.participantCount} participants completed this one-time session.`
           : undefined}
         onClose={() => setSelectedTransactionGroup(null)}
-        items={(
-          selectedTransactionGroup?.serviceId
+        items={transactionGroupDetailParticipants(
+          (selectedTransactionGroup?.serviceId
             ? (completedMultiUseByService.get(selectedTransactionGroup.serviceId) ?? [])
             : []
-        ).map((handshake) => ({
-          id: handshake.id,
-          title: handshake.counterpart
-            ? `${handshake.counterpart.first_name} ${handshake.counterpart.last_name}`.trim() || handshake.counterpart.email
-            : handshake.requester_name,
-          subtitle: 'Completed participant',
-          meta: formatDate(handshake.updated_at),
-          value: formatHours(handshake.provisioned_hours),
-          avatarUrl: handshake.counterpart?.avatar_url ?? null,
+          ).map((handshake) => ({
+            id: handshake.id,
+            title: handshake.counterpart
+              ? `${handshake.counterpart.first_name} ${handshake.counterpart.last_name}`.trim() || handshake.counterpart.email
+              : handshake.requester_name,
+            subtitle: 'Completed participant',
+            meta: formatDate(handshake.updated_at),
+            value: formatHours(handshake.provisioned_hours),
+            avatarUrl: handshake.counterpart?.avatar_url ?? null,
+          })),
+          (selectedTransactionGroup?.participants ?? []).map((agreement) => ({
+            id: agreement.id,
+            title: agreement.counterpart_name,
+            subtitle: activeHandshakeLabel(agreement.status),
+            meta: agreement.note,
+            value: formatAmount(agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
+            avatarUrl: agreement.counterpart_avatar_url ?? null,
+            onClick: agreement.counterpart_id
+              ? () => openPublicProfile(agreement.counterpart_id)
+              : undefined,
+          })),
+        )}
+      />
+
+      <MultiUseDetailsModal
+        isOpen={!!selectedActiveAgreementGroup}
+        title={selectedActiveAgreementGroup?.service_title ?? 'Group session'}
+        subtitle={selectedActiveAgreementGroup
+          ? `${selectedActiveAgreementGroup.participant_count ?? 0} active participants in this group offer.`
+          : undefined}
+        onClose={() => setSelectedActiveAgreementGroup(null)}
+        items={(selectedActiveAgreementGroup?.participants ?? []).map((agreement) => ({
+          id: agreement.id,
+          title: agreement.counterpart_name,
+          subtitle: activeHandshakeLabel(agreement.status),
+          meta: agreement.note,
+          value: formatAmount(agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
+          avatarUrl: agreement.counterpart_avatar_url ?? null,
+          onClick: agreement.counterpart_id
+            ? () => openPublicProfile(agreement.counterpart_id)
+            : undefined,
         }))}
+        emptyMessage="No participants to show yet."
       />
     </Box>
   )

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -13,6 +13,7 @@ import type { Transaction, TransactionSummary, User } from '@/types'
 import MultiUseDetailsModal from '@/components/MultiUseDetailsModal'
 import {
   completedGroupOfferParticipantCount,
+  completedGroupOfferParticipants,
   groupActiveAgreements,
   groupTransactionRows,
   isTimeActivityParticipantStatus,
@@ -628,6 +629,19 @@ const TransactionHistoryPage = () => {
     return map
   }, [handshakes, user])
 
+  const completedGroupOfferParticipantsByServiceId = useMemo(() => {
+    const map = new Map<string, ExpectedAgreement[]>()
+    for (const handshake of handshakes) {
+      if (!isMultiUseHandshake(handshake) || handshake.service_type !== 'Offer') continue
+      if (handshake.status !== 'completed') continue
+
+      const agreement = toExpectedAgreement(handshake, user)
+      if (!agreement?.service_id) continue
+      map.set(agreement.service_id, [...(map.get(agreement.service_id) ?? []), agreement])
+    }
+    return map
+  }, [handshakes, user])
+
   const activeAgreementSections = useMemo(() => {
     return INSIGHT_SERVICE_TYPES
       .map((type) => ({
@@ -671,12 +685,21 @@ const TransactionHistoryPage = () => {
         })
       },
       participants: (transaction) => {
-        return transaction.service_id
-          ? groupOfferParticipantsByServiceId.get(transaction.service_id)
-          : undefined
+        if (!transaction.service_id) return undefined
+        return completedGroupOfferParticipants({
+          participants: groupOfferParticipantsByServiceId.get(transaction.service_id),
+          completedParticipants: completedGroupOfferParticipantsByServiceId.get(transaction.service_id),
+        })
       },
     })
-  }, [activeAgreementByServiceId, completedMultiUseByService, groupOfferParticipantsByServiceId, transactions, user?.id])
+  }, [
+    activeAgreementByServiceId,
+    completedGroupOfferParticipantsByServiceId,
+    completedMultiUseByService,
+    groupOfferParticipantsByServiceId,
+    transactions,
+    user?.id,
+  ])
 
   const fetchTransactions = useCallback(async (signal?: AbortSignal) => {
     const requestId = ++requestIdRef.current

--- a/frontend/src/test/utils/timeActivityGrouping.test.ts
+++ b/frontend/src/test/utils/timeActivityGrouping.test.ts
@@ -3,6 +3,7 @@ import {
   groupActiveAgreements,
   groupTransactionRows,
   completedGroupOfferParticipantCount,
+  completedGroupOfferParticipants,
   isTimeActivityParticipantStatus,
   timeActivityVisibleParticipants,
   transactionGroupDetailParticipants,
@@ -138,6 +139,19 @@ describe('timeActivityGrouping', () => {
   it('uses completed participant count over active session count for completed group transfer rows', () => {
     expect(completedGroupOfferParticipantCount({ participantCount: 5, completedCount: 3 })).toBe(3)
     expect(completedGroupOfferParticipantCount({ participantCount: 2, completedCount: 0 })).toBe(2)
+  })
+
+  it('uses completed participant avatars over active session avatars for completed group transfer rows', () => {
+    const participants = [
+      { ...baseAgreement, id: 'accepted-1', counterpart_name: 'Accepted One', status: 'accepted' as const },
+      { ...baseAgreement, id: 'accepted-2', counterpart_name: 'Accepted Two', status: 'accepted' as const },
+      { ...baseAgreement, id: 'completed-1', counterpart_name: 'Completed One', status: 'completed' as const },
+    ]
+    const completedParticipants = participants.filter((item) => item.status === 'completed')
+
+    expect(completedGroupOfferParticipants({ participants, completedParticipants }).map((item) => item.id)).toEqual([
+      'completed-1',
+    ])
   })
 
   it('excludes inactive handshake statuses from group offer participant displays', () => {

--- a/frontend/src/test/utils/timeActivityGrouping.test.ts
+++ b/frontend/src/test/utils/timeActivityGrouping.test.ts
@@ -5,6 +5,7 @@ import {
   completedGroupOfferParticipantCount,
   completedGroupOfferParticipants,
   isTimeActivityParticipantStatus,
+  timeActivityAvatarPreview,
   timeActivityVisibleParticipants,
   transactionGroupDetailParticipants,
   type TimeActivityAgreement,
@@ -58,6 +59,74 @@ describe('timeActivityGrouping', () => {
     expect(grouped[0].participants.map((item) => item.counterpart_name)).toEqual([
       'Can Sahin',
       'Zeynep Arslan',
+    ])
+  })
+
+  it('groups active event agreements by event service', () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...baseAgreement,
+        id: 'event-hs-1',
+        service_id: 'event-1',
+        service_title: 'Community Mending and Repair Cafe',
+        service_type: 'Event',
+        schedule_type: 'One-Time',
+        max_participants: 10,
+        expected_delta: 0,
+        counterpart_name: 'Zeynep Arslan',
+      },
+      {
+        ...baseAgreement,
+        id: 'event-hs-2',
+        service_id: 'event-1',
+        service_title: 'Community Mending and Repair Cafe',
+        service_type: 'Event',
+        schedule_type: 'One-Time',
+        max_participants: 10,
+        expected_delta: 0,
+        counterpart_name: 'Selin Aksoy',
+      },
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      service_id: 'event-1',
+      counterpart_name: '2 members',
+      participant_count: 2,
+      is_grouped_multi_use: true,
+    })
+    expect(grouped[0].participants.map((item) => item.counterpart_name)).toEqual([
+      'Zeynep Arslan',
+      'Selin Aksoy',
+    ])
+  })
+
+  it('treats a single event agreement with loaded participants as grouped', () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...baseAgreement,
+        id: 'event-hs-1',
+        service_id: 'event-1',
+        service_title: 'Community Mending and Repair Cafe',
+        service_type: 'Event',
+        expected_delta: 0,
+        counterpart_name: 'Current Attendee',
+        participants: [
+          { ...baseAgreement, id: 'organizer', service_type: 'Event', counterpart_name: 'Organizer User', is_current_user_provider: true },
+          { ...baseAgreement, id: 'attendee', service_type: 'Event', counterpart_name: 'Current Attendee', is_current_user_provider: false },
+        ],
+      },
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      counterpart_name: '2 members',
+      participant_count: 2,
+      is_grouped_multi_use: true,
+    })
+    expect(grouped[0].participants.map((item) => item.counterpart_name)).toEqual([
+      'Organizer User',
+      'Current Attendee',
     ])
   })
 
@@ -172,6 +241,25 @@ describe('timeActivityGrouping', () => {
       'hs-1',
       'hs-2',
       'hs-3',
+    ])
+  })
+
+  it('previews the first five avatars and reports overflow', () => {
+    const participants = Array.from({ length: 7 }, (_, index) => ({
+      ...baseAgreement,
+      id: `hs-${index + 1}`,
+      counterpart_name: `Member ${index + 1}`,
+    }))
+
+    expect(timeActivityAvatarPreview(participants)).toMatchObject({
+      overflowCount: 2,
+    })
+    expect(timeActivityAvatarPreview(participants).visibleParticipants.map((item) => item.id)).toEqual([
+      'hs-1',
+      'hs-2',
+      'hs-3',
+      'hs-4',
+      'hs-5',
     ])
   })
 })

--- a/frontend/src/test/utils/timeActivityGrouping.test.ts
+++ b/frontend/src/test/utils/timeActivityGrouping.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  groupActiveAgreements,
+  groupTransactionRows,
+  transactionGroupDetailParticipants,
+  type TimeActivityAgreement,
+  type TimeActivityTransaction,
+} from '@/utils/timeActivityGrouping'
+
+const baseAgreement = {
+  service_id: 'service-1',
+  service_title: 'Neighborhood Manti Cooking Circle',
+  service_type: 'Offer',
+  schedule_type: 'One-Time',
+  max_participants: 3,
+  is_current_user_provider: true,
+  status: 'accepted',
+  provisioned_hours: 3,
+  reserved_delta: 0,
+  expected_delta: 3,
+  note: 'Time expected after completion',
+} satisfies Omit<TimeActivityAgreement, 'id' | 'counterpart_name'>
+
+const baseTransaction = {
+  transaction_type: 'transfer',
+  service_id: 'service-1',
+  service_title: 'Neighborhood Manti Cooking Circle',
+  service_type: 'Offer',
+  schedule_type: 'One-Time',
+  max_participants: 3,
+  is_current_user_provider: true,
+  amount: 3,
+  balance_after: 10,
+  created_at: '2026-05-09T10:00:00Z',
+  description: 'Completed exchange',
+} satisfies Omit<TimeActivityTransaction, 'id'>
+
+describe('timeActivityGrouping', () => {
+  it('groups active one-time group offer agreements by service session', () => {
+    const grouped = groupActiveAgreements([
+      { ...baseAgreement, id: 'hs-1', counterpart_name: 'Can Sahin' },
+      { ...baseAgreement, id: 'hs-2', counterpart_name: 'Zeynep Arslan' },
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      service_id: 'service-1',
+      counterpart_name: '2 members',
+      participant_count: 2,
+      expected_delta: 3,
+      reserved_delta: 0,
+      is_grouped_multi_use: true,
+    })
+    expect(grouped[0].participants.map((item) => item.counterpart_name)).toEqual([
+      'Can Sahin',
+      'Zeynep Arslan',
+    ])
+  })
+
+  it('keeps one-to-one active agreements as individual rows', () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...baseAgreement,
+        id: 'hs-1',
+        service_id: 'solo-service',
+        max_participants: 1,
+        counterpart_name: 'Can Sahin',
+      },
+      {
+        ...baseAgreement,
+        id: 'hs-2',
+        service_id: 'another-service',
+        max_participants: 1,
+        counterpart_name: 'Zeynep Arslan',
+      },
+    ])
+
+    expect(grouped).toHaveLength(2)
+    expect(grouped.every((item) => item.participant_count === 1)).toBe(true)
+  })
+
+  it('groups completed one-time group offer transfer rows without summing duplicate provider credit', () => {
+    const grouped = groupTransactionRows([
+      { ...baseTransaction, id: 'tx-1' },
+      { ...baseTransaction, id: 'tx-2', created_at: '2026-05-09T11:00:00Z' },
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      serviceId: 'service-1',
+      amount: 3,
+      participantCount: 2,
+      isMultiUse: true,
+    })
+    expect(grouped[0].items).toHaveLength(2)
+  })
+
+  it('marks a single visible group offer transfer as a grouped activity row when participant count is known', () => {
+    const grouped = groupTransactionRows(
+      [{ ...baseTransaction, id: 'tx-1' }],
+      {
+        participantCount: () => 2,
+        participants: () => [
+          { ...baseAgreement, id: 'hs-1', counterpart_name: 'Can Sahin', counterpart_avatar_url: 'can.jpg' },
+          { ...baseAgreement, id: 'hs-2', counterpart_name: 'Zeynep Arslan', counterpart_avatar_url: 'zeynep.jpg' },
+        ],
+      },
+    )
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      counterpartLabel: '2 members',
+      participantCount: 2,
+      isMultiUse: true,
+    })
+    expect(grouped[0].participants?.map((item) => item.counterpart_avatar_url)).toEqual([
+      'can.jpg',
+      'zeynep.jpg',
+    ])
+  })
+
+  it('does not duplicate active fallback participants when completed details exist', () => {
+    const completedParticipants = [
+      { id: 'completed-1', title: 'Can Sahin' },
+      { id: 'completed-2', title: 'Zeynep Arslan' },
+    ]
+    const activeFallback = [
+      { id: 'active-1', title: 'Can Sahin' },
+      { id: 'active-2', title: 'Zeynep Arslan' },
+    ]
+
+    expect(transactionGroupDetailParticipants(completedParticipants, activeFallback)).toEqual(completedParticipants)
+  })
+})

--- a/frontend/src/test/utils/timeActivityGrouping.test.ts
+++ b/frontend/src/test/utils/timeActivityGrouping.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   groupActiveAgreements,
   groupTransactionRows,
+  completedGroupOfferParticipantCount,
+  isTimeActivityParticipantStatus,
+  timeActivityVisibleParticipants,
   transactionGroupDetailParticipants,
   type TimeActivityAgreement,
   type TimeActivityTransaction,
@@ -130,5 +133,31 @@ describe('timeActivityGrouping', () => {
     ]
 
     expect(transactionGroupDetailParticipants(completedParticipants, activeFallback)).toEqual(completedParticipants)
+  })
+
+  it('uses completed participant count over active session count for completed group transfer rows', () => {
+    expect(completedGroupOfferParticipantCount({ participantCount: 5, completedCount: 3 })).toBe(3)
+    expect(completedGroupOfferParticipantCount({ participantCount: 2, completedCount: 0 })).toBe(2)
+  })
+
+  it('excludes inactive handshake statuses from group offer participant displays', () => {
+    expect(isTimeActivityParticipantStatus('accepted')).toBe(true)
+    expect(isTimeActivityParticipantStatus('completed')).toBe(true)
+    expect(isTimeActivityParticipantStatus('declined')).toBe(false)
+    expect(isTimeActivityParticipantStatus('cancelled')).toBe(false)
+  })
+
+  it('keeps all participant avatars visible instead of capping at two', () => {
+    const participants = [
+      { ...baseAgreement, id: 'hs-1', counterpart_name: 'Can Sahin' },
+      { ...baseAgreement, id: 'hs-2', counterpart_name: 'Zeynep Arslan' },
+      { ...baseAgreement, id: 'hs-3', counterpart_name: 'Ayse Kaya' },
+    ]
+
+    expect(timeActivityVisibleParticipants(participants).map((item) => item.id)).toEqual([
+      'hs-1',
+      'hs-2',
+      'hs-3',
+    ])
   })
 })

--- a/frontend/src/utils/timeActivityGrouping.ts
+++ b/frontend/src/utils/timeActivityGrouping.ts
@@ -1,0 +1,221 @@
+import type { Handshake } from '@/services/handshakeAPI'
+import type { Transaction } from '@/types'
+
+export interface TimeActivityAgreement {
+  id: string
+  service_id?: string | null
+  service_title: string
+  service_type?: Handshake['service_type']
+  schedule_type?: Handshake['schedule_type'] | null
+  max_participants?: number | null
+  scheduled_time?: string | null
+  is_current_user_provider: boolean
+  counterpart_id?: string | null
+  counterpart_name: string
+  counterpart_email?: string
+  counterpart_avatar_url?: string | null
+  status: Handshake['status']
+  provisioned_hours?: number
+  reserved_delta: number
+  expected_delta: number
+  note: string
+  participant_count?: number
+  participants?: TimeActivityAgreement[]
+  is_grouped_multi_use?: boolean
+}
+
+export interface TimeActivityTransaction {
+  id: string
+  service_id?: string | null
+  transaction_type: Transaction['transaction_type'] | string
+  service_type?: Transaction['service_type']
+  schedule_type?: Transaction['schedule_type']
+  max_participants?: number | null
+  is_current_user_provider?: boolean
+  amount: number
+  balance_after: number
+  created_at: string
+  service_title?: string | null
+  counterpart?: Transaction['counterpart']
+  description?: string
+}
+
+export interface GroupedTransactionRow<T extends TimeActivityTransaction = TimeActivityTransaction> {
+  key: string
+  serviceId?: string | null
+  primary: T
+  items: T[]
+  amount: number
+  balanceAfter: number
+  createdAt: string
+  counterpartLabel: string
+  counterpartId?: string | null
+  counterpartAvatarUrl?: string | null
+  description: string
+  isMultiUse: boolean
+  participantCount: number
+  participants?: TimeActivityAgreement[]
+}
+
+function isOneTimeGroupOffer(item: {
+  service_id?: string | null
+  service_type?: string | null
+  schedule_type?: string | null
+  max_participants?: number | null
+}) {
+  return (
+    item.service_type === 'Offer'
+    && item.schedule_type === 'One-Time'
+    && (item.max_participants ?? 0) > 1
+    && Boolean(item.service_id)
+  )
+}
+
+function sessionKey(item: { service_id?: string | null; scheduled_time?: string | null }) {
+  return `${item.service_id ?? 'unknown'}:${item.scheduled_time ?? 'fixed-session'}`
+}
+
+function representativeDelta(values: number[]) {
+  const nonZero = values.filter((value) => value !== 0)
+  if (nonZero.length === 0) return 0
+  const positives = nonZero.filter((value) => value > 0)
+  if (positives.length > 0) return Math.max(...positives)
+  return Math.min(...nonZero)
+}
+
+export function groupActiveAgreements<T extends TimeActivityAgreement>(agreements: T[]): TimeActivityAgreement[] {
+  const groups = new Map<string, T[]>()
+  const output: T[] = []
+
+  for (const agreement of agreements) {
+    if (!isOneTimeGroupOffer(agreement)) {
+      output.push({
+        ...agreement,
+        participant_count: agreement.participant_count ?? 1,
+        participants: agreement.participants ?? [agreement],
+        is_grouped_multi_use: false,
+      })
+      continue
+    }
+
+    const key = sessionKey(agreement)
+    groups.set(key, [...(groups.get(key) ?? []), agreement])
+  }
+
+  for (const [key, participants] of groups.entries()) {
+    if (participants.length === 1) {
+      const [single] = participants
+      output.push({
+        ...single,
+        participant_count: 1,
+        participants: [single],
+        is_grouped_multi_use: false,
+      })
+      continue
+    }
+
+    const [primary] = participants
+    output.push({
+      ...primary,
+      id: `group:${key}`,
+      counterpart_id: null,
+      counterpart_name: `${participants.length} members`,
+      counterpart_email: '',
+      counterpart_avatar_url: null,
+      expected_delta: representativeDelta(participants.map((item) => item.expected_delta)),
+      reserved_delta: representativeDelta(participants.map((item) => item.reserved_delta)),
+      note: `${participants.length} members in this group session`,
+      participant_count: participants.length,
+      participants,
+      is_grouped_multi_use: true,
+    })
+  }
+
+  return output
+}
+
+function isGroupOfferTransfer(transaction: TimeActivityTransaction) {
+  return (
+    isOneTimeGroupOffer(transaction)
+    && transaction.transaction_type === 'transfer'
+    && transaction.is_current_user_provider === true
+  )
+}
+
+export function groupTransactionRows<T extends TimeActivityTransaction>(
+  transactions: T[],
+  options: {
+    counterpartLabel?: (transaction: T) => string
+    counterpartId?: (transaction: T) => string | null | undefined
+    counterpartAvatarUrl?: (transaction: T) => string | null | undefined
+    description?: (transaction: T) => string
+    participantCount?: (transaction: T) => number | null | undefined
+    participants?: (transaction: T) => TimeActivityAgreement[] | null | undefined
+  } = {},
+): GroupedTransactionRow<T>[] {
+  const groups = new Map<string, GroupedTransactionRow<T>>()
+
+  for (const transaction of transactions) {
+    const shouldGroup = isGroupOfferTransfer(transaction)
+    const key = shouldGroup ? `group-offer-transfer:${sessionKey(transaction)}` : transaction.id
+    const existing = groups.get(key)
+
+    if (existing) {
+      existing.items.push(transaction)
+      const knownParticipantCount = options.participantCount?.(transaction)
+      const knownParticipants = options.participants?.(transaction) ?? undefined
+      existing.createdAt = new Date(transaction.created_at).getTime() > new Date(existing.createdAt).getTime()
+        ? transaction.created_at
+        : existing.createdAt
+      existing.balanceAfter = transaction.balance_after
+      existing.amount = representativeDelta(existing.items.map((item) => item.amount))
+      existing.participantCount = Math.max(existing.items.length, knownParticipantCount ?? 0)
+      existing.participants = knownParticipants ?? existing.participants
+      existing.counterpartLabel = `${existing.participantCount} members`
+      existing.counterpartId = null
+      existing.counterpartAvatarUrl = null
+      existing.description = `Settled once for ${existing.participantCount} participants. Open details to view everyone in this session.`
+      existing.isMultiUse = true
+      continue
+    }
+
+    const knownParticipantCount = shouldGroup ? Math.max(1, options.participantCount?.(transaction) ?? 1) : 1
+    const knownParticipants = shouldGroup ? options.participants?.(transaction) ?? undefined : undefined
+
+    groups.set(key, {
+      key,
+      serviceId: transaction.service_id,
+      primary: transaction,
+      items: [transaction],
+      amount: transaction.amount,
+      balanceAfter: transaction.balance_after,
+      createdAt: transaction.created_at,
+      counterpartLabel: shouldGroup && knownParticipantCount > 1
+        ? `${knownParticipantCount} members`
+        : options.counterpartLabel?.(transaction) ?? 'Time activity',
+      counterpartId: shouldGroup && knownParticipantCount > 1
+        ? null
+        : options.counterpartId?.(transaction) ?? transaction.counterpart?.id ?? null,
+      counterpartAvatarUrl: shouldGroup && knownParticipantCount > 1
+        ? null
+        : options.counterpartAvatarUrl?.(transaction) ?? transaction.counterpart?.avatar_url ?? null,
+      description: shouldGroup && knownParticipantCount > 1
+        ? `Settled once for ${knownParticipantCount} participants. Open details to view everyone in this session.`
+        : options.description?.(transaction) ?? transaction.description ?? '',
+      isMultiUse: shouldGroup && knownParticipantCount > 1,
+      participantCount: knownParticipantCount,
+      participants: knownParticipants,
+    })
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+}
+
+export function transactionGroupDetailParticipants<TCompleted, TFallback>(
+  completedParticipants: TCompleted[],
+  fallbackParticipants: TFallback[],
+): Array<TCompleted | TFallback> {
+  return completedParticipants.length > 0 ? completedParticipants : fallbackParticipants
+}

--- a/frontend/src/utils/timeActivityGrouping.ts
+++ b/frontend/src/utils/timeActivityGrouping.ts
@@ -99,6 +99,18 @@ export function completedGroupOfferParticipantCount({
   return completedCount && completedCount > 0 ? completedCount : participantCount ?? null
 }
 
+export function completedGroupOfferParticipants<T>({
+  participants,
+  completedParticipants,
+}: {
+  participants?: T[] | null
+  completedParticipants?: T[] | null
+}) {
+  return completedParticipants && completedParticipants.length > 0
+    ? completedParticipants
+    : participants
+}
+
 export function timeActivityVisibleParticipants<T>(participants?: T[] | null): T[] {
   return participants ?? []
 }

--- a/frontend/src/utils/timeActivityGrouping.ts
+++ b/frontend/src/utils/timeActivityGrouping.ts
@@ -78,9 +78,29 @@ function sessionKey(item: { service_id?: string | null; scheduled_time?: string 
 function representativeDelta(values: number[]) {
   const nonZero = values.filter((value) => value !== 0)
   if (nonZero.length === 0) return 0
+  // Group-offer rows represent one shared session, so we keep one representative
+  // participant delta instead of summing duplicate provider-side transfer rows.
   const positives = nonZero.filter((value) => value > 0)
   if (positives.length > 0) return Math.max(...positives)
   return Math.min(...nonZero)
+}
+
+export function isTimeActivityParticipantStatus(status?: string | null) {
+  return status === 'accepted' || status === 'checked_in' || status === 'attended' || status === 'completed'
+}
+
+export function completedGroupOfferParticipantCount({
+  participantCount,
+  completedCount,
+}: {
+  participantCount?: number | null
+  completedCount?: number | null
+}) {
+  return completedCount && completedCount > 0 ? completedCount : participantCount ?? null
+}
+
+export function timeActivityVisibleParticipants<T>(participants?: T[] | null): T[] {
+  return participants ?? []
 }
 
 export function groupActiveAgreements<T extends TimeActivityAgreement>(agreements: T[]): TimeActivityAgreement[] {

--- a/frontend/src/utils/timeActivityGrouping.ts
+++ b/frontend/src/utils/timeActivityGrouping.ts
@@ -71,6 +71,15 @@ function isOneTimeGroupOffer(item: {
   )
 }
 
+function isGroupableActiveSession(item: {
+  service_id?: string | null
+  service_type?: string | null
+  schedule_type?: string | null
+  max_participants?: number | null
+}) {
+  return isOneTimeGroupOffer(item) || (item.service_type === 'Event' && Boolean(item.service_id))
+}
+
 function sessionKey(item: { service_id?: string | null; scheduled_time?: string | null }) {
   return `${item.service_id ?? 'unknown'}:${item.scheduled_time ?? 'fixed-session'}`
 }
@@ -115,12 +124,21 @@ export function timeActivityVisibleParticipants<T>(participants?: T[] | null): T
   return participants ?? []
 }
 
+export function timeActivityAvatarPreview<T>(participants?: T[] | null, maxVisible = 5) {
+  const allParticipants = timeActivityVisibleParticipants(participants)
+  const visibleParticipants = allParticipants.slice(0, maxVisible)
+  return {
+    visibleParticipants,
+    overflowCount: Math.max(0, allParticipants.length - visibleParticipants.length),
+  }
+}
+
 export function groupActiveAgreements<T extends TimeActivityAgreement>(agreements: T[]): TimeActivityAgreement[] {
   const groups = new Map<string, T[]>()
   const output: T[] = []
 
   for (const agreement of agreements) {
-    if (!isOneTimeGroupOffer(agreement)) {
+    if (!isGroupableActiveSession(agreement)) {
       output.push({
         ...agreement,
         participant_count: agreement.participant_count ?? 1,
@@ -137,6 +155,25 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
   for (const [key, participants] of groups.entries()) {
     if (participants.length === 1) {
       const [single] = participants
+      const loadedParticipants = single.participants?.length ? single.participants : [single]
+      if (single.service_type === 'Event' && loadedParticipants.length > 1) {
+        output.push({
+          ...single,
+          id: `group:${key}`,
+          counterpart_id: null,
+          counterpart_name: `${loadedParticipants.length} members`,
+          counterpart_email: '',
+          counterpart_avatar_url: null,
+          expected_delta: representativeDelta(loadedParticipants.map((item) => item.expected_delta)),
+          reserved_delta: representativeDelta(loadedParticipants.map((item) => item.reserved_delta)),
+          note: `${loadedParticipants.length} members in this event`,
+          participant_count: loadedParticipants.length,
+          participants: loadedParticipants,
+          is_grouped_multi_use: true,
+        })
+        continue
+      }
+
       output.push({
         ...single,
         participant_count: 1,

--- a/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
+++ b/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
@@ -5,6 +5,7 @@ import {
   groupActiveAgreements,
   groupTransactionRows,
   isTimeActivityParticipantStatus,
+  timeActivityAvatarPreview,
   timeActivityAvatarStackWidth,
   timeActivityVisibleParticipants,
   type TimeActivityAgreement,
@@ -51,6 +52,79 @@ describe("timeActivityGrouping", () => {
     expect((grouped[0].participants ?? []).map((item) => item.counterpart_name)).toEqual([
       "Can Sahin",
       "Zeynep Arslan",
+    ]);
+  });
+
+  it("groups active event agreements into one visible row", () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...groupOfferAgreement,
+        id: "event-hs-1",
+        service_id: "event-1",
+        service_title: "Community Mending and Repair Cafe",
+        service_type: "Event",
+        expected_delta: 0,
+        counterpart_name: "Zeynep Arslan",
+      },
+      {
+        ...groupOfferAgreement,
+        id: "event-hs-2",
+        service_id: "event-1",
+        service_title: "Community Mending and Repair Cafe",
+        service_type: "Event",
+        expected_delta: 0,
+        counterpart_name: "Selin Aksoy",
+      },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].counterpart_name).toBe("2 members");
+    expect(grouped[0].participant_count).toBe(2);
+    expect(grouped[0].is_grouped_multi_use).toBe(true);
+    expect((grouped[0].participants ?? []).map((item) => item.counterpart_name)).toEqual([
+      "Zeynep Arslan",
+      "Selin Aksoy",
+    ]);
+  });
+
+  it("treats a single event agreement with loaded participants as grouped", () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...groupOfferAgreement,
+        id: "event-hs-1",
+        service_id: "event-1",
+        service_title: "Community Mending and Repair Cafe",
+        service_type: "Event",
+        expected_delta: 0,
+        counterpart_name: "Current Attendee",
+        participants: [
+          {
+            ...groupOfferAgreement,
+            id: "organizer",
+            service_type: "Event",
+            counterpart_name: "Organizer User",
+            is_current_user_provider: true,
+          },
+          {
+            ...groupOfferAgreement,
+            id: "attendee",
+            service_type: "Event",
+            counterpart_name: "Current Attendee",
+            is_current_user_provider: false,
+          },
+        ],
+      },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]).toMatchObject({
+      counterpart_name: "2 members",
+      participant_count: 2,
+      is_grouped_multi_use: true,
+    });
+    expect((grouped[0].participants ?? []).map((item) => item.counterpart_name)).toEqual([
+      "Organizer User",
+      "Current Attendee",
     ]);
   });
 
@@ -147,5 +221,22 @@ describe("timeActivityGrouping", () => {
   it("sizes stacked avatars for every visible participant", () => {
     expect(timeActivityAvatarStackWidth(1)).toBe(22);
     expect(timeActivityAvatarStackWidth(3)).toBe(46);
+  });
+
+  it("previews the first five avatars and reports overflow", () => {
+    const participants = Array.from({ length: 7 }, (_, index) => ({
+      ...groupOfferAgreement,
+      id: `hs-${index + 1}`,
+      counterpart_name: `Member ${index + 1}`,
+    }));
+
+    expect(timeActivityAvatarPreview(participants).overflowCount).toBe(2);
+    expect(timeActivityAvatarPreview(participants).visibleParticipants.map((item) => item.id)).toEqual([
+      "hs-1",
+      "hs-2",
+      "hs-3",
+      "hs-4",
+      "hs-5",
+    ]);
   });
 });

--- a/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
+++ b/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
@@ -1,0 +1,116 @@
+import {
+  activeAgreementParticipantLabel,
+  completedTransactionParticipantLabel,
+  groupActiveAgreements,
+  groupTransactionRows,
+  type TimeActivityAgreement,
+  type TimeActivityTransaction,
+} from "../../utils/timeActivityGrouping";
+
+const groupOfferAgreement = {
+  service_id: "service-1",
+  service_title: "Neighborhood Manti Cooking Circle",
+  service_type: "Offer",
+  schedule_type: "One-Time",
+  max_participants: 3,
+  is_current_user_provider: true,
+  status: "accepted",
+  reserved_delta: 0,
+  expected_delta: 3,
+  note: "Time expected after completion",
+} satisfies Omit<TimeActivityAgreement, "id" | "counterpart_name">;
+
+const groupOfferTransaction = {
+  transaction_type: "transfer",
+  service_id: "service-1",
+  service_title: "Neighborhood Manti Cooking Circle",
+  service_type: "Offer",
+  schedule_type: "One-Time",
+  max_participants: 3,
+  is_current_user_provider: true,
+  amount: 3,
+  balance_after: 10,
+  created_at: "2026-05-09T10:00:00Z",
+} satisfies Omit<TimeActivityTransaction, "id">;
+
+describe("timeActivityGrouping", () => {
+  it("groups active one-time group offer agreements into one visible row", () => {
+    const grouped = groupActiveAgreements([
+      { ...groupOfferAgreement, id: "hs-1", counterpart_name: "Can Sahin" },
+      { ...groupOfferAgreement, id: "hs-2", counterpart_name: "Zeynep Arslan" },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].counterpart_name).toBe("2 members");
+    expect(grouped[0].participant_count).toBe(2);
+    expect(grouped[0].expected_delta).toBe(3);
+    expect((grouped[0].participants ?? []).map((item) => item.counterpart_name)).toEqual([
+      "Can Sahin",
+      "Zeynep Arslan",
+    ]);
+  });
+
+  it("keeps one-to-one active agreements separate", () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...groupOfferAgreement,
+        id: "hs-1",
+        service_id: "solo-1",
+        max_participants: 1,
+        counterpart_name: "Can Sahin",
+      },
+      {
+        ...groupOfferAgreement,
+        id: "hs-2",
+        service_id: "solo-2",
+        max_participants: 1,
+        counterpart_name: "Zeynep Arslan",
+      },
+    ]);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped.every((item) => item.participant_count === 1)).toBe(true);
+  });
+
+  it("groups completed one-time group offer transfers without double-counting hours", () => {
+    const grouped = groupTransactionRows([
+      { ...groupOfferTransaction, id: "tx-1" },
+      { ...groupOfferTransaction, id: "tx-2", created_at: "2026-05-09T11:00:00Z" },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].participantCount).toBe(2);
+    expect(grouped[0].amount).toBe(3);
+    expect(grouped[0].items).toHaveLength(2);
+  });
+
+  it("marks a single visible group offer transfer as grouped when participant count is known", () => {
+    const grouped = groupTransactionRows(
+      [{ ...groupOfferTransaction, id: "tx-1" }],
+      {
+        participantCount: () => 2,
+        participants: () => [
+          { ...groupOfferAgreement, id: "hs-1", counterpart_name: "Can Sahin", counterpart_avatar_url: "can.jpg" },
+          { ...groupOfferAgreement, id: "hs-2", counterpart_name: "Zeynep Arslan", counterpart_avatar_url: "zeynep.jpg" },
+        ],
+      },
+    );
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].counterpartLabel).toBe("2 members");
+    expect(grouped[0].participantCount).toBe(2);
+    expect(grouped[0].isMultiUse).toBe(true);
+    expect(grouped[0].participants?.map((item) => item.counterpart_avatar_url)).toEqual([
+      "can.jpg",
+      "zeynep.jpg",
+    ]);
+  });
+
+  it("labels grouped completed transaction participants as completed participants", () => {
+    expect(completedTransactionParticipantLabel()).toBe("Completed participant");
+  });
+
+  it("labels active agreement participants as session confirmed", () => {
+    expect(activeAgreementParticipantLabel("accepted")).toBe("Session confirmed");
+  });
+});

--- a/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
+++ b/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
@@ -1,8 +1,12 @@
 import {
   activeAgreementParticipantLabel,
+  completedGroupOfferParticipantCount,
   completedTransactionParticipantLabel,
   groupActiveAgreements,
   groupTransactionRows,
+  isTimeActivityParticipantStatus,
+  timeActivityAvatarStackWidth,
+  timeActivityVisibleParticipants,
   type TimeActivityAgreement,
   type TimeActivityTransaction,
 } from "../../utils/timeActivityGrouping";
@@ -112,5 +116,36 @@ describe("timeActivityGrouping", () => {
 
   it("labels active agreement participants as session confirmed", () => {
     expect(activeAgreementParticipantLabel("accepted")).toBe("Session confirmed");
+  });
+
+  it("uses completed participant count over active session count for completed group transfer rows", () => {
+    expect(completedGroupOfferParticipantCount({ participantCount: 5, completedCount: 3 })).toBe(3);
+    expect(completedGroupOfferParticipantCount({ participantCount: 2, completedCount: 0 })).toBe(2);
+  });
+
+  it("excludes inactive handshake statuses from group offer participant displays", () => {
+    expect(isTimeActivityParticipantStatus("accepted")).toBe(true);
+    expect(isTimeActivityParticipantStatus("completed")).toBe(true);
+    expect(isTimeActivityParticipantStatus("declined")).toBe(false);
+    expect(isTimeActivityParticipantStatus("cancelled")).toBe(false);
+  });
+
+  it("keeps all participant avatars visible instead of capping at two", () => {
+    const participants = [
+      { ...groupOfferAgreement, id: "hs-1", counterpart_name: "Can Sahin" },
+      { ...groupOfferAgreement, id: "hs-2", counterpart_name: "Zeynep Arslan" },
+      { ...groupOfferAgreement, id: "hs-3", counterpart_name: "Ayse Kaya" },
+    ];
+
+    expect(timeActivityVisibleParticipants(participants).map((item) => item.id)).toEqual([
+      "hs-1",
+      "hs-2",
+      "hs-3",
+    ]);
+  });
+
+  it("sizes stacked avatars for every visible participant", () => {
+    expect(timeActivityAvatarStackWidth(1)).toBe(22);
+    expect(timeActivityAvatarStackWidth(3)).toBe(46);
   });
 });

--- a/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
+++ b/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  Modal,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -27,6 +28,14 @@ import { listHandshakes, type Handshake } from "../../api/handshakes";
 import { getUserHistory } from "../../api/users";
 import type { UserHistoryItem } from "../../api/types";
 import type { ProfileStackParamList } from "../../navigation/ProfileStack";
+import {
+  activeAgreementParticipantLabel,
+  completedTransactionParticipantLabel,
+  groupActiveAgreements,
+  groupTransactionRows,
+  type GroupedTransactionRow,
+  type TimeActivityAgreement as ExpectedAgreement,
+} from "../../utils/timeActivityGrouping";
 
 const PAGE_SIZE = 20;
 const ACTIVE_HANDSHAKE_STATUSES = new Set(["accepted", "checked_in", "attended"]);
@@ -37,21 +46,6 @@ const FILTERS: Array<{ key: TransactionDirection; label: string }> = [
   { key: "debit", label: "Used" },
 ];
 const SERVICE_TYPE_ORDER = ["Offer", "Need", "Event"] as const;
-
-type ExpectedAgreement = {
-  id: string;
-  service_id?: string | null;
-  service_title: string;
-  service_type?: Handshake["service_type"];
-  is_current_user_provider: boolean;
-  counterpart_id?: string | null;
-  counterpart_name: string;
-  counterpart_avatar_url?: string | null;
-  status: Handshake["status"];
-  reserved_delta: number;
-  expected_delta: number;
-  note: string;
-};
 
 type EventHistoryItem = UserHistoryItem & {
   event_status: "completed" | "attended";
@@ -216,9 +210,7 @@ function handshakeCounterpartName(handshake: Handshake, currentUserName?: string
 }
 
 function activeHandshakeLabel(status: Handshake["status"]): string {
-  if (status === "checked_in") return "Checked in";
-  if (status === "attended") return "Attended";
-  return "Session confirmed";
+  return activeAgreementParticipantLabel(status);
 }
 
 function toExpectedAgreement(
@@ -243,6 +235,10 @@ function toExpectedAgreement(
     service_id: handshake.service_id ?? null,
     service_title: String(handshake.service_title ?? "Untitled service"),
     service_type: handshake.service_type,
+    schedule_type: handshake.schedule_type,
+    max_participants: handshake.max_participants,
+    scheduled_time:
+      typeof handshake.scheduled_time === "string" ? handshake.scheduled_time : null,
     is_current_user_provider: isProvider,
     counterpart_id: handshake.counterpart?.id ?? null,
     counterpart_name: handshakeCounterpartName(handshake, currentUserName),
@@ -359,6 +355,7 @@ export default function TimeActivityScreen() {
   const [eventHistory, setEventHistory] = useState<EventHistoryItem[]>([]);
   const [summary, setSummary] = useState<TransactionSummary>(EMPTY_SUMMARY);
   const [activeAgreements, setActiveAgreements] = useState<ExpectedAgreement[]>([]);
+  const [agreementParticipants, setAgreementParticipants] = useState<ExpectedAgreement[]>([]);
   const [direction, setDirection] = useState<TransactionDirection>("all");
   const [page, setPage] = useState(1);
   const [count, setCount] = useState(0);
@@ -368,6 +365,9 @@ export default function TimeActivityScreen() {
   const [isAgreementsOpen, setIsAgreementsOpen] = useState(false);
   const [isEventActivityOpen, setIsEventActivityOpen] = useState(false);
   const [openAgreementSections, setOpenAgreementSections] = useState<Record<string, boolean>>({});
+  const [selectedAgreementGroup, setSelectedAgreementGroup] = useState<ExpectedAgreement | null>(null);
+  const [selectedTransactionGroup, setSelectedTransactionGroup] =
+    useState<GroupedTransactionRow<Transaction> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const totalPages = useMemo(
@@ -397,6 +397,15 @@ export default function TimeActivityScreen() {
     }
     return map;
   }, [activeAgreements]);
+  const agreementParticipantsByServiceId = useMemo(() => {
+    const map = new Map<string, ExpectedAgreement[]>();
+    for (const agreement of agreementParticipants) {
+      if (!agreement.service_id || agreement.service_type !== "Offer") continue;
+      if (agreement.schedule_type !== "One-Time" || (agreement.max_participants ?? 0) <= 1) continue;
+      map.set(agreement.service_id, [...(map.get(agreement.service_id) ?? []), agreement]);
+    }
+    return map;
+  }, [agreementParticipants]);
   const activeAgreementSections = useMemo(
     () =>
       SERVICE_TYPE_ORDER.map((type) => ({
@@ -404,6 +413,45 @@ export default function TimeActivityScreen() {
         items: activeAgreements.filter((agreement) => agreement.service_type === type),
       })).filter((section) => section.items.length > 0),
     [activeAgreements],
+  );
+  const groupedTransactions = useMemo(
+    () =>
+      groupTransactionRows<Transaction>(transactions, {
+        counterpartLabel: (transaction) => {
+          const matchingAgreement =
+            transaction.service_id && isServiceLevelNeedTransaction(transaction)
+              ? activeAgreementByServiceId.get(transaction.service_id)
+              : undefined;
+          return matchingAgreement?.counterpart_name ?? transactionCounterpartName(transaction, user?.id);
+        },
+        counterpartId: (transaction) => {
+          const matchingAgreement =
+            transaction.service_id && isServiceLevelNeedTransaction(transaction)
+              ? activeAgreementByServiceId.get(transaction.service_id)
+              : undefined;
+          return matchingAgreement?.counterpart_id ?? transaction.counterpart?.id ?? null;
+        },
+        counterpartAvatarUrl: (transaction) => {
+          const matchingAgreement =
+            transaction.service_id && isServiceLevelNeedTransaction(transaction)
+              ? activeAgreementByServiceId.get(transaction.service_id)
+              : undefined;
+          return matchingAgreement?.counterpart_avatar_url ?? transaction.counterpart?.avatar_url ?? null;
+        },
+        description: transactionFriendlyDescription,
+        participantCount: (transaction) => {
+          const participants = transaction.service_id
+            ? agreementParticipantsByServiceId.get(transaction.service_id)
+            : undefined;
+          return participants?.length ?? null;
+        },
+        participants: (transaction) => {
+          return transaction.service_id
+            ? agreementParticipantsByServiceId.get(transaction.service_id)
+            : undefined;
+        },
+      }),
+    [activeAgreementByServiceId, agreementParticipantsByServiceId, transactions, user?.id],
   );
   const insightStats = useMemo(() => {
     const now = new Date();
@@ -552,13 +600,16 @@ export default function TimeActivityScreen() {
   const loadAgreements = useCallback(async () => {
     try {
       const res = await listHandshakes({ page: 1, page_size: 100 });
-      const nextAgreements = (res.results ?? [])
-        .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
+      const allAgreements = (res.results ?? [])
         .map((handshake) => toExpectedAgreement(handshake, currentUserName, user?.id))
         .filter((item): item is ExpectedAgreement => item !== null);
+      const nextAgreements = allAgreements
+        .filter((agreement) => ACTIVE_HANDSHAKE_STATUSES.has(agreement.status as Handshake["status"]));
 
-      setActiveAgreements(nextAgreements);
+      setAgreementParticipants(allAgreements);
+      setActiveAgreements(groupActiveAgreements(nextAgreements));
     } catch {
+      setAgreementParticipants([]);
       setActiveAgreements([]);
     }
   }, [currentUserName, user?.id]);
@@ -727,14 +778,15 @@ export default function TimeActivityScreen() {
   }, []);
 
   return (
+    <>
     <FlatList
       style={styles.container}
       contentContainerStyle={{
         paddingTop: 16,
         paddingBottom: Math.max(24, insets.bottom + 12),
       }}
-      data={transactions}
-      keyExtractor={(item) => item.id}
+      data={groupedTransactions}
+      keyExtractor={(item) => item.key}
       refreshControl={
         <RefreshControl
           refreshing={isRefreshing}
@@ -1168,6 +1220,7 @@ export default function TimeActivityScreen() {
 
                         {sectionOpen ? section.items.map((agreement, index) => {
                           const accent = roleAccent(agreement.is_current_user_provider);
+                          const isGroupedAgreement = agreement.is_grouped_multi_use === true;
                           const displayDelta =
                             agreement.expected_delta !== 0
                               ? agreement.expected_delta
@@ -1186,11 +1239,15 @@ export default function TimeActivityScreen() {
                                 : "No time change";
 
                           return (
-                            <View
+                            <Pressable
                               key={agreement.id}
+                              onPress={() => {
+                                if (isGroupedAgreement) setSelectedAgreementGroup(agreement);
+                              }}
                               style={[
                                 styles.agreementRow,
                                 index > 0 && styles.agreementRowBorder,
+                                isGroupedAgreement && styles.pressableRow,
                               ]}
                             >
                               <View style={styles.agreementLeft}>
@@ -1271,7 +1328,7 @@ export default function TimeActivityScreen() {
                                 </Text>
                                 <Text style={styles.agreementNote}>{valueNote}</Text>
                               </View>
-                            </View>
+                            </Pressable>
                           );
                         }) : null}
                       </View>
@@ -1428,48 +1485,64 @@ export default function TimeActivityScreen() {
         </>
       }
       renderItem={({ item }) => {
-        const accent = transactionAccent(item);
-        const matchingAgreement =
-          item.service_id && isServiceLevelNeedTransaction(item)
-            ? activeAgreementByServiceId.get(item.service_id)
-            : undefined;
-        const counterpart =
-          matchingAgreement?.counterpart_name ?? transactionCounterpartName(item, user?.id);
-        const counterpartId = matchingAgreement?.counterpart_id ?? item.counterpart?.id ?? null;
-        const counterpartAvatarUrl =
-          matchingAgreement?.counterpart_avatar_url ?? item.counterpart?.avatar_url ?? null;
+        const transaction = item.primary;
+        const accent = transactionAccent(transaction);
+        const counterpart = item.counterpartLabel;
+        const counterpartId = item.counterpartId ?? null;
+        const counterpartAvatarUrl = item.counterpartAvatarUrl ?? null;
         const counterpartInitial = counterpart.trim().charAt(0).toUpperCase() || "?";
-        const isRefund = item.transaction_type === "refund";
+        const participantAvatars = item.isMultiUse
+          ? (item.participants ?? []).slice(0, 2)
+          : [];
+        const isRefund = transaction.transaction_type === "refund";
         const isPositive = item.amount >= 0;
         const amountColor = isRefund ? colors.PURPLE : isPositive ? colors.GREEN : colors.AMBER;
         const amountBg = isRefund ? colors.PURPLE_LT : isPositive ? colors.GREEN_LT : colors.AMBER_LT;
         return (
-          <View style={styles.transactionCard}>
+          <Pressable
+            onPress={() => {
+              if (item.isMultiUse) setSelectedTransactionGroup(item);
+            }}
+            style={({ pressed }) => [
+              styles.transactionCard,
+              item.isMultiUse && styles.pressableRow,
+              pressed && item.isMultiUse && styles.pressed,
+            ]}
+          >
             <View style={styles.transactionTopRow}>
               <View style={styles.transactionTopLeft}>
                 <View style={[styles.iconBadge, { backgroundColor: accent.bg }]}>
                   <Ionicons name={accent.icon} size={18} color={accent.color} />
                 </View>
                 <Pressable
-                  onPress={() => openServiceDetail(item.service_id)}
-                  disabled={!item.service_id}
+                  onPress={() => openServiceDetail(transaction.service_id)}
+                  disabled={!transaction.service_id}
                   style={({ pressed }) => [
                     styles.transactionHeadText,
                     pressed && styles.pressed,
                   ]}
                 >
                   <Text style={styles.transactionAction} numberOfLines={1}>
-                    {transactionActionTitle(item)}
+                    {transactionActionTitle(transaction)}
                   </Text>
                   <Text
                     style={[
                       styles.transactionService,
-                      item.service_id && styles.linkText,
+                      transaction.service_id && styles.linkText,
                     ]}
                     numberOfLines={1}
                   >
-                    {transactionDisplayTitle(item)}
+                    {transactionDisplayTitle(transaction)}
                   </Text>
+                  {item.isMultiUse ? (
+                    <View style={styles.compactBadgeRow}>
+                      <View style={styles.neutralPill}>
+                        <Text style={styles.neutralPillText}>
+                          {item.participantCount} members
+                        </Text>
+                      </View>
+                    </View>
+                  ) : null}
                 </Pressable>
               </View>
               <View style={[styles.amountPill, { backgroundColor: amountBg }]}>
@@ -1488,7 +1561,34 @@ export default function TimeActivityScreen() {
                   pressed && styles.pressed,
                 ]}
               >
-                {counterpartAvatarUrl ? (
+                {participantAvatars.length > 0 ? (
+                  <View style={styles.avatarStack}>
+                    {participantAvatars.map((participant, avatarIndex) => {
+                      const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
+                      return participant.counterpart_avatar_url ? (
+                        <Image
+                          key={participant.id}
+                          source={{ uri: participant.counterpart_avatar_url }}
+                          style={[
+                            styles.stackedAvatar,
+                            avatarIndex > 0 && styles.stackedAvatarOverlap,
+                          ]}
+                        />
+                      ) : (
+                        <View
+                          key={participant.id}
+                          style={[
+                            styles.stackedAvatar,
+                            styles.whoAvatarFallback,
+                            avatarIndex > 0 && styles.stackedAvatarOverlap,
+                          ]}
+                        >
+                          <Text style={styles.whoAvatarInitial}>{initial}</Text>
+                        </View>
+                      );
+                    })}
+                  </View>
+                ) : counterpartAvatarUrl ? (
                   <Image
                     source={{ uri: counterpartAvatarUrl }}
                     style={styles.whoAvatar}
@@ -1502,10 +1602,10 @@ export default function TimeActivityScreen() {
                   {counterpart}
                 </Text>
               </Pressable>
-              <Text style={styles.transactionDate}>{formatDate(item.created_at)}</Text>
+              <Text style={styles.transactionDate}>{formatDate(item.createdAt)}</Text>
             </View>
 
-          </View>
+          </Pressable>
         );
       }}
       ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
@@ -1519,7 +1619,7 @@ export default function TimeActivityScreen() {
         )
       }
       ListFooterComponent={
-        transactions.length > 0 ? (
+        groupedTransactions.length > 0 ? (
           <View style={styles.footerWrap}>
             {isLoadingMore ? (
               <ActivityIndicator size="small" color={colors.GREEN} />
@@ -1539,6 +1639,173 @@ export default function TimeActivityScreen() {
       }
       ListFooterComponentStyle={{ paddingTop: 16 }}
     />
+
+    <Modal
+      visible={Boolean(selectedAgreementGroup)}
+      transparent
+      animationType="slide"
+      onRequestClose={() => setSelectedAgreementGroup(null)}
+    >
+      <Pressable
+        style={styles.modalBackdrop}
+        onPress={() => setSelectedAgreementGroup(null)}
+      />
+      <View style={styles.participantSheet}>
+        <View style={styles.participantSheetHandle} />
+        <View style={styles.participantSheetHeader}>
+          <View style={styles.participantSheetTitleWrap}>
+            <Text style={styles.participantSheetTitle}>
+              {selectedAgreementGroup?.service_title ?? "Group session"}
+            </Text>
+            <Text style={styles.participantSheetSubtitle}>
+              {(selectedAgreementGroup?.participant_count ?? 0)} active member
+              {(selectedAgreementGroup?.participant_count ?? 0) === 1 ? "" : "s"}
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => setSelectedAgreementGroup(null)}
+            style={({ pressed }) => [
+              styles.participantSheetClose,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Ionicons name="close" size={18} color={colors.GRAY700} />
+          </Pressable>
+        </View>
+
+        <ScrollView style={styles.participantList} contentContainerStyle={styles.participantListContent}>
+          {(selectedAgreementGroup?.participants ?? []).map((participant) => {
+            const delta = participant.expected_delta !== 0
+              ? participant.expected_delta
+              : participant.reserved_delta;
+            const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
+
+            return (
+              <Pressable
+                key={participant.id}
+                onPress={() => {
+                  if (!participant.counterpart_id) return;
+                  setSelectedAgreementGroup(null);
+                  openPublicProfile(participant.counterpart_id);
+                }}
+                disabled={!participant.counterpart_id || participant.counterpart_id === user?.id}
+                style={({ pressed }) => [
+                  styles.participantRow,
+                  pressed && styles.pressed,
+                ]}
+              >
+                {participant.counterpart_avatar_url ? (
+                  <Image
+                    source={{ uri: participant.counterpart_avatar_url }}
+                    style={styles.participantAvatar}
+                  />
+                ) : (
+                  <View style={[styles.participantAvatar, styles.whoAvatarFallback]}>
+                    <Text style={styles.whoAvatarInitial}>{initial}</Text>
+                  </View>
+                )}
+                <View style={styles.participantInfo}>
+                  <Text style={styles.participantName} numberOfLines={1}>
+                    {participant.counterpart_name}
+                  </Text>
+                  <Text style={styles.participantMeta} numberOfLines={1}>
+                    {activeHandshakeLabel(participant.status)}
+                  </Text>
+                </View>
+                <Text style={styles.participantValue}>
+                  {delta !== 0 ? formatAmount(delta) : "0h"}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+
+    <Modal
+      visible={Boolean(selectedTransactionGroup)}
+      transparent
+      animationType="slide"
+      onRequestClose={() => setSelectedTransactionGroup(null)}
+    >
+      <Pressable
+        style={styles.modalBackdrop}
+        onPress={() => setSelectedTransactionGroup(null)}
+      />
+      <View style={styles.participantSheet}>
+        <View style={styles.participantSheetHandle} />
+        <View style={styles.participantSheetHeader}>
+          <View style={styles.participantSheetTitleWrap}>
+            <Text style={styles.participantSheetTitle}>
+              {selectedTransactionGroup?.primary.service_title ?? "Group activity"}
+            </Text>
+            <Text style={styles.participantSheetSubtitle}>
+              {(selectedTransactionGroup?.participantCount ?? 0)} member
+              {(selectedTransactionGroup?.participantCount ?? 0) === 1 ? "" : "s"}
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => setSelectedTransactionGroup(null)}
+            style={({ pressed }) => [
+              styles.participantSheetClose,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Ionicons name="close" size={18} color={colors.GRAY700} />
+          </Pressable>
+        </View>
+
+        <ScrollView style={styles.participantList} contentContainerStyle={styles.participantListContent}>
+          {(
+            selectedTransactionGroup?.participants ?? []
+          ).map((participant) => {
+            const delta = participant.expected_delta !== 0
+              ? participant.expected_delta
+              : participant.reserved_delta;
+            const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
+
+            return (
+              <Pressable
+                key={participant.id}
+                onPress={() => {
+                  if (!participant.counterpart_id) return;
+                  setSelectedTransactionGroup(null);
+                  openPublicProfile(participant.counterpart_id);
+                }}
+                disabled={!participant.counterpart_id || participant.counterpart_id === user?.id}
+                style={({ pressed }) => [
+                  styles.participantRow,
+                  pressed && styles.pressed,
+                ]}
+              >
+                {participant.counterpart_avatar_url ? (
+                  <Image
+                    source={{ uri: participant.counterpart_avatar_url }}
+                    style={styles.participantAvatar}
+                  />
+                ) : (
+                  <View style={[styles.participantAvatar, styles.whoAvatarFallback]}>
+                    <Text style={styles.whoAvatarInitial}>{initial}</Text>
+                  </View>
+                )}
+                <View style={styles.participantInfo}>
+                  <Text style={styles.participantName} numberOfLines={1}>
+                    {participant.counterpart_name}
+                  </Text>
+                  <Text style={styles.participantMeta} numberOfLines={1}>
+                    {completedTransactionParticipantLabel()}
+                  </Text>
+                </View>
+                <Text style={styles.participantValue}>
+                  {delta !== 0 ? formatAmount(delta) : "0h"}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+    </>
   );
 }
 
@@ -2093,6 +2360,9 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: colors.GRAY100,
   },
+  pressableRow: {
+    borderRadius: 14,
+  },
   agreementLeft: {
     flex: 1,
     flexDirection: "row",
@@ -2288,6 +2558,22 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: colors.GRAY600,
   },
+  avatarStack: {
+    flexDirection: "row",
+    alignItems: "center",
+    width: 34,
+  },
+  stackedAvatar: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: colors.WHITE,
+    backgroundColor: colors.GRAY100,
+  },
+  stackedAvatarOverlap: {
+    marginLeft: -10,
+  },
   whoName: {
     fontSize: 13,
     fontWeight: "600",
@@ -2408,6 +2694,103 @@ const styles = StyleSheet.create({
     paddingVertical: 48,
     alignItems: "center",
     justifyContent: "center",
+  },
+  modalBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(15, 23, 42, 0.36)",
+  },
+  participantSheet: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    maxHeight: "72%",
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    backgroundColor: colors.WHITE,
+    paddingTop: 10,
+    paddingHorizontal: 18,
+    paddingBottom: 18,
+    shadowColor: "#000",
+    shadowOpacity: 0.16,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: -6 },
+    elevation: 12,
+  },
+  participantSheetHandle: {
+    alignSelf: "center",
+    width: 44,
+    height: 4,
+    borderRadius: 999,
+    backgroundColor: colors.GRAY200,
+    marginBottom: 14,
+  },
+  participantSheetHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    marginBottom: 8,
+  },
+  participantSheetTitleWrap: {
+    flex: 1,
+  },
+  participantSheetTitle: {
+    fontSize: 17,
+    fontWeight: "800",
+    color: colors.GRAY900,
+  },
+  participantSheetSubtitle: {
+    marginTop: 3,
+    fontSize: 13,
+    color: colors.GRAY500,
+  },
+  participantSheetClose: {
+    width: 34,
+    height: 34,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.GRAY100,
+  },
+  participantList: {
+    maxHeight: 360,
+  },
+  participantListContent: {
+    paddingBottom: 8,
+  },
+  participantRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.GRAY100,
+  },
+  participantAvatar: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: colors.GRAY100,
+  },
+  participantInfo: {
+    flex: 1,
+    minWidth: 0,
+  },
+  participantName: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.GRAY800,
+  },
+  participantMeta: {
+    marginTop: 2,
+    fontSize: 12,
+    color: colors.GRAY500,
+  },
+  participantValue: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: colors.GREEN,
   },
   pressed: {
     opacity: 0.85,

--- a/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
+++ b/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
@@ -25,6 +25,7 @@ import {
   type TransactionSummary,
 } from "../../api/transactions";
 import { listHandshakes, type Handshake } from "../../api/handshakes";
+import { getGroupChat, type GroupChatParticipant } from "../../api/chats";
 import { getUserHistory } from "../../api/users";
 import type { UserHistoryItem } from "../../api/types";
 import type { ProfileStackParamList } from "../../navigation/ProfileStack";
@@ -35,6 +36,7 @@ import {
   groupActiveAgreements,
   groupTransactionRows,
   isTimeActivityParticipantStatus,
+  timeActivityAvatarPreview,
   timeActivityAvatarStackWidth,
   timeActivityVisibleParticipants,
   type GroupedTransactionRow,
@@ -256,6 +258,59 @@ function toExpectedAgreement(
       ? "Time expected after completion"
       : "Already reserved at acceptance",
   };
+}
+
+function eventGroupParticipantToAgreement(
+  participant: GroupChatParticipant,
+  sourceAgreement: ExpectedAgreement,
+  index: number,
+): ExpectedAgreement {
+  return {
+    ...sourceAgreement,
+    id: `event-participant:${sourceAgreement.service_id}:${participant.id}`,
+    counterpart_id: participant.id,
+    counterpart_name: participant.name || "Unknown user",
+    counterpart_avatar_url: participant.avatar_url ?? null,
+    is_current_user_provider: index === 0,
+    reserved_delta: 0,
+    expected_delta: 0,
+    note: index === 0 ? "Organizer" : "Attendee",
+    participants: undefined,
+    is_grouped_multi_use: false,
+  };
+}
+
+async function enrichEventAgreementParticipants(
+  agreements: ExpectedAgreement[],
+): Promise<ExpectedAgreement[]> {
+  const eventServices = new Map<string, ExpectedAgreement>();
+  for (const agreement of agreements) {
+    if (agreement.service_type === "Event" && agreement.service_id && !eventServices.has(agreement.service_id)) {
+      eventServices.set(agreement.service_id, agreement);
+    }
+  }
+  if (eventServices.size === 0) return agreements;
+
+  const participantEntries = await Promise.all(
+    Array.from(eventServices.entries()).map(async ([serviceId, sourceAgreement]) => {
+      try {
+        const thread = await getGroupChat(serviceId);
+        const participants = (thread.participants ?? []).map((participant, index) =>
+          eventGroupParticipantToAgreement(participant, sourceAgreement, index),
+        );
+        return [serviceId, participants] as const;
+      } catch {
+        return [serviceId, [] as ExpectedAgreement[]] as const;
+      }
+    }),
+  );
+
+  const participantsByServiceId = new Map(participantEntries);
+  return agreements.map((agreement) => {
+    if (agreement.service_type !== "Event" || !agreement.service_id) return agreement;
+    const participants = participantsByServiceId.get(agreement.service_id);
+    return participants?.length ? { ...agreement, participants } : agreement;
+  });
 }
 
 function typeTone(type: "Offer" | "Need" | "Event") {
@@ -634,9 +689,10 @@ export default function TimeActivityScreen() {
         .filter((item): item is ExpectedAgreement => item !== null);
       const nextAgreements = allAgreements
         .filter((agreement) => ACTIVE_HANDSHAKE_STATUSES.has(agreement.status as Handshake["status"]));
+      const enrichedAgreements = await enrichEventAgreementParticipants(nextAgreements);
 
       setAgreementParticipants(allAgreements);
-      setActiveAgreements(groupActiveAgreements(nextAgreements));
+      setActiveAgreements(groupActiveAgreements(enrichedAgreements));
     } catch {
       setAgreementParticipants([]);
       setActiveAgreements([]);
@@ -1203,6 +1259,9 @@ export default function TimeActivityScreen() {
                           : agreement.reserved_delta),
                       0,
                     );
+                    const sectionSummary = section.type === "Event"
+                      ? `${section.items.length} active`
+                      : `${section.items.length} active · ${formatAmount(sectionTotal)}`;
 
                     return (
                       <View key={section.type}>
@@ -1237,7 +1296,7 @@ export default function TimeActivityScreen() {
                                 { color: sectionTone.color },
                               ]}
                             >
-                              {section.items.length} active · {formatAmount(sectionTotal)}
+                              {sectionSummary}
                             </Text>
                             <Ionicons
                               name={sectionOpen ? "chevron-up" : "chevron-down"}
@@ -1254,6 +1313,7 @@ export default function TimeActivityScreen() {
                             agreement.expected_delta !== 0
                               ? agreement.expected_delta
                               : agreement.reserved_delta;
+                          const showTimeValue = agreement.service_type !== "Event" || displayDelta !== 0;
                           const valueColor =
                             displayDelta > 0
                               ? colors.GREEN
@@ -1269,6 +1329,7 @@ export default function TimeActivityScreen() {
                           const agreementParticipants = isGroupedAgreement
                             ? timeActivityVisibleParticipants(agreement.participants)
                             : [];
+                          const agreementAvatarPreview = timeActivityAvatarPreview(agreementParticipants);
 
                           return (
                             <Pressable
@@ -1316,10 +1377,14 @@ export default function TimeActivityScreen() {
                                         <View
                                           style={[
                                             styles.avatarStack,
-                                            { width: timeActivityAvatarStackWidth(agreementParticipants.length) },
+                                            {
+                                              width: timeActivityAvatarStackWidth(
+                                                agreementAvatarPreview.visibleParticipants.length + (agreementAvatarPreview.overflowCount > 0 ? 1 : 0),
+                                              ),
+                                            },
                                           ]}
                                         >
-                                          {agreementParticipants.map((participant, avatarIndex) => {
+                                          {agreementAvatarPreview.visibleParticipants.map((participant, avatarIndex) => {
                                             const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
                                             return participant.counterpart_avatar_url ? (
                                               <Image
@@ -1343,6 +1408,13 @@ export default function TimeActivityScreen() {
                                               </View>
                                             );
                                           })}
+                                          {agreementAvatarPreview.overflowCount > 0 ? (
+                                            <View style={[styles.stackedAvatar, styles.avatarOverflowBadge, styles.stackedAvatarOverlap]}>
+                                              <Text style={styles.avatarOverflowText}>
+                                                +{agreementAvatarPreview.overflowCount}
+                                              </Text>
+                                            </View>
+                                          ) : null}
                                         </View>
                                         <Text style={styles.neutralPillText}>
                                           {agreement.participant_count} members
@@ -1393,12 +1465,14 @@ export default function TimeActivityScreen() {
                                 </View>
                               </View>
 
-                              <View style={styles.agreementRight}>
-                                <Text style={[styles.agreementValue, { color: valueColor }]}>
-                                  {displayDelta !== 0 ? formatAmount(displayDelta) : "No hours"}
-                                </Text>
-                                <Text style={styles.agreementNote}>{valueNote}</Text>
-                              </View>
+                              {showTimeValue ? (
+                                <View style={styles.agreementRight}>
+                                  <Text style={[styles.agreementValue, { color: valueColor }]}>
+                                    {displayDelta !== 0 ? formatAmount(displayDelta) : "No hours"}
+                                  </Text>
+                                  <Text style={styles.agreementNote}>{valueNote}</Text>
+                                </View>
+                              ) : null}
                             </Pressable>
                           );
                         }) : null}
@@ -1427,11 +1501,6 @@ export default function TimeActivityScreen() {
                   </Text>
                 </View>
                 <View style={styles.sectionHeaderMeta}>
-                  <View style={[styles.upcomingChip, { backgroundColor: colors.WHITE }]}>
-                    <Text style={[styles.upcomingChipText, { color: colors.AMBER }]}>
-                      {formatHours(eventHistory.reduce((sum, event) => sum + Number(event.duration || 0), 0))}
-                    </Text>
-                  </View>
                   <Ionicons
                     name={isEventActivityOpen ? "chevron-up" : "chevron-down"}
                     size={20}
@@ -1499,14 +1568,6 @@ export default function TimeActivityScreen() {
                       </View>
                     </View>
 
-                    <View style={styles.agreementRight}>
-                      <Text style={[styles.agreementValue, { color: colors.AMBER }]}>
-                        {formatHours(Number(event.duration))}
-                      </Text>
-                      <Text style={styles.agreementNote}>
-                        {formatDate(event.completed_date)}
-                      </Text>
-                    </View>
                   </View>
                 ))}
               </View>
@@ -1565,6 +1626,7 @@ export default function TimeActivityScreen() {
         const participantAvatars = item.isMultiUse
           ? timeActivityVisibleParticipants(item.participants)
           : [];
+        const participantAvatarPreview = timeActivityAvatarPreview(participantAvatars);
         const isRefund = transaction.transaction_type === "refund";
         const isPositive = item.amount >= 0;
         const amountColor = isRefund ? colors.PURPLE : isPositive ? colors.GREEN : colors.AMBER;
@@ -1636,10 +1698,14 @@ export default function TimeActivityScreen() {
                   <View
                     style={[
                       styles.avatarStack,
-                      { width: timeActivityAvatarStackWidth(participantAvatars.length) },
+                      {
+                        width: timeActivityAvatarStackWidth(
+                          participantAvatarPreview.visibleParticipants.length + (participantAvatarPreview.overflowCount > 0 ? 1 : 0),
+                        ),
+                      },
                     ]}
                   >
-                    {participantAvatars.map((participant, avatarIndex) => {
+                    {participantAvatarPreview.visibleParticipants.map((participant, avatarIndex) => {
                       const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
                       return participant.counterpart_avatar_url ? (
                         <Image
@@ -1663,6 +1729,13 @@ export default function TimeActivityScreen() {
                         </View>
                       );
                     })}
+                    {participantAvatarPreview.overflowCount > 0 ? (
+                      <View style={[styles.stackedAvatar, styles.avatarOverflowBadge, styles.stackedAvatarOverlap]}>
+                        <Text style={styles.avatarOverflowText}>
+                          +{participantAvatarPreview.overflowCount}
+                        </Text>
+                      </View>
+                    ) : null}
                   </View>
                 ) : counterpartAvatarUrl ? (
                   <Image
@@ -1734,8 +1807,11 @@ export default function TimeActivityScreen() {
               {selectedAgreementGroup?.service_title ?? "Group session"}
             </Text>
             <Text style={styles.participantSheetSubtitle}>
-              {(selectedAgreementGroup?.participant_count ?? 0)} active member
-              {(selectedAgreementGroup?.participant_count ?? 0) === 1 ? "" : "s"}
+              {selectedAgreementGroup?.service_type === "Event"
+                ? `${selectedAgreementGroup?.participant_count ?? 0} organizers and attendees`
+                : `${selectedAgreementGroup?.participant_count ?? 0} active member${
+                    (selectedAgreementGroup?.participant_count ?? 0) === 1 ? "" : "s"
+                  }`}
             </Text>
           </View>
           <Pressable
@@ -1751,6 +1827,8 @@ export default function TimeActivityScreen() {
 
         <ScrollView style={styles.participantList} contentContainerStyle={styles.participantListContent}>
           {(selectedAgreementGroup?.participants ?? []).map((participant) => {
+            const isEventParticipant =
+              selectedAgreementGroup?.service_type === "Event" || participant.service_type === "Event";
             const delta = participant.expected_delta !== 0
               ? participant.expected_delta
               : participant.reserved_delta;
@@ -1785,12 +1863,14 @@ export default function TimeActivityScreen() {
                     {participant.counterpart_name}
                   </Text>
                   <Text style={styles.participantMeta} numberOfLines={1}>
-                    {activeHandshakeLabel(participant.status)}
+                    {isEventParticipant ? participant.note : activeHandshakeLabel(participant.status)}
                   </Text>
                 </View>
-                <Text style={styles.participantValue}>
-                  {delta !== 0 ? formatAmount(delta) : "0h"}
-                </Text>
+                {!isEventParticipant ? (
+                  <Text style={styles.participantValue}>
+                    {delta !== 0 ? formatAmount(delta) : "0h"}
+                  </Text>
+                ) : null}
               </Pressable>
             );
           })}
@@ -2657,6 +2737,16 @@ const styles = StyleSheet.create({
   },
   stackedAvatarOverlap: {
     marginLeft: -10,
+  },
+  avatarOverflowBadge: {
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.GRAY800,
+  },
+  avatarOverflowText: {
+    color: colors.WHITE,
+    fontSize: 8,
+    fontWeight: "900",
   },
   whoName: {
     fontSize: 13,

--- a/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
+++ b/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
@@ -30,9 +30,13 @@ import type { UserHistoryItem } from "../../api/types";
 import type { ProfileStackParamList } from "../../navigation/ProfileStack";
 import {
   activeAgreementParticipantLabel,
+  completedGroupOfferParticipantCount,
   completedTransactionParticipantLabel,
   groupActiveAgreements,
   groupTransactionRows,
+  isTimeActivityParticipantStatus,
+  timeActivityAvatarStackWidth,
+  timeActivityVisibleParticipants,
   type GroupedTransactionRow,
   type TimeActivityAgreement as ExpectedAgreement,
 } from "../../utils/timeActivityGrouping";
@@ -402,6 +406,17 @@ export default function TimeActivityScreen() {
     for (const agreement of agreementParticipants) {
       if (!agreement.service_id || agreement.service_type !== "Offer") continue;
       if (agreement.schedule_type !== "One-Time" || (agreement.max_participants ?? 0) <= 1) continue;
+      if (!isTimeActivityParticipantStatus(agreement.status)) continue;
+      map.set(agreement.service_id, [...(map.get(agreement.service_id) ?? []), agreement]);
+    }
+    return map;
+  }, [agreementParticipants]);
+  const completedAgreementParticipantsByServiceId = useMemo(() => {
+    const map = new Map<string, ExpectedAgreement[]>();
+    for (const agreement of agreementParticipants) {
+      if (!agreement.service_id || agreement.service_type !== "Offer") continue;
+      if (agreement.schedule_type !== "One-Time" || (agreement.max_participants ?? 0) <= 1) continue;
+      if (agreement.status !== "completed") continue;
       map.set(agreement.service_id, [...(map.get(agreement.service_id) ?? []), agreement]);
     }
     return map;
@@ -443,15 +458,29 @@ export default function TimeActivityScreen() {
           const participants = transaction.service_id
             ? agreementParticipantsByServiceId.get(transaction.service_id)
             : undefined;
-          return participants?.length ?? null;
+          const completedParticipants = transaction.service_id
+            ? completedAgreementParticipantsByServiceId.get(transaction.service_id)
+            : undefined;
+          return completedGroupOfferParticipantCount({
+            participantCount: participants?.length,
+            completedCount: completedParticipants?.length,
+          });
         },
         participants: (transaction) => {
-          return transaction.service_id
-            ? agreementParticipantsByServiceId.get(transaction.service_id)
-            : undefined;
+          if (!transaction.service_id) return undefined;
+          const completedParticipants = completedAgreementParticipantsByServiceId.get(transaction.service_id);
+          return completedParticipants && completedParticipants.length > 0
+            ? completedParticipants
+            : agreementParticipantsByServiceId.get(transaction.service_id);
         },
       }),
-    [activeAgreementByServiceId, agreementParticipantsByServiceId, transactions, user?.id],
+    [
+      activeAgreementByServiceId,
+      agreementParticipantsByServiceId,
+      completedAgreementParticipantsByServiceId,
+      transactions,
+      user?.id,
+    ],
   );
   const insightStats = useMemo(() => {
     const now = new Date();
@@ -1237,6 +1266,9 @@ export default function TimeActivityScreen() {
                               : agreement.reserved_delta !== 0
                                 ? "Reserved now"
                                 : "No time change";
+                          const agreementParticipants = isGroupedAgreement
+                            ? timeActivityVisibleParticipants(agreement.participants)
+                            : [];
 
                           return (
                             <Pressable
@@ -1279,18 +1311,57 @@ export default function TimeActivityScreen() {
                                     </Text>
                                   </Pressable>
                                   <View style={styles.compactBadgeRow}>
-                                    <Pressable
-                                      onPress={() => openPublicProfile(agreement.counterpart_id)}
-                                      disabled={!agreement.counterpart_id || agreement.counterpart_id === user?.id}
-                                      style={({ pressed }) => [
-                                        styles.neutralPill,
-                                        pressed && styles.pressed,
-                                      ]}
-                                    >
-                                      <Text style={styles.neutralPillText}>
-                                        {agreement.counterpart_name}
-                                      </Text>
-                                    </Pressable>
+                                    {agreementParticipants.length > 0 ? (
+                                      <View style={styles.memberPill}>
+                                        <View
+                                          style={[
+                                            styles.avatarStack,
+                                            { width: timeActivityAvatarStackWidth(agreementParticipants.length) },
+                                          ]}
+                                        >
+                                          {agreementParticipants.map((participant, avatarIndex) => {
+                                            const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
+                                            return participant.counterpart_avatar_url ? (
+                                              <Image
+                                                key={participant.id}
+                                                source={{ uri: participant.counterpart_avatar_url }}
+                                                style={[
+                                                  styles.stackedAvatar,
+                                                  avatarIndex > 0 && styles.stackedAvatarOverlap,
+                                                ]}
+                                              />
+                                            ) : (
+                                              <View
+                                                key={participant.id}
+                                                style={[
+                                                  styles.stackedAvatar,
+                                                  styles.whoAvatarFallback,
+                                                  avatarIndex > 0 && styles.stackedAvatarOverlap,
+                                                ]}
+                                              >
+                                                <Text style={styles.whoAvatarInitial}>{initial}</Text>
+                                              </View>
+                                            );
+                                          })}
+                                        </View>
+                                        <Text style={styles.neutralPillText}>
+                                          {agreement.participant_count} members
+                                        </Text>
+                                      </View>
+                                    ) : (
+                                      <Pressable
+                                        onPress={() => openPublicProfile(agreement.counterpart_id)}
+                                        disabled={!agreement.counterpart_id || agreement.counterpart_id === user?.id}
+                                        style={({ pressed }) => [
+                                          styles.neutralPill,
+                                          pressed && styles.pressed,
+                                        ]}
+                                      >
+                                        <Text style={styles.neutralPillText}>
+                                          {agreement.counterpart_name}
+                                        </Text>
+                                      </Pressable>
+                                    )}
                                     <View
                                       style={[
                                         styles.statePill,
@@ -1492,7 +1563,7 @@ export default function TimeActivityScreen() {
         const counterpartAvatarUrl = item.counterpartAvatarUrl ?? null;
         const counterpartInitial = counterpart.trim().charAt(0).toUpperCase() || "?";
         const participantAvatars = item.isMultiUse
-          ? (item.participants ?? []).slice(0, 2)
+          ? timeActivityVisibleParticipants(item.participants)
           : [];
         const isRefund = transaction.transaction_type === "refund";
         const isPositive = item.amount >= 0;
@@ -1562,7 +1633,12 @@ export default function TimeActivityScreen() {
                 ]}
               >
                 {participantAvatars.length > 0 ? (
-                  <View style={styles.avatarStack}>
+                  <View
+                    style={[
+                      styles.avatarStack,
+                      { width: timeActivityAvatarStackWidth(participantAvatars.length) },
+                    ]}
+                  >
                     {participantAvatars.map((participant, avatarIndex) => {
                       const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
                       return participant.counterpart_avatar_url ? (
@@ -2561,7 +2637,15 @@ const styles = StyleSheet.create({
   avatarStack: {
     flexDirection: "row",
     alignItems: "center",
-    width: 34,
+  },
+  memberPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    backgroundColor: colors.GRAY100,
   },
   stackedAvatar: {
     width: 22,

--- a/mobile-client/src/utils/timeActivityGrouping.ts
+++ b/mobile-client/src/utils/timeActivityGrouping.ts
@@ -1,0 +1,224 @@
+export interface TimeActivityAgreement {
+  id: string;
+  service_id?: string | null;
+  service_title: string;
+  service_type?: string | null;
+  schedule_type?: string | null;
+  max_participants?: number | null;
+  scheduled_time?: string | null;
+  is_current_user_provider: boolean;
+  counterpart_id?: string | null;
+  counterpart_name: string;
+  counterpart_avatar_url?: string | null;
+  status: string;
+  reserved_delta: number;
+  expected_delta: number;
+  note: string;
+  participant_count?: number;
+  participants?: TimeActivityAgreement[];
+  is_grouped_multi_use?: boolean;
+}
+
+export interface TimeActivityTransaction {
+  id: string;
+  service_id?: string | null;
+  transaction_type: string;
+  service_type?: string | null;
+  schedule_type?: string | null;
+  max_participants?: number | null;
+  is_current_user_provider?: boolean;
+  amount: number;
+  balance_after: number;
+  created_at: string;
+  service_title?: string | null;
+  counterpart?: {
+    id: string;
+    first_name?: string;
+    last_name?: string;
+    email?: string;
+    avatar_url?: string | null;
+  } | null;
+  description?: string;
+}
+
+export interface GroupedTransactionRow<T extends TimeActivityTransaction = TimeActivityTransaction> {
+  key: string;
+  serviceId?: string | null;
+  primary: T;
+  items: T[];
+  amount: number;
+  balanceAfter: number;
+  createdAt: string;
+  counterpartLabel: string;
+  counterpartId?: string | null;
+  counterpartAvatarUrl?: string | null;
+  description: string;
+  isMultiUse: boolean;
+  participantCount: number;
+  participants?: TimeActivityAgreement[];
+}
+
+function isOneTimeGroupOffer(item: {
+  service_id?: string | null;
+  service_type?: string | null;
+  schedule_type?: string | null;
+  max_participants?: number | null;
+}) {
+  return (
+    item.service_type === "Offer" &&
+    item.schedule_type === "One-Time" &&
+    (item.max_participants ?? 0) > 1 &&
+    Boolean(item.service_id)
+  );
+}
+
+function sessionKey(item: { service_id?: string | null; scheduled_time?: string | null }) {
+  return `${item.service_id ?? "unknown"}:${item.scheduled_time ?? "fixed-session"}`;
+}
+
+function representativeDelta(values: number[]) {
+  const nonZero = values.filter((value) => value !== 0);
+  if (nonZero.length === 0) return 0;
+  const positives = nonZero.filter((value) => value > 0);
+  if (positives.length > 0) return Math.max(...positives);
+  return Math.min(...nonZero);
+}
+
+export function groupActiveAgreements<T extends TimeActivityAgreement>(agreements: T[]): TimeActivityAgreement[] {
+  const groups = new Map<string, T[]>();
+  const output: T[] = [];
+
+  for (const agreement of agreements) {
+    if (!isOneTimeGroupOffer(agreement)) {
+      output.push({
+        ...agreement,
+        participant_count: agreement.participant_count ?? 1,
+        participants: agreement.participants ?? [agreement],
+        is_grouped_multi_use: false,
+      });
+      continue;
+    }
+
+    const key = sessionKey(agreement);
+    groups.set(key, [...(groups.get(key) ?? []), agreement]);
+  }
+
+  for (const [key, participants] of groups.entries()) {
+    if (participants.length === 1) {
+      const [single] = participants;
+      output.push({
+        ...single,
+        participant_count: 1,
+        participants: [single],
+        is_grouped_multi_use: false,
+      });
+      continue;
+    }
+
+    const [primary] = participants;
+    output.push({
+      ...primary,
+      id: `group:${key}`,
+      counterpart_id: null,
+      counterpart_name: `${participants.length} members`,
+      counterpart_avatar_url: null,
+      expected_delta: representativeDelta(participants.map((item) => item.expected_delta)),
+      reserved_delta: representativeDelta(participants.map((item) => item.reserved_delta)),
+      note: `${participants.length} members in this group session`,
+      participant_count: participants.length,
+      participants,
+      is_grouped_multi_use: true,
+    });
+  }
+
+  return output;
+}
+
+function isGroupOfferTransfer(transaction: TimeActivityTransaction) {
+  return (
+    isOneTimeGroupOffer(transaction) &&
+    transaction.transaction_type === "transfer" &&
+    transaction.is_current_user_provider === true
+  );
+}
+
+export function groupTransactionRows<T extends TimeActivityTransaction>(
+  transactions: T[],
+  options: {
+    counterpartLabel?: (transaction: T) => string;
+    counterpartId?: (transaction: T) => string | null | undefined;
+    counterpartAvatarUrl?: (transaction: T) => string | null | undefined;
+    description?: (transaction: T) => string;
+    participantCount?: (transaction: T) => number | null | undefined;
+    participants?: (transaction: T) => TimeActivityAgreement[] | null | undefined;
+  } = {},
+): GroupedTransactionRow<T>[] {
+  const groups = new Map<string, GroupedTransactionRow<T>>();
+
+  for (const transaction of transactions) {
+    const shouldGroup = isGroupOfferTransfer(transaction);
+    const key = shouldGroup ? `group-offer-transfer:${sessionKey(transaction)}` : transaction.id;
+    const existing = groups.get(key);
+
+    if (existing) {
+      existing.items.push(transaction);
+      const knownParticipantCount = options.participantCount?.(transaction);
+      const knownParticipants = options.participants?.(transaction) ?? undefined;
+      existing.createdAt = new Date(transaction.created_at).getTime() > new Date(existing.createdAt).getTime()
+        ? transaction.created_at
+        : existing.createdAt;
+      existing.balanceAfter = transaction.balance_after;
+      existing.amount = representativeDelta(existing.items.map((item) => item.amount));
+      existing.participantCount = Math.max(existing.items.length, knownParticipantCount ?? 0);
+      existing.participants = knownParticipants ?? existing.participants;
+      existing.counterpartLabel = `${existing.participantCount} members`;
+      existing.counterpartId = null;
+      existing.counterpartAvatarUrl = null;
+      existing.description = `Settled once for ${existing.participantCount} participants. Open details to view everyone in this session.`;
+      existing.isMultiUse = true;
+      continue;
+    }
+
+    const knownParticipantCount = shouldGroup ? Math.max(1, options.participantCount?.(transaction) ?? 1) : 1;
+    const knownParticipants = shouldGroup ? options.participants?.(transaction) ?? undefined : undefined;
+
+    groups.set(key, {
+      key,
+      serviceId: transaction.service_id,
+      primary: transaction,
+      items: [transaction],
+      amount: transaction.amount,
+      balanceAfter: transaction.balance_after,
+      createdAt: transaction.created_at,
+      counterpartLabel: shouldGroup && knownParticipantCount > 1
+        ? `${knownParticipantCount} members`
+        : options.counterpartLabel?.(transaction) ?? "Time activity",
+      counterpartId: shouldGroup && knownParticipantCount > 1
+        ? null
+        : options.counterpartId?.(transaction) ?? transaction.counterpart?.id ?? null,
+      counterpartAvatarUrl: shouldGroup && knownParticipantCount > 1
+        ? null
+        : options.counterpartAvatarUrl?.(transaction) ?? transaction.counterpart?.avatar_url ?? null,
+      description: shouldGroup && knownParticipantCount > 1
+        ? `Settled once for ${knownParticipantCount} participants. Open details to view everyone in this session.`
+        : options.description?.(transaction) ?? transaction.description ?? "",
+      isMultiUse: shouldGroup && knownParticipantCount > 1,
+      participantCount: knownParticipantCount,
+      participants: knownParticipants,
+    });
+  }
+
+  return Array.from(groups.values()).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+
+export function completedTransactionParticipantLabel() {
+  return "Completed participant";
+}
+
+export function activeAgreementParticipantLabel(status: string) {
+  if (status === "checked_in") return "Checked in";
+  if (status === "attended") return "Attended";
+  return "Session confirmed";
+}

--- a/mobile-client/src/utils/timeActivityGrouping.ts
+++ b/mobile-client/src/utils/timeActivityGrouping.ts
@@ -72,6 +72,15 @@ function isOneTimeGroupOffer(item: {
   );
 }
 
+function isGroupableActiveSession(item: {
+  service_id?: string | null;
+  service_type?: string | null;
+  schedule_type?: string | null;
+  max_participants?: number | null;
+}) {
+  return isOneTimeGroupOffer(item) || (item.service_type === "Event" && Boolean(item.service_id));
+}
+
 function sessionKey(item: { service_id?: string | null; scheduled_time?: string | null }) {
   return `${item.service_id ?? "unknown"}:${item.scheduled_time ?? "fixed-session"}`;
 }
@@ -104,6 +113,15 @@ export function timeActivityVisibleParticipants<T>(participants?: T[] | null): T
   return participants ?? [];
 }
 
+export function timeActivityAvatarPreview<T>(participants?: T[] | null, maxVisible = 5) {
+  const allParticipants = timeActivityVisibleParticipants(participants);
+  const visibleParticipants = allParticipants.slice(0, maxVisible);
+  return {
+    visibleParticipants,
+    overflowCount: Math.max(0, allParticipants.length - visibleParticipants.length),
+  };
+}
+
 export function timeActivityAvatarStackWidth(participantCount: number, avatarSize = 22, overlap = 10) {
   if (participantCount <= 0) return 0;
   return avatarSize + (participantCount - 1) * (avatarSize - overlap);
@@ -114,7 +132,7 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
   const output: T[] = [];
 
   for (const agreement of agreements) {
-    if (!isOneTimeGroupOffer(agreement)) {
+    if (!isGroupableActiveSession(agreement)) {
       output.push({
         ...agreement,
         participant_count: agreement.participant_count ?? 1,
@@ -131,6 +149,24 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
   for (const [key, participants] of groups.entries()) {
     if (participants.length === 1) {
       const [single] = participants;
+      const loadedParticipants = single.participants?.length ? single.participants : [single];
+      if (single.service_type === "Event" && loadedParticipants.length > 1) {
+        output.push({
+          ...single,
+          id: `group:${key}`,
+          counterpart_id: null,
+          counterpart_name: `${loadedParticipants.length} members`,
+          counterpart_avatar_url: null,
+          expected_delta: representativeDelta(loadedParticipants.map((item) => item.expected_delta)),
+          reserved_delta: representativeDelta(loadedParticipants.map((item) => item.reserved_delta)),
+          note: `${loadedParticipants.length} members in this event`,
+          participant_count: loadedParticipants.length,
+          participants: loadedParticipants,
+          is_grouped_multi_use: true,
+        });
+        continue;
+      }
+
       output.push({
         ...single,
         participant_count: 1,

--- a/mobile-client/src/utils/timeActivityGrouping.ts
+++ b/mobile-client/src/utils/timeActivityGrouping.ts
@@ -79,9 +79,34 @@ function sessionKey(item: { service_id?: string | null; scheduled_time?: string 
 function representativeDelta(values: number[]) {
   const nonZero = values.filter((value) => value !== 0);
   if (nonZero.length === 0) return 0;
+  // Group-offer rows represent one shared session, so we keep one representative
+  // participant delta instead of summing duplicate provider-side transfer rows.
   const positives = nonZero.filter((value) => value > 0);
   if (positives.length > 0) return Math.max(...positives);
   return Math.min(...nonZero);
+}
+
+export function isTimeActivityParticipantStatus(status?: string | null) {
+  return status === "accepted" || status === "checked_in" || status === "attended" || status === "completed";
+}
+
+export function completedGroupOfferParticipantCount({
+  participantCount,
+  completedCount,
+}: {
+  participantCount?: number | null;
+  completedCount?: number | null;
+}) {
+  return completedCount && completedCount > 0 ? completedCount : participantCount ?? null;
+}
+
+export function timeActivityVisibleParticipants<T>(participants?: T[] | null): T[] {
+  return participants ?? [];
+}
+
+export function timeActivityAvatarStackWidth(participantCount: number, avatarSize = 22, overlap = 10) {
+  if (participantCount <= 0) return 0;
+  return avatarSize + (participantCount - 1) * (avatarSize - overlap);
 }
 
 export function groupActiveAgreements<T extends TimeActivityAgreement>(agreements: T[]): TimeActivityAgreement[] {


### PR DESCRIPTION
## Summary
- Grouped one-time group offer entries in Time Activity so multi-participant sessions render as a single readable row instead of repeated participant rows.
- Added participant detail sheets/modals for grouped Time Activity rows on both web and mobile.
- Fixed grouped row copy and visuals: `N members`, overlapping participant avatars, correct active/completed participant labels, and no duplicate modal rows.

## Test Plan
- [x] Web: `npx vitest run src/test/utils/timeActivityGrouping.test.ts`
- [x] Web: `npx tsc -p tsconfig.app.json --noEmit`
- [x] Web: `npx eslint src/pages/TransactionHistoryPage.tsx src/utils/timeActivityGrouping.ts src/test/utils/timeActivityGrouping.test.ts`
- [x] Mobile: `npx jest src/api/__tests__/timeActivityGrouping.test.ts --selectProjects api --runTestsByPath --runInBand`
- [x] Mobile: `npx tsc --noEmit`
- [x] Checked lints on edited files

Fixes #522