### PR TITLE
chore(e2e): unbreak the full E2E feature suite (config + a11y user + CI gate)

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -282,14 +282,32 @@ jobs:
         id: feature
         if: steps.select.outputs.feature_tests != ''
         working-directory: frontend
-        continue-on-error: true  # soft-fail until suite is fully stable
+        continue-on-error: true  # soft-fail individual test failures until suite is fully stable
         env:
           PLAYWRIGHT_BASE_URL: http://localhost
           CI: "true"
+          FEATURE_TESTS: ${{ steps.select.outputs.feature_tests }}
         run: |
-          echo "Running feature tests: ${{ steps.select.outputs.feature_tests }}"
+          echo "Running feature tests: $FEATURE_TESTS"
           npx playwright test \
-            ${{ steps.select.outputs.feature_tests }}
+            $FEATURE_TESTS \
+            2>&1 | tee /tmp/playwright-feature.log
+
+      # ── 17b. Hard-fail on test-runner config errors ──────────────────────
+      # `continue-on-error` above swallows test failures, which we want
+      # while the suite stabilises. It also swallows config / parse errors
+      # that prevent the runner from starting at all — which we *don't*
+      # want, because that means zero tests ran. This step makes that
+      # specific failure mode block the job.
+      - name: Verify feature test runner actually executed
+        if: steps.feature.outcome != 'skipped'
+        run: |
+          if ! grep -qE "^Running [0-9]+ tests using" /tmp/playwright-feature.log; then
+            echo "::error::Playwright never started the feature suite (likely a config or parse error). Inspect the 'Run feature tests' step output."
+            tail -n 60 /tmp/playwright-feature.log || true
+            exit 1
+          fi
+          echo "Feature runner executed normally; per-test failures are soft-failed by design."
 
       # ── 18. Upload HTML report (always, so failures are inspectable) ──────
       - name: Upload Playwright HTML report

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -36,7 +36,7 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     env:
       DOCKER_BUILDKIT: "1"
       COMPOSE_DOCKER_CLI_BUILD: "1"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -61,7 +61,14 @@ export default defineConfig({
     },
     {
       name: 'chromium-mobile',
-      testMatch: ['**/responsive/**', '**/a11y/**', '**/feature-11/**'],
+      // Restrict to actual spec files. The directory globs without an
+      // extension constraint also pick up README.md / coverage notes,
+      // which Playwright then tries to parse as TypeScript and crashes.
+      testMatch: [
+        '**/responsive/**/*.@(spec|test).?(c|m)[jt]s?(x)',
+        '**/a11y/**/*.@(spec|test).?(c|m)[jt]s?(x)',
+        '**/feature-11/**/*.@(spec|test).?(c|m)[jt]s?(x)',
+      ],
       use: { ...devices['Pixel 7'] },
     },
   ],

--- a/frontend/tests/e2e/helpers/auth.ts
+++ b/frontend/tests/e2e/helpers/auth.ts
@@ -1,7 +1,7 @@
 import { type Page, expect } from '@playwright/test'
 
 // ─── Demo user credentials (seeded by setup_demo.py) ─────────────────────────
-export const USERS = {
+const DEMO_USERS = {
   elif:   { email: 'elif@demo.com',   password: 'demo123', name: 'Elif Yılmaz' },
   cem:    { email: 'cem@demo.com',    password: 'demo123', name: 'Cem Demir'   },
   ayse:   { email: 'ayse@demo.com',   password: 'demo123', name: 'Ayşe Kaya'   },
@@ -11,6 +11,14 @@ export const USERS = {
   deniz:  { email: 'deniz@demo.com',  password: 'demo123', name: 'Deniz Aydın' },
   burak:  { email: 'burak@demo.com',  password: 'demo123', name: 'Burak Kurt'  },
   yasemin:{ email: 'yasemin@demo.com',password: 'demo123', name: 'Yasemin Ergin' },
+} as const
+
+// `regular` is the role-agnostic alias used by tests that just need any
+// signed-in non-admin (e.g. the a11y baseline). Aliased to `cem` (member
+// role, no admin flag) so the seed stays the source of truth.
+export const USERS = {
+  ...DEMO_USERS,
+  regular: DEMO_USERS.cem,
 } as const
 
 export type DemoUser = (typeof USERS)[keyof typeof USERS]


### PR DESCRIPTION
## Summary

The full E2E feature suite has been silently broken in CI. Three small fixes restore it.

### 1. `chromium-mobile` testMatch matched non-spec files

`frontend/playwright.config.ts` listed three directory globs without an extension constraint:

```ts
testMatch: ['**/responsive/**', '**/a11y/**', '**/feature-11/**']
```

Those match every file in the directory, including `tests/e2e/feature-11/README.md`. Playwright tries to parse it as TypeScript, fails with `SyntaxError: Unexpected token (1:0)`, and aborts before running any test. This is why `workflow_dispatch run_all=true` runs (and any local attempt to run the chromium-mobile project) crash at discovery.

Tightened each glob to `*.@(spec|test).?(c|m)[jt]s?(x)`, mirroring the default testMatch.

**Verification:** `npx playwright test --list --project chromium-mobile` now reports `13 tests in 5 files` (was: SyntaxError exit). Full discovery: `338 tests in 175 files`.

### 2. `USERS.regular` was undefined

`frontend/tests/e2e/a11y/baseline.spec.ts` calls `loginAs(page, USERS.regular)` for every authenticated-page check (dashboard / profile / forum / search / create-offer / create-event). `USERS` in `helpers/auth.ts` only exported the named demo users; `USERS.regular` was `undefined`, `loginAs` blew up on `undefined.email`, and the page sat on `/login` for the rest of the test. axe then ran its critical-violation pass against the *login* page — every authenticated-page a11y check has been a silent no-op.

Aliased `USERS.regular` to the `cem` demo user (member role, no admin flag) so the seed stays the source of truth and existing per-user specs still resolve.

**Verification (against a healthy local stack):**
- before: 9 of 9 a11y baseline tests fail (all stuck on /login)
- after: 7 passed, 1 skipped, 1 failed — the remaining failure is a button-name drift in the create-offer modal, not a config issue

### 3. CI hid the runner-never-started failure mode

`.github/workflows/ci-e2e.yml` runs the feature tests with `continue-on-error: true` "until the suite is fully stable". That deliberately swallows individual test failures — fine — but it also swallows config / parse errors that prevent the runner from ever starting. The chromium-mobile crash has been masked this way: the step exits non-zero before any test runs, and the job conclusion stays green.

Capture the runner output with `tee`, then add a follow-up step that hard-fails the job if Playwright never printed its `Running N tests using M workers` header. Real test failures stay soft-failed by design; runner-never-started becomes a blocking signal.

---

## Why this matters

Before this PR, the full feature suite (~150 specs beyond the smoke set) had effectively never run cleanly in CI — every `workflow_dispatch run_all=true` and most full PR runs crashed at parse time and were silently soft-failed.

After this PR, that path actually executes, surfacing whatever real test failures the masked runs have been hiding. Those become follow-up bug-fix PRs.

## Test plan

- [ ] `Run feature tests` step prints `Running N tests using M workers` (visible in CI log)
- [ ] `Verify feature test runner actually executed` step is green
- [ ] If individual tests fail, the job still returns success (continue-on-error preserved)
- [ ] If a future commit introduces a parse error in the e2e tree, this job goes red instead of silently green