### PR TITLE
feat(api): enforce service edit permissions based on status

### DIFF
--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -315,6 +315,41 @@ class TestServiceViewSet:
         service.refresh_from_db()
         assert service.title == 'Updated Title'
 
+    def test_update_non_active_service_is_rejected_with_clear_403(self):
+        """Editing must be limited to Active services. Non-Active statuses must
+        return 403 with a status-aware message, not a misleading 404."""
+        owner = UserFactory()
+        client = AuthenticatedAPIClient().authenticate_user(owner)
+
+        for status_value in ('Agreed', 'Completed', 'Cancelled'):
+            service = ServiceFactory(user=owner, status=status_value, title='Original')
+            response = client.patch(
+                f'/api/services/{service.id}/', {'title': f'Renamed {status_value}'},
+            )
+            assert response.status_code == 403, (
+                f'PATCH on {status_value} service expected 403, got {response.status_code}.'
+            )
+            detail = str(response.data.get('detail') or response.data)
+            assert 'no longer be edited' in detail.lower() or status_value.lower() in detail.lower(), (
+                f'Expected status-aware error message for {status_value}, got: {detail}'
+            )
+            service.refresh_from_db()
+            assert service.title == 'Original', (
+                f'{status_value} service title was mutated despite 403 response.'
+            )
+
+    def test_update_active_hidden_service_is_allowed_for_owner(self):
+        """Owners must still be able to edit their own hidden (is_visible=False)
+        Active listings; the list visibility filter must not leak into writes."""
+        owner = UserFactory()
+        service = ServiceFactory(user=owner, status='Active', is_visible=False, title='Original')
+        client = AuthenticatedAPIClient().authenticate_user(owner)
+
+        response = client.patch(f'/api/services/{service.id}/', {'title': 'Renamed hidden'})
+        assert response.status_code == 200, response.data
+        service.refresh_from_db()
+        assert service.title == 'Renamed hidden'
+
     def test_update_offer_allowed_when_application_exists_and_notifies_applicant(self):
         """Offer owner can edit and pending applicants get notified."""
         owner = UserFactory()

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -326,13 +326,7 @@ class TestServiceViewSet:
             response = client.patch(
                 f'/api/services/{service.id}/', {'title': f'Renamed {status_value}'},
             )
-            assert response.status_code == 403, (
-                f'PATCH on {status_value} service expected 403, got {response.status_code}.'
-            )
-            detail = str(response.data.get('detail') or response.data)
-            assert 'no longer be edited' in detail.lower() or status_value.lower() in detail.lower(), (
-                f'Expected status-aware error message for {status_value}, got: {detail}'
-            )
+            assert_problem_detail(response, 403, contains_text='no longer be edited')
             service.refresh_from_db()
             assert service.title == 'Original', (
                 f'{status_value} service title was mutated despite 403 response.'
@@ -346,7 +340,7 @@ class TestServiceViewSet:
         client = AuthenticatedAPIClient().authenticate_user(owner)
 
         response = client.patch(f'/api/services/{service.id}/', {'title': 'Renamed hidden'})
-        assert response.status_code == 200, response.data
+        assert_api_response(response, 200, schema={'title': 'Renamed hidden'})
         service.refresh_from_db()
         assert service.title == 'Renamed hidden'
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2300,6 +2300,16 @@ class ServiceViewSet(viewsets.ModelViewSet):
 
     @track_performance
     def get_queryset(self):
+        # Owner edits/deletes must work for services in any status
+        # (Agreed/Completed/Cancelled/hidden). The list-time visibility filter
+        # below would otherwise hide them and produce a misleading 404.
+        # Authorization is enforced in perform_update / destroy.
+        if self.action in ('update', 'partial_update', 'destroy'):
+            return (
+                Service.objects
+                .select_related('user', 'event_evaluation_summary')
+                .prefetch_related('tags')
+            )
         user_param = self.request.query_params.get('user')
         # Use Prefetch object to optimize nested user badges query
         user_badges_prefetch = Prefetch(
@@ -2760,6 +2770,14 @@ class ServiceViewSet(viewsets.ModelViewSet):
             raise PermissionDenied('Attempting to modify another user\'s service')
 
         is_admin = getattr(self.request.user, 'role', None) == 'admin'
+
+        # Only Active services are editable. Once a service is Agreed, Completed,
+        # Cancelled or otherwise locked, surface a clear 403 instead of the
+        # misleading 404 that the list-time visibility filter used to produce.
+        if service.status != 'Active' and not is_admin:
+            raise PermissionDenied(
+                f'This service can no longer be edited (status: {service.status}).'
+            )
 
         if service.type == 'Event' and not is_admin:
             if service.is_in_lockdown_window:


### PR DESCRIPTION
## Summary

Closes the "edit on non-Active service returns a misleading 404" bug. The list-time queryset filter (`is_visible=True`, ranking annotations) was leaking into write actions, so owners hit `404` when patching their own `Active + is_visible=False` service, and `404` instead of a clear `403` when patching `Agreed`/`Completed`/`Cancelled` ones. This PR enforces the existing `Service.edit_lock_reason` contract on the server.

## Changes

**`backend/api/views.py`**

- `ServiceViewSet.get_queryset` — for `update`/`partial_update`/`destroy` actions, returns the unfiltered queryset so owners can always reach their own services. Auth is enforced downstream.
- `ServiceViewSet.perform_update` — rejects edits with `403 PermissionDenied("This service can no longer be edited (status: …).")` when `service.status != 'Active'`. Admins bypass.

**`backend/api/tests/integration/test_service_api.py` **

- `test_update_non_active_service_is_rejected_with_clear_403` — loops `Agreed`/`Completed`/`Cancelled`, asserts `403` + status-aware message via `assert_problem_detail`, confirms the title was not mutated.
- `test_update_active_hidden_service_is_allowed_for_owner` — owner can still PATCH their own hidden Active listing; verified via `assert_api_response(response, 200, schema={'title': 'Renamed hidden'})`.

## Why this contract

`Service.status = 'Cancelled'` is **soft-delete** (the `DELETE` handler at `views.py:2828` flips status, list queries `exclude(status='Cancelled')`, and the model's own `edit_lock_reason` already declares completed/cancelled as locked). PR enforces that contract on the API; it doesn't introduce new policy.

If a user wants to undo a "Remove listing", that should be a separate `POST /api/services/<id>/reactivate/` action — explicitly out of scope here, since loosening this rule would break soft-delete semantics.

## Test plan

- [x] `make test-assert-sweep` — clean.
- [x] `pytest api/tests/integration/test_service_api.py` — 52 passed.
- [ ] Manually PATCH `/api/services/<active-hidden-id>/` as the owner → `200` with the new title.
- [ ] Manually PATCH `/api/services/<agreed-id>/` as the owner → `403` with body `{"detail": "This service can no longer be edited (status: Agreed)."}`.
- [ ] PATCH another user's service as a non-admin → `403 "Attempting to modify another user's service"` (unchanged).
- [ ] PATCH any service as an admin regardless of status → `200`.

## CI

| Check | Status |
| --- | --- |
| `test (unit)` | ✅ |
| `test (integration)` | ✅ |
| `Playwright E2E` | ✅ |
| `CodeQL` × 3 | ✅ |
| `codecov/patch` | ✅ |
| `assert-sweep guardrail` | ✅ (after replacing raw `status_code ==` asserts with `assert_problem_detail` / `assert_api_response`) |

## Notes for reviewer

- **`404 → 403` for other users' services.** Because the write-action queryset no longer hides them, hitting `/api/services/<someone-else-id>/` now returns `403 "Attempting to modify another user's service"` instead of `404`. UUIDv4 ids make existence-harvesting impractical, but the behaviour change is intentional and worth knowing.
- **Slim write-action prefetches.** The override only `select_related`s `user`, `event_evaluation_summary` and prefetches `tags`. Sufficient today; if the PATCH response ever uses ranking annotations, those prefetches need to be added back here too.
- **Branch is behind `dev`.** Mergeable per GitHub, but rebase + local smoke before merge is wise.
