### PR TITLE
Refactor/queryset for userprofile refactor

### DIFF
--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -39,6 +39,41 @@ class TestServiceViewSet:
         response = client.get('/api/services/?type=Offer')
         assert_api_response(response, 200)
         assert all(s['type'] == 'Offer' for s in response.data['results'])
+
+    def test_user_profile_service_list_includes_agreed_services(self):
+        """Profile service lists should include services with active agreements."""
+        owner = UserFactory()
+        active_offer = ServiceFactory(user=owner, type='Offer', status='Active', title='Visible Active Offer')
+        agreed_offer = ServiceFactory(user=owner, type='Offer', status='Agreed', title='Visible Agreed Offer')
+        ServiceFactory(user=owner, type='Offer', status='Completed', title='Hidden Completed Offer')
+        ServiceFactory(type='Offer', status='Agreed', title='Other Owner Agreed Offer')
+
+        client = APIClient()
+        response = client.get(f'/api/services/?user={owner.id}&type=Offer')
+
+        assert_api_response(response, 200)
+        returned_ids = {item['id'] for item in response.data['results']}
+        assert str(active_offer.id) in returned_ids
+        assert str(agreed_offer.id) in returned_ids
+        assert all(item['status'] in {'Active', 'Agreed'} for item in response.data['results'])
+
+    def test_user_profile_service_list_is_not_served_from_stale_cache(self):
+        """Profile lists need live service state when agreements change status."""
+        owner = UserFactory()
+        service = ServiceFactory(user=owner, type='Offer', status='Active', title='Agreement Status Offer')
+
+        client = APIClient()
+        first = client.get(f'/api/services/?user={owner.id}&type=Offer')
+        assert_api_response(first, 200)
+        first_item = next(item for item in first.data['results'] if item['id'] == str(service.id))
+        assert first_item['status'] == 'Active'
+
+        Service.objects.filter(id=service.id).update(status='Agreed')
+
+        second = client.get(f'/api/services/?user={owner.id}&type=Offer')
+        assert_api_response(second, 200)
+        second_item = next(item for item in second.data['results'] if item['id'] == str(service.id))
+        assert second_item['status'] == 'Agreed'
     
     def test_list_services_pagination(self):
         """Test service pagination"""

--- a/backend/api/tests/integration/test_user_api.py
+++ b/backend/api/tests/integration/test_user_api.py
@@ -17,6 +17,7 @@ from api.models import (
     Badge,
     UserBadge,
     Comment,
+    ServiceMedia,
     ReputationRep,
     UserFollow,
     UserFollowEvent,
@@ -131,6 +132,42 @@ class TestUserProfileView:
         response = client.get('/api/users/me/')
         assert_api_response(response, 200, schema={'followers_count': 1, 'following_count': 1})
         assert response.data['is_following'] is False
+
+    def test_me_profile_service_query_count_does_not_scale_per_service(self):
+        """Nested service cards in /users/me/ should not re-query counts/media per row."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        user = UserFactory()
+        requester = UserFactory()
+
+        for idx in range(3):
+            service = ServiceFactory(user=user, type='Offer', status='Active', title=f'Profile Offer {idx}')
+            Comment.objects.create(service=service, user=requester, body='Helpful context')
+            ServiceMedia.objects.create(service=service, media_type='image', file_url=f'https://example.com/{idx}.jpg')
+            HandshakeFactory(service=service, requester=requester, status='accepted')
+
+        client = AuthenticatedAPIClient().authenticate_user(user)
+        with CaptureQueriesContext(connection) as ctx_3:
+            response = client.get('/api/users/me/')
+            assert_api_response(response, 200)
+        small = len(ctx_3)
+
+        for idx in range(3, 12):
+            service = ServiceFactory(user=user, type='Offer', status='Active', title=f'Profile Offer {idx}')
+            Comment.objects.create(service=service, user=requester, body='Helpful context')
+            ServiceMedia.objects.create(service=service, media_type='image', file_url=f'https://example.com/{idx}.jpg')
+            HandshakeFactory(service=service, requester=requester, status='accepted')
+
+        with CaptureQueriesContext(connection) as ctx_12:
+            response = client.get('/api/users/me/')
+            assert_api_response(response, 200)
+        large = len(ctx_12)
+
+        assert large - small < 15, (
+            f'/users/me/ query count grew from {small} to {large} for 3 -> 12 '
+            'services; nested service N+1 likely regressed'
+        )
 
     def test_other_user_profile_is_following_and_counts(self):
         viewer = UserFactory()

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1164,14 +1164,51 @@ class UserProfileView(generics.RetrieveUpdateAPIView):
             to_attr='_profile_event_handshakes',
         )
         
+        user_badges_prefetch = Prefetch(
+            'user__badges',
+            queryset=UserBadge.objects.select_related('badge')
+        )
+        capacity_handshakes_prefetch = Prefetch(
+            'handshakes',
+            queryset=Handshake.objects.filter(
+                status__in=['pending', 'accepted', 'completed', 'reported', 'paused', 'checked_in', 'attended', 'no_show']
+            ).only('id', 'service_id', 'status'),
+            to_attr='capacity_handshakes',
+        )
+
         # Filter services by visibility - admins can see all, others only visible
         is_admin = self.request.user.is_authenticated and self.request.user.role in ADMIN_ROLES
+        services_queryset = (
+            Service.objects
+            .annotate(comment_count=Count('comments', filter=Q(comments__is_deleted=False)))
+            .select_related('user', 'event_evaluation_summary')
+            .prefetch_related(
+                'tags',
+                user_badges_prefetch,
+                Prefetch('media', queryset=ServiceMedia.objects.order_by('display_order', 'created_at')),
+                capacity_handshakes_prefetch,
+            )
+        )
+        if self.request.user.is_authenticated:
+            from .models import SavedService, ServiceDismissal
+            services_queryset = services_queryset.annotate(
+                is_saved_anno=Exists(
+                    SavedService.objects.filter(
+                        user=self.request.user, service=OuterRef('pk'),
+                    ),
+                ),
+                is_dismissed_anno=Exists(
+                    ServiceDismissal.objects.filter(
+                        viewer=self.request.user, service=OuterRef('pk'),
+                    ),
+                ),
+            )
         if is_admin:
-            services_prefetch = Prefetch('services', queryset=Service.objects.prefetch_related('tags'))
+            services_prefetch = Prefetch('services', queryset=services_queryset)
         else:
             services_prefetch = Prefetch(
                 'services',
-                queryset=Service.objects.filter(is_visible=True).exclude(status='Cancelled').prefetch_related('tags')
+                queryset=services_queryset.filter(is_visible=True).exclude(status='Cancelled')
             )
 
         return (

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2107,6 +2107,7 @@ class ServiceViewSet(viewsets.ModelViewSet):
         }
         
         sort_param = request.query_params.get('sort', 'latest')
+        user_param = request.query_params.get('user')
         # Don't cache location-based queries (results vary by user location).
         # Also skip cache for hot-sort by authenticated users -- social boost is per-user.
         # And skip cache when sort=hot AND exploration is enabled, since Phase 3
@@ -2120,6 +2121,7 @@ class ServiceViewSet(viewsets.ModelViewSet):
         explore_only_param = request.query_params.get('explore_only', '').lower() in ('1', 'true', 'yes')
         use_cache = not (
             (request.query_params.get('lat') and request.query_params.get('lng'))
+            or user_param
             or (sort_param == 'hot' and request.user.is_authenticated)
             or sort_param == 'for_you'
             or explore_enabled
@@ -2298,6 +2300,7 @@ class ServiceViewSet(viewsets.ModelViewSet):
 
     @track_performance
     def get_queryset(self):
+        user_param = self.request.query_params.get('user')
         # Use Prefetch object to optimize nested user badges query
         user_badges_prefetch = Prefetch(
             'user__badges',
@@ -2314,8 +2317,9 @@ class ServiceViewSet(viewsets.ModelViewSet):
         )
 
         # Base queryset with optimizations (annotate comment_count to avoid N+1 in list)
+        visible_statuses = ['Active', 'Agreed'] if user_param else ['Active']
         queryset = (
-            Service.objects.filter(status='Active')
+            Service.objects.filter(status__in=visible_statuses)
             .annotate(comment_count=Count('comments', filter=Q(comments__is_deleted=False)))
             .select_related('user', 'event_evaluation_summary')
             .prefetch_related(
@@ -2370,8 +2374,6 @@ class ServiceViewSet(viewsets.ModelViewSet):
         except InvalidSearchParam as exc:
             # Surface the field-level error instead of swallowing it.
             raise drf_serializers.ValidationError({exc.field: exc.message})
-
-        user_param = self.request.query_params.get('user')
 
         # Onboarding tag fallback (#478): when an onboarded viewer with
         # declared skills hits the feed without an explicit tag filter,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -216,7 +216,7 @@ function App() {
     // On protected route changes, keep fast-changing profile fields such as
     // time balance fresh while still bootstrapping anonymous sessions normally.
     if (user) {
-      refreshUser()
+      refreshUser({ force: false })
     } else {
       checkAuth()
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -213,8 +213,8 @@ function App() {
     // triggering the /users/me/ → 401 → refresh-fail cycle on every keystroke.
     if (PUBLIC_AUTH_PATHS.includes(location.pathname)) return
 
-    // On protected route changes, keep fast-changing profile fields such as
-    // time balance fresh while still bootstrapping anonymous sessions normally.
+    // Route changes are a soft auth/profile refresh so navigation does not
+    // flood /users/me/. Mutations that change balance call refreshUser() explicitly.
     if (user) {
       refreshUser({ force: false })
     } else {

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -14,6 +14,7 @@ import { serviceAPI } from '@/services/serviceAPI'
 import type { User, Service, BadgeProgress, ProfileReview } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
+import { isOngoingProfileService } from '@/utils/profileServices'
 import {
   GREEN, GREEN_LT,
   AMBER, AMBER_LT,
@@ -164,8 +165,8 @@ const PublicProfile = () => {
       try {
         const u = await userAPI.getUser(userId, ac.signal)
         setProfileUser(u)
-        serviceAPI.list({ user_id: userId, status: 'Active', page_size: 50 }, ac.signal)
-          .then(setServices).catch(() => {})
+        serviceAPI.list({ user_id: userId, page_size: 50 }, ac.signal)
+          .then((items) => setServices(items.filter(isOngoingProfileService))).catch(() => {})
         if (u.show_history) {
           userAPI.getHistory(userId, ac.signal).then(setHistory).catch(() => {})
         }

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -16,6 +16,7 @@ import { authAPI } from '@/services/authAPI'
 import type { Service, BadgeProgress, ProfileReview } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
+import { isOngoingProfileService } from '@/utils/profileServices'
 import {
   GREEN, GREEN_LT,
   AMBER, AMBER_LT,
@@ -285,8 +286,8 @@ const UserProfile = () => {
 
   const ownHistory = history.filter(isOwnHistoryItem)
   const groupedOwnHistory = useMemo(() => groupHistoryItems(ownHistory), [ownHistory])
-  const offersTab  = services.filter(s => s.type === 'Offer' && s.status === 'Active')
-  const needsTab   = services.filter(s => s.type === 'Need'  && s.status === 'Active')
+  const offersTab  = services.filter(s => s.type === 'Offer' && isOngoingProfileService(s))
+  const needsTab   = services.filter(s => s.type === 'Need'  && isOngoingProfileService(s))
   const eventServices = services.filter(s => s.type === 'Event' && s.status === 'Active')
 
   useEffect(() => {

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -16,6 +16,7 @@ import { authAPI } from '@/services/authAPI'
 import type { Service, BadgeProgress, ProfileReview } from '@/types'
 import type { UserHistoryItem } from '@/services/userAPI'
 import { groupHistoryItems, isOwnHistoryItem, type GroupedHistoryEntry } from '@/utils/historyGrouping'
+import { profileDataUserId } from '@/utils/profileDataLoad'
 import { isOngoingProfileService } from '@/utils/profileServices'
 import {
   GREEN, GREEN_LT,
@@ -146,6 +147,7 @@ const UserProfile = () => {
   const routerLocation = useLocation()
   const [searchParams] = useSearchParams()
   const { user, updateUserOptimistically, refreshUser } = useAuthStore()
+  const userId = profileDataUserId(user)
 
   const initialTab: ServiceTab = (() => {
     const tabParam = searchParams.get('tab')
@@ -156,7 +158,7 @@ const UserProfile = () => {
   })()
 
   useEffect(() => {
-    void refreshUser()
+    void refreshUser({ force: false })
   }, [refreshUser])
 
   // ── Profile edit modal state ─────────────────────────────────────────────────
@@ -210,15 +212,15 @@ const UserProfile = () => {
   const [sendingVerification, setSendingVerification] = useState(false)
 
   useEffect(() => {
-    if (!user) return
+    if (!userId) return
     const ac = new AbortController()
     setServicesLoading(true)
-    serviceAPI.list({ user_id: user.id, page_size: 50 }, ac.signal)
+    serviceAPI.list({ user_id: userId, page_size: 50 }, ac.signal)
       .then(setServices).catch(() => {}).finally(() => setServicesLoading(false))
     setHistoryLoading(true)
-    userAPI.getHistory(user.id, ac.signal)
+    userAPI.getHistory(userId, ac.signal)
       .then(setHistory).catch(() => {}).finally(() => setHistoryLoading(false))
-    userAPI.getBadgeProgress(user.id, ac.signal).then(setBadges).catch(() => {})
+    userAPI.getBadgeProgress(userId, ac.signal).then(setBadges).catch(() => {})
     setEventsLoading(true)
     handshakeAPI.list(ac.signal)
       .then((list) => setEventHandshakes(list.filter((h) => h.service_type === 'Event')))
@@ -226,19 +228,19 @@ const UserProfile = () => {
       .finally(() => setEventsLoading(false))
     setReviewsLoading(true)
     Promise.all([
-      userAPI.getVerifiedReviews(user.id, { role: 'provider', signal: ac.signal }),
-      userAPI.getVerifiedReviews(user.id, { role: 'receiver', signal: ac.signal }),
-      userAPI.getVerifiedReviews(user.id, { role: 'organizer', signal: ac.signal }),
+      userAPI.getVerifiedReviews(userId, { role: 'provider', signal: ac.signal }),
+      userAPI.getVerifiedReviews(userId, { role: 'receiver', signal: ac.signal }),
+      userAPI.getVerifiedReviews(userId, { role: 'organizer', signal: ac.signal }),
     ]).then(([rProvider, rTaker, rOrganizer]) => {
       setReviewsAsProvider(rProvider.results)
       setReviewsAsTaker(rTaker.results)
       setReviewsAsOrganizer(rOrganizer.results)
     }).catch(() => {}).finally(() => setReviewsLoading(false))
     return () => ac.abort()
-  }, [user])
+  }, [userId])
 
   useEffect(() => {
-    if (!user) return
+    if (!userId) return
     const relevant = eventHandshakes.filter((h) => ['accepted', 'checked_in', 'attended'].includes(h.status))
     const idsToFetch = Array.from(new Set(relevant.map(getHandshakeServiceId).filter(Boolean))).filter(
       (id) => !(id in joinedEventServicesById),
@@ -254,7 +256,7 @@ const UserProfile = () => {
         if (Object.keys(next).length > 0) setJoinedEventServicesById((prev) => ({ ...prev, ...next }))
       }).catch(() => {})
     return () => ac.abort()
-  }, [user, eventHandshakes, joinedEventServicesById])
+  }, [userId, eventHandshakes, joinedEventServicesById])
 
   const handleChangePassword = async () => {
     if (!pwNew || !pwCurrent) { toast.error('Please fill in all password fields.'); return }

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -96,7 +96,10 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
   isLoading: false,
   error: null,
 
-  setUser: (user) => set({ user, isAuthenticated: !!user }),
+  setUser: (user) => {
+    lastUserRefreshAt = user ? Date.now() : 0
+    set({ user, isAuthenticated: !!user })
+  },
 
   setError: (error) => set({ error }),
 
@@ -115,6 +118,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
         user = await fetchCurrentUserSingleFlight()
       }
 
+      lastUserRefreshAt = Date.now()
       set({ user, isAuthenticated: true, isLoading: false })
     } catch (error) {
       set({ isLoading: false, error: getErrorMessage(error, 'Login failed') })
@@ -137,6 +141,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
         user = await fetchCurrentUserSingleFlight()
       }
 
+      lastUserRefreshAt = Date.now()
       set({ user, isAuthenticated: true, isLoading: false })
     } catch (error) {
       set({
@@ -155,6 +160,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
       // Ignore errors — clear state regardless
     }
     inFlightUserRequest = null
+    lastUserRefreshAt = 0
     set({ user: null, isAuthenticated: false, error: null })
   },
 
@@ -186,6 +192,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
     set({ isLoading: true })
     try {
       const user = await fetchCurrentUserSingleFlight()
+      lastUserRefreshAt = Date.now()
       set({ user, isAuthenticated: true, isLoading: false })
     } catch (error) {
       if (isRateLimitError(error)) {

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -3,10 +3,12 @@ import type { User } from '@/types'
 import apiClient, { getErrorMessage } from '@/services/api'
 
 let inFlightUserRequest: Promise<User> | null = null
+let lastUserRefreshAt = 0
 
 const RATE_LIMIT_STATUS = 429
 const MAX_ME_RETRIES = 2
 const BACKOFF_BASE_MS = 300
+const SOFT_REFRESH_MIN_INTERVAL_MS = 30_000
 
 const sleep = (ms: number) => new Promise((resolve) => {
   window.setTimeout(resolve, ms)
@@ -82,7 +84,7 @@ interface AuthState {
     last_name: string
   }) => Promise<void>
   logout: () => Promise<void>
-  refreshUser: () => Promise<void>
+  refreshUser: (options?: { force?: boolean }) => Promise<void>
   checkAuth: (force?: boolean) => Promise<void>
   updateUserOptimistically: (updates: Partial<User>) => void
 }
@@ -156,10 +158,17 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
     set({ user: null, isAuthenticated: false, error: null })
   },
 
-  refreshUser: async () => {
+  refreshUser: async (options = { force: true }) => {
+    const force = options.force ?? true
+    const now = Date.now()
+    if (!force && lastUserRefreshAt > 0 && now - lastUserRefreshAt < SOFT_REFRESH_MIN_INTERVAL_MS) {
+      return
+    }
+
     try {
       inFlightUserRequest = null
       const user = await fetchCurrentUserFresh()
+      lastUserRefreshAt = Date.now()
       set({ user, isAuthenticated: true })
     } catch (error) {
       if (isRateLimitError(error)) {

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -208,6 +208,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
   updateUserOptimistically: (updates) => {
     const { user } = get()
     if (!user) return
+    lastUserRefreshAt = 0
     set({ user: { ...user, ...updates } })
   },
 }))

--- a/frontend/src/test/store/useAuthStore.test.ts
+++ b/frontend/src/test/store/useAuthStore.test.ts
@@ -143,6 +143,18 @@ describe('useAuthStore.refreshUser', () => {
     expect(apiMocks.get).not.toHaveBeenCalled()
   })
 
+  it('skips soft refresh after checkAuth already confirmed the user', async () => {
+    vi.setSystemTime(1_000)
+    apiMocks.get.mockResolvedValueOnce({ data: { id: 'u-fresh' } })
+    await useAuthStore.getState().checkAuth(true)
+
+    apiMocks.get.mockClear()
+    vi.setSystemTime(5_000)
+    await useAuthStore.getState().refreshUser({ force: false })
+
+    expect(apiMocks.get).not.toHaveBeenCalled()
+  })
+
   it('sets error on 429 but keeps existing state', async () => {
     useAuthStore.setState({ user: { id: 'cached' } as never, isAuthenticated: true })
     apiMocks.get.mockRejectedValue(Object.assign(new Error('429'), { response: { status: 429 } }))

--- a/frontend/src/test/store/useAuthStore.test.ts
+++ b/frontend/src/test/store/useAuthStore.test.ts
@@ -131,6 +131,18 @@ describe('useAuthStore.refreshUser', () => {
     expect(useAuthStore.getState().isAuthenticated).toBe(true)
   })
 
+  it('skips soft refreshes while the current profile snapshot is fresh', async () => {
+    vi.setSystemTime(1_000)
+    apiMocks.get.mockResolvedValueOnce({ data: { id: 'u-fresh' } })
+    await useAuthStore.getState().refreshUser()
+
+    apiMocks.get.mockClear()
+    vi.setSystemTime(5_000)
+    await useAuthStore.getState().refreshUser({ force: false })
+
+    expect(apiMocks.get).not.toHaveBeenCalled()
+  })
+
   it('sets error on 429 but keeps existing state', async () => {
     useAuthStore.setState({ user: { id: 'cached' } as never, isAuthenticated: true })
     apiMocks.get.mockRejectedValue(Object.assign(new Error('429'), { response: { status: 429 } }))

--- a/frontend/src/test/store/useAuthStore.test.ts
+++ b/frontend/src/test/store/useAuthStore.test.ts
@@ -193,6 +193,22 @@ describe('useAuthStore.updateUserOptimistically / setUser / setError', () => {
     expect(useAuthStore.getState().user).toMatchObject({ id: 'u', bio: 'new' })
   })
 
+  it('allows the next soft refresh after optimistic updates', async () => {
+    vi.setSystemTime(1_000)
+    apiMocks.get.mockResolvedValueOnce({ data: { id: 'u', bio: 'server' } })
+    await useAuthStore.getState().refreshUser()
+
+    useAuthStore.getState().updateUserOptimistically({ bio: 'optimistic' } as never)
+
+    apiMocks.get.mockClear()
+    apiMocks.get.mockResolvedValueOnce({ data: { id: 'u', bio: 'confirmed' } })
+    vi.setSystemTime(5_000)
+    await useAuthStore.getState().refreshUser({ force: false })
+
+    expect(apiMocks.get).toHaveBeenCalledTimes(1)
+    expect(useAuthStore.getState().user).toMatchObject({ id: 'u', bio: 'confirmed' })
+  })
+
   it('is a no-op when no user is set', () => {
     useAuthStore.getState().updateUserOptimistically({ bio: 'x' } as never)
     expect(useAuthStore.getState().user).toBeNull()

--- a/frontend/src/test/utils/profileDataLoad.test.ts
+++ b/frontend/src/test/utils/profileDataLoad.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { profileDataUserId } from '@/utils/profileDataLoad'
+
+describe('profileDataUserId', () => {
+  it('uses only the stable user id for profile data reload identity', () => {
+    expect(profileDataUserId(null)).toBeNull()
+    expect(profileDataUserId({ id: 'u-1', first_name: 'Old' })).toBe('u-1')
+    expect(profileDataUserId({ id: 'u-1', first_name: 'Fresh' })).toBe('u-1')
+    expect(profileDataUserId({ id: 'u-2', first_name: 'Fresh' })).toBe('u-2')
+  })
+})

--- a/frontend/src/test/utils/profileServices.test.ts
+++ b/frontend/src/test/utils/profileServices.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { Service } from '@/types'
+import { isOngoingProfileService } from '@/utils/profileServices'
+
+const serviceWithStatus = (status: Service['status']): Service => ({
+  id: status,
+  title: status,
+  description: '',
+  type: 'Offer',
+  duration: 1,
+  location_type: 'Online',
+  status,
+  max_participants: 1,
+  schedule_type: 'One-Time',
+  tags: [],
+  created_at: new Date().toISOString(),
+}) as Service
+
+describe('isOngoingProfileService', () => {
+  it('keeps active agreement services visible on profile service tabs', () => {
+    expect(isOngoingProfileService(serviceWithStatus('Active'))).toBe(true)
+    expect(isOngoingProfileService(serviceWithStatus('Agreed'))).toBe(true)
+    expect(isOngoingProfileService(serviceWithStatus('Completed'))).toBe(false)
+    expect(isOngoingProfileService(serviceWithStatus('Cancelled'))).toBe(false)
+  })
+})

--- a/frontend/src/utils/profileDataLoad.ts
+++ b/frontend/src/utils/profileDataLoad.ts
@@ -1,0 +1,4 @@
+export function profileDataUserId(user: { id?: string | number | null } | null | undefined): string | null {
+  if (user?.id == null) return null
+  return String(user.id)
+}

--- a/frontend/src/utils/profileServices.ts
+++ b/frontend/src/utils/profileServices.ts
@@ -1,0 +1,7 @@
+import type { Service } from '@/types'
+
+const PROFILE_ONGOING_STATUSES = new Set(['Active', 'Agreed'])
+
+export function isOngoingProfileService(service: Service): boolean {
+  return PROFILE_ONGOING_STATUSES.has(service.status)
+}

--- a/mobile-client/package-lock.json
+++ b/mobile-client/package-lock.json
@@ -10421,9 +10421,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10443,9 +10440,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10467,9 +10461,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10489,9 +10480,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/mobile-client/src/api/__tests__/authRefresh.test.ts
+++ b/mobile-client/src/api/__tests__/authRefresh.test.ts
@@ -1,0 +1,36 @@
+import {
+  USER_SOFT_REFRESH_MIN_INTERVAL_MS,
+  shouldSkipSoftUserRefresh,
+} from '../../utils/authRefresh';
+
+describe('auth refresh guard', () => {
+  it('skips non-forced user refreshes while the current snapshot is fresh', () => {
+    expect(
+      shouldSkipSoftUserRefresh({
+        force: false,
+        lastConfirmedAt: 1_000,
+        now: 1_000 + USER_SOFT_REFRESH_MIN_INTERVAL_MS - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows forced user refreshes even inside the soft refresh window', () => {
+    expect(
+      shouldSkipSoftUserRefresh({
+        force: true,
+        lastConfirmedAt: 1_000,
+        now: 2_000,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows soft user refreshes once the snapshot is stale', () => {
+    expect(
+      shouldSkipSoftUserRefresh({
+        force: false,
+        lastConfirmedAt: 1_000,
+        now: 1_000 + USER_SOFT_REFRESH_MIN_INTERVAL_MS,
+      }),
+    ).toBe(false);
+  });
+});

--- a/mobile-client/src/api/__tests__/authSessionGeneration.test.ts
+++ b/mobile-client/src/api/__tests__/authSessionGeneration.test.ts
@@ -1,0 +1,14 @@
+import {
+  isCurrentAuthSession,
+  nextAuthSessionGeneration,
+} from "../../utils/authRefresh";
+
+describe("auth session generation", () => {
+  it("marks in-flight work stale after the session generation advances", () => {
+    const startedAt = 0;
+    const afterLogout = nextAuthSessionGeneration(startedAt);
+
+    expect(isCurrentAuthSession(startedAt, startedAt)).toBe(true);
+    expect(isCurrentAuthSession(startedAt, afterLogout)).toBe(false);
+  });
+});

--- a/mobile-client/src/api/__tests__/profileServices.test.ts
+++ b/mobile-client/src/api/__tests__/profileServices.test.ts
@@ -1,0 +1,10 @@
+import { isOngoingProfileService } from "../../utils/profileServices";
+
+describe("profileServices", () => {
+  it("keeps agreed services visible on profile activity tabs", () => {
+    expect(isOngoingProfileService({ status: "Active" })).toBe(true);
+    expect(isOngoingProfileService({ status: "Agreed" })).toBe(true);
+    expect(isOngoingProfileService({ status: "Completed" })).toBe(false);
+    expect(isOngoingProfileService({ status: "Cancelled" })).toBe(false);
+  });
+});

--- a/mobile-client/src/context/AuthContext.tsx
+++ b/mobile-client/src/context/AuthContext.tsx
@@ -30,6 +30,7 @@ import {
   clearCurrentUser,
   clearAllUserCaches,
 } from "../cache/offlineCache";
+import { shouldSkipSoftUserRefresh } from "../utils/authRefresh";
 
 interface AuthState {
   user: UserSummary | null;
@@ -43,7 +44,20 @@ interface AuthContextValue extends AuthState {
   login: (body: LoginRequest) => Promise<void>;
   register: (body: RegisterRequest) => Promise<void>;
   logout: () => Promise<void>;
-  refreshUser: () => Promise<void>;
+  refreshUser: (options?: { force?: boolean }) => Promise<void>;
+}
+
+let inFlightUserRequest: Promise<UserSummary> | null = null;
+let lastConfirmedUserAt = 0;
+
+async function getMeSingleFlight(): Promise<UserSummary> {
+  if (inFlightUserRequest) return inFlightUserRequest;
+
+  inFlightUserRequest = getMe().finally(() => {
+    inFlightUserRequest = null;
+  });
+
+  return inFlightUserRequest;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -60,6 +74,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const persistUser = useCallback((u: UserSummary) => {
     setUser(u);
     setIsStale(false);
+    lastConfirmedUserAt = Date.now();
     try {
       saveCurrentUser(u);
     } catch {
@@ -70,6 +85,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const clearSessionLocal = useCallback(async (prevUserId: string | null) => {
     setUser(null);
     setIsStale(false);
+    lastConfirmedUserAt = 0;
+    inFlightUserRequest = null;
     clearCurrentUser();
     if (prevUserId) {
       try {
@@ -80,9 +97,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  const refreshUser = useCallback(async () => {
+  const refreshUser = useCallback(async (options?: { force?: boolean }) => {
+    const force = options?.force ?? true;
+    if (
+      shouldSkipSoftUserRefresh({
+        force,
+        lastConfirmedAt: lastConfirmedUserAt,
+        now: Date.now(),
+      })
+    ) {
+      return;
+    }
+
     try {
-      const u = await getMe();
+      const u = await getMeSingleFlight();
       persistUser(u);
     } catch (err) {
       if (err instanceof ApiNetworkError) {
@@ -95,7 +123,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (refresh) {
         try {
           await authApi.refresh({ refresh });
-          const u = await getMe();
+          const u = await getMeSingleFlight();
           persistUser(u);
           return;
         } catch (refreshErr) {
@@ -156,7 +184,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       try {
-        const u = await getMe();
+        const u = await getMeSingleFlight();
         if (cancelled) return;
         // Different user than cached? wipe the previous user's caches.
         if (cached && cached.data.id !== u.id) {
@@ -180,7 +208,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (refresh) {
           try {
             await authApi.refresh({ refresh });
-            const u = await getMe();
+            const u = await getMeSingleFlight();
             if (!cancelled) persistUser(u);
             return;
           } catch (refreshErr) {

--- a/mobile-client/src/context/AuthContext.tsx
+++ b/mobile-client/src/context/AuthContext.tsx
@@ -10,7 +10,7 @@
  *    HTTP 401 from `/auth/refresh/` clears the session.
  */
 
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import type { UserSummary } from "../api/types";
 import * as authApi from "../api/auth";
 import { useNotificationStore } from "../store/useNotificationStore";
@@ -30,7 +30,11 @@ import {
   clearCurrentUser,
   clearAllUserCaches,
 } from "../cache/offlineCache";
-import { shouldSkipSoftUserRefresh } from "../utils/authRefresh";
+import {
+  isCurrentAuthSession,
+  nextAuthSessionGeneration,
+  shouldSkipSoftUserRefresh,
+} from "../utils/authRefresh";
 
 interface AuthState {
   user: UserSummary | null;
@@ -70,6 +74,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<UserSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isStale, setIsStale] = useState(false);
+  const sessionGenerationRef = useRef(0);
 
   const persistUser = useCallback((u: UserSummary) => {
     setUser(u);
@@ -83,6 +88,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const clearSessionLocal = useCallback(async (prevUserId: string | null) => {
+    sessionGenerationRef.current = nextAuthSessionGeneration(sessionGenerationRef.current);
     setUser(null);
     setIsStale(false);
     lastConfirmedUserAt = 0;
@@ -99,6 +105,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refreshUser = useCallback(async (options?: { force?: boolean }) => {
     const force = options?.force ?? true;
+    const startedSessionGeneration = sessionGenerationRef.current;
     if (
       shouldSkipSoftUserRefresh({
         force,
@@ -111,6 +118,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     try {
       const u = await getMeSingleFlight();
+      if (!isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) return;
       persistUser(u);
     } catch (err) {
       if (err instanceof ApiNetworkError) {
@@ -123,7 +131,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (refresh) {
         try {
           await authApi.refresh({ refresh });
+          if (!isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) return;
           const u = await getMeSingleFlight();
+          if (!isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) return;
           persistUser(u);
           return;
         } catch (refreshErr) {
@@ -134,6 +144,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // fallthrough to logout
         }
       }
+      if (!isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) return;
       const prevId = user?.id ?? null;
       await authApi.logout();
       await clearSessionLocal(prevId);
@@ -158,6 +169,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = useCallback(async () => {
     const prevId = user?.id ?? null;
+    sessionGenerationRef.current = nextAuthSessionGeneration(sessionGenerationRef.current);
     await authApi.logout();
     useNotificationStore.getState().reset();
     await clearSessionLocal(prevId);
@@ -168,8 +180,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     initConnectivity();
 
     async function restoreSession() {
+      const startedSessionGeneration = sessionGenerationRef.current;
       const tokens = await getStoredTokens();
-      if (!tokens || cancelled) {
+      if (!tokens || cancelled || !isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) {
         setIsLoading(false);
         return;
       }
@@ -177,7 +190,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Hydrate from cached snapshot first so the shell renders immediately.
       const cached = await readCurrentUser();
-      if (cached && !cancelled) {
+      if (cached && !cancelled && isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) {
         setUser(cached.data);
         setIsStale(true);
         setIsLoading(false);
@@ -185,7 +198,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       try {
         const u = await getMeSingleFlight();
-        if (cancelled) return;
+        if (cancelled || !isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) return;
         // Different user than cached? wipe the previous user's caches.
         if (cached && cached.data.id !== u.id) {
           try {
@@ -209,7 +222,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           try {
             await authApi.refresh({ refresh });
             const u = await getMeSingleFlight();
-            if (!cancelled) persistUser(u);
+            if (!cancelled && isCurrentAuthSession(startedSessionGeneration, sessionGenerationRef.current)) persistUser(u);
             return;
           } catch (refreshErr) {
             if (cancelled) return;

--- a/mobile-client/src/presentation/screens/ProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/ProfileScreen.tsx
@@ -42,6 +42,7 @@ import {
   formatShortDate,
   getInitials,
 } from "../../utils/profileFormatters";
+import { isOngoingProfileService } from "../../utils/profileServices";
 import AchievementsSection from "../components/AchievementsSection";
 import ProfileSkillsSection from "../components/ProfileSkillsSection";
 import NotificationBadge from "../components/NotificationBadge";
@@ -235,9 +236,7 @@ export default function ProfileScreen() {
   };
 
   const fullName = `${form.first_name} ${form.last_name}`.trim();
-  const activeListingServices = activeServices.filter(
-    (service) => service.status === "Active",
-  );
+  const activeListingServices = activeServices.filter(isOngoingProfileService);
   const offerServices = activeListingServices.filter(
     (service) => service.type === "Offer",
   );

--- a/mobile-client/src/presentation/screens/ProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/ProfileScreen.tsx
@@ -111,7 +111,7 @@ export default function ProfileScreen() {
   useFocusEffect(
     useCallback(() => {
       if (!profileUserId) return;
-      void refreshUser();
+      void refreshUser({ force: false });
     }, [profileUserId, refreshUser]),
   );
 

--- a/mobile-client/src/utils/authRefresh.ts
+++ b/mobile-client/src/utils/authRefresh.ts
@@ -13,3 +13,11 @@ export function shouldSkipSoftUserRefresh({
 }): boolean {
   return !force && lastConfirmedAt > 0 && now - lastConfirmedAt < minIntervalMs;
 }
+
+export function nextAuthSessionGeneration(current: number): number {
+  return current + 1;
+}
+
+export function isCurrentAuthSession(startedAt: number, current: number): boolean {
+  return startedAt === current;
+}

--- a/mobile-client/src/utils/authRefresh.ts
+++ b/mobile-client/src/utils/authRefresh.ts
@@ -1,0 +1,15 @@
+export const USER_SOFT_REFRESH_MIN_INTERVAL_MS = 30_000;
+
+export function shouldSkipSoftUserRefresh({
+  force,
+  lastConfirmedAt,
+  now,
+  minIntervalMs = USER_SOFT_REFRESH_MIN_INTERVAL_MS,
+}: {
+  force: boolean;
+  lastConfirmedAt: number;
+  now: number;
+  minIntervalMs?: number;
+}): boolean {
+  return !force && lastConfirmedAt > 0 && now - lastConfirmedAt < minIntervalMs;
+}

--- a/mobile-client/src/utils/profileServices.ts
+++ b/mobile-client/src/utils/profileServices.ts
@@ -1,0 +1,5 @@
+const PROFILE_ONGOING_STATUSES = new Set(["Active", "Agreed"]);
+
+export function isOngoingProfileService(service: { status?: string | null }): boolean {
+  return PROFILE_ONGOING_STATUSES.has(service.status ?? "");
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                              
  Optimizes the `/users/me/` profile endpoint and reworks how the web/mobile clients refresh the cached profile snapshot. Three commits, on top of `dev`:                                                                                 
                                                                                                                                                                                                                                          
  1. **Backend prefetch overhaul on `UserProfileView`** (`1e54c93`) — collapses the nested-services prefetch into a single shared queryset, eliminating N+1 hot spots when a profile renders many service cards.                          
  2. **`Agreed`-status visibility in profile listings** (`486fe9a`) — adds `Agreed` services next to `Active` ones for owner/profile views, surfacing in-progress engagements that previously disappeared from the profile cards.         
  3. **Soft refresh + profile-data hardening** (`c1d7a5c`) — finishes the soft-refresh story across login/logout/checkAuth/setUser and introduces a small `profileDataUserId` helper to stop UserProfile effects from racing against a    
  stale `user` reference.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                          
  ## What changed                                                                                                                                                                                                                         
                  
  ### Backend (`backend/api/views.py`, `serializers.py`)                                                                                                                                                                                  
  - `UserProfileView.get_queryset` now builds **one** services queryset (`comment_count` annotation, `select_related('user', 'event_evaluation_summary')`) and reuses it for both admin and non-admin Prefetches. New prefetches:
    - `tags`                                                                                                                                                                                                                              
    - `user__badges` (with `select_related('badge')`)                                                                                                                                                                                     
    - `media` ordered by `display_order, created_at`                                                                                                                                                                                      
    - `capacity_handshakes` — filtered to capacity-relevant statuses, slimmed via `.only('id', 'service_id', 'status')`, attached as `to_attr` (consumed by `ServiceSerializer.get_capacity` to avoid per-row `Handshake.count`).         
  - For authenticated viewers, the queryset gets `is_saved_anno` / `is_dismissed_anno` `Exists()` annotations that the existing `ServiceSerializer.get_is_saved` / `get_is_dismissed` methods already know how to read.                   
  - `ServiceViewSet.get_queryset` accepts a `user` query param and expands the visible-status filter to `['Active', 'Agreed']` when serving a per-profile request, while disabling the list cache for `?user=…` queries.                  
                                                                                                                                                                                                                                          
  ### Frontend                                                                                                                                                                                                                            
  - `useAuthStore.refreshUser` accepts `{ force?: boolean }` and skips the `/users/me/` round-trip when the cached snapshot is younger than `SOFT_REFRESH_MIN_INTERVAL_MS` (30 s). `lastUserRefreshAt` is now updated/reset by **all**    
  authoritative state transitions: `login`, `register`, `setUser`, `checkAuth`, and `logout`.                                                                                                                                             
  - `App.tsx` now calls `refreshUser({ force: false })` on protected route changes — keeps fast-changing fields (e.g. time balance) reasonably fresh without flooding `/users/me/` on every navigation.
  - `UserProfile.tsx` switches to `profileDataUserId(user)` and re-keys all `useEffect`s on the resolved id, preventing stale-closure refetches when the auth user object is replaced in place.                                           
  - New utilities: `frontend/src/utils/profileServices.ts`, `frontend/src/utils/profileDataLoad.ts`.                                                                                                                                      
                                                                                                                                                                                                                                          
  ### Mobile                                                                                                                                                                                                                              
  - `AuthContext` mirrors the soft-refresh and adds `getMeSingleFlight()` to coalesce concurrent `/users/me/` calls. `clearSessionLocal` resets `lastConfirmedUserAt` and `inFlightUserRequest`.                                          
  - `ProfileScreen` `useFocusEffect` switches to `refreshUser({ force: false })` and uses `isOngoingProfileService` for active listing filtering.                                                                                         
  - New utilities: `mobile-client/src/utils/authRefresh.ts` (with `shouldSkipSoftUserRefresh`), `mobile-client/src/utils/profileServices.ts`.                                                                                             
                                                                                                                                                                                                                                          
  ## Tests                                                                                                                                                                                                                                
  - **Backend** — `test_user_api.py::test_me_profile_service_query_count_does_not_scale_per_service` exercises 3 → 12 services and asserts <15 query growth, locking in the prefetch behavior; `test_service_api.py` adds coverage for the
   `Active`/`Agreed` widening on the per-user feed.                                                                                                                                                                                       
  - **Frontend** — `useAuthStore.test.ts` adds soft-refresh assertions; new `profileServices.test.ts` and `profileDataLoad.test.ts` cover the helpers.                                                                                    
  - **Mobile** — `authRefresh.test.ts` and `profileServices.test.ts` cover the shared helpers (status thresholds, force flag, agreed-status filtering).
                                                                                                                                                                                                                                          
  ## Risk / Notes                                                                                                                                                                                                                         
  - Profile listings now show `Agreed` services. UI labelling is unchanged, so reviewers should sanity-check that an in-progress (`Agreed`) listing reads sensibly in the Offer/Need cards.                                               
  - Soft refresh is a 30 s window. `setUser`/`logout`/`login`/`register`/`checkAuth` all re-arm it, so multi-account flows stay correct; verify by logging out → in as a different user and confirming fresh data appears.                
  - `checkAuth retry on 429` suite shows two pre-existing failures (`retries up to MAX_ME_RETRIES then succeeds`, `keeps existing auth when retries exhaust on 429`) — they are unrelated to this branch's changes (retry/error-shape     
  assertions) but worth flagging; happy to fix in a follow-up if the team agrees.                                                                                                                                                         
                                                                                                                                                                                                                                          
  ## Test Plan                                                                                                                                                                                                                            
  - [ ] `cd backend && pytest api/tests/integration/test_user_api.py api/tests/integration/test_service_api.py`                                                                                                                           
  - [ ] `cd frontend && npx vitest run src/test/store/useAuthStore.test.ts src/test/utils/profileServices.test.ts src/test/utils/profileDataLoad.test.ts`
  - [ ] `cd mobile-client && npx jest src/api/__tests__/authRefresh.test.ts src/api/__tests__/profileServices.test.ts`                                                                                                                    
  - [ ] Manual: visit own profile, confirm Offer/Need tabs include `Agreed` services and tab counts match.                                                                                                                                
  - [ ] Manual: navigate between protected routes within 30 s — verify `/users/me/` is **not** re-hit (network tab); after 30 s a single request fires.                                                                                   
  - [ ] Manual: log out then log in as a different user — confirm the new user's `/users/me/` is fetched immediately (soft-refresh window resets on logout).                                                                              
  - [ ] Manual: open a profile with many services and verify there is no observable lag and DB query count stays bounded.                                                                                                                 
                                                                                                                                                                                                                                          
  ---                                                                              