### PR TITLE
fix(forum): soft-delete topics so reports survive removal (#542)

### DIFF
--- a/backend/api/migrations/0080_forumtopic_soft_delete.py
+++ b/backend/api/migrations/0080_forumtopic_soft_delete.py
@@ -1,0 +1,48 @@
+"""Soft-delete support for ForumTopic.
+
+Adds `is_deleted` and `deleted_at` so that topic removal preserves any
+Report rows referencing the topic (Report.reported_forum_topic uses
+on_delete=CASCADE). Hard-deleting a topic previously wiped its entire
+moderation history; the soft-delete flag keeps reports intact while
+hiding the topic from public listings.
+
+Mirrors the existing ForumPost.is_deleted pattern.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0079_event_recurrence'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='forumtopic',
+            name='is_deleted',
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    'Soft delete flag. Hides topic from public views while '
+                    'preserving moderation history (reports).'
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name='forumtopic',
+            name='deleted_at',
+            field=models.DateTimeField(
+                null=True,
+                blank=True,
+                help_text='When the topic was soft-deleted',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='forumtopic',
+            index=models.Index(
+                fields=['category', 'is_deleted', '-created_at'],
+                name='api_forumto_categor_be09f6_idx',
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1155,6 +1155,11 @@ class ForumTopic(models.Model):
     body = models.TextField(max_length=10000)
     is_pinned = models.BooleanField(default=False, help_text='Pinned topics appear at the top')
     is_locked = models.BooleanField(default=False, help_text='Locked topics cannot receive new posts')
+    is_deleted = models.BooleanField(
+        default=False,
+        help_text='Soft delete flag. Hides topic from public views while preserving moderation history (reports).',
+    )
+    deleted_at = models.DateTimeField(null=True, blank=True, help_text='When the topic was soft-deleted')
     view_count = models.IntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -1168,6 +1173,7 @@ class ForumTopic(models.Model):
             models.Index(fields=['category', '-is_pinned', '-created_at']),
             models.Index(fields=['author', 'created_at']),
             models.Index(fields=['category', 'is_pinned']),
+            models.Index(fields=['category', 'is_deleted', '-created_at']),
         ]
 
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -3291,31 +3291,35 @@ class ForumCategorySerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_topic_count(self, obj):
-        """Return count of topics in this category"""
+        """Return count of non-deleted topics in this category"""
         if hasattr(obj, 'topic_count_annotated'):
             return obj.topic_count_annotated
-        return obj.topics.count()
+        return obj.topics.filter(is_deleted=False).count()
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_post_count(self, obj):
-        """Return count of all posts across topics in this category"""
+        """Return count of all posts across non-deleted topics in this category"""
         if hasattr(obj, 'post_count_annotated'):
             return obj.post_count_annotated
-        return ForumPost.objects.filter(topic__category=obj, is_deleted=False).count()
+        return ForumPost.objects.filter(
+            topic__category=obj,
+            topic__is_deleted=False,
+            is_deleted=False,
+        ).count()
 
     @extend_schema_field(OpenApiTypes.DATETIME)
     def get_last_activity(self, obj):
         """Return timestamp of most recent activity in this category"""
         if hasattr(obj, 'last_activity_annotated'):
             return obj.last_activity_annotated
-        
-        # Check most recent post
+
+        # Check most recent post (only on non-deleted topics)
         latest_post = ForumPost.objects.filter(
-            topic__category=obj, is_deleted=False
+            topic__category=obj, topic__is_deleted=False, is_deleted=False
         ).order_by('-created_at').first()
-        
-        # Check most recent topic
-        latest_topic = obj.topics.order_by('-created_at').first()
+
+        # Check most recent (non-deleted) topic
+        latest_topic = obj.topics.filter(is_deleted=False).order_by('-created_at').first()
         
         if latest_post and latest_topic:
             return max(latest_post.created_at, latest_topic.created_at)
@@ -3374,11 +3378,12 @@ class ForumTopicSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'category', 'category_name', 'category_slug',
             'author_id', 'author_name', 'author_avatar_url',
-            'title', 'body', 'is_pinned', 'is_locked', 'view_count',
+            'title', 'body', 'is_pinned', 'is_locked', 'is_deleted',
+            'view_count',
             'reply_count', 'last_activity', 'created_at', 'updated_at'
         ]
         read_only_fields = [
-            'id', 'author_id', 'is_pinned', 'is_locked', 
+            'id', 'author_id', 'is_pinned', 'is_locked', 'is_deleted',
             'view_count', 'created_at', 'updated_at'
         ]
 

--- a/backend/api/tests/integration/test_calendar_api.py
+++ b/backend/api/tests/integration/test_calendar_api.py
@@ -220,7 +220,14 @@ class TestMeCalendarItems:
         active_requester = UserFactory()
         svc = ServiceFactory(user=provider, type='Offer', duration=Decimal('2.00'), max_participants=3)
         scheduled = timezone.now() + timedelta(days=5)
-        completed_at = timezone.now() - timedelta(days=10)
+        # Pin the completion time to mid-day. The calendar models a completed
+        # session as ending at completed_at and starting duration hours earlier;
+        # if completed_at falls in the small hours the computed start crosses
+        # midnight and lands on the previous day, breaking the same-day
+        # assertion below.
+        completed_at = (timezone.now() - timedelta(days=10)).replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
         handshake = HandshakeFactory(
             service=svc, requester=requester, status='completed',
             scheduled_time=scheduled,

--- a/backend/api/tests/integration/test_forum_api.py
+++ b/backend/api/tests/integration/test_forum_api.py
@@ -1276,3 +1276,165 @@ class TestDeletedAuthorTraceability:
 
         assert results[deleted_topic_id]['author_name'] == '[Deleted User]'
         assert results[deleted_topic_id]['author_id'] is None
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestForumTopicSoftDelete:
+    """DELETE /api/forum/topics/<pk>/ soft-deletes the topic.
+
+    Reports filed against the topic (and its posts) must survive so the
+    moderation trail is not lost. Public list/detail/post views must hide
+    the topic.
+    """
+
+    def _delete_url(self, topic_id):
+        return f'/api/forum/topics/{topic_id}/'
+
+    def test_delete_topic_is_soft_delete(self):
+        """DELETE marks is_deleted=True instead of removing the row."""
+        author = UserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(author=author, category=category)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(author)
+
+        response = client.delete(self._delete_url(topic.id))
+        assert_api_response(response, 204)
+
+        topic.refresh_from_db()
+        assert topic.is_deleted is True
+        assert topic.deleted_at is not None
+        # Row still exists
+        assert ForumTopic.objects.filter(pk=topic.pk).exists()
+
+    def test_report_against_topic_survives_topic_deletion(self):
+        """Regression for #542: deleting a topic must NOT cascade-delete reports.
+
+        Before the fix, ForumTopicViewSet.destroy hard-deleted the row and
+        Report.reported_forum_topic (on_delete=CASCADE) wiped the report.
+        """
+        author = UserFactory()
+        reporter = UserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(author=author, category=category, title='Bad Topic')
+
+        # File a report against the topic and a report against a post in it.
+        post = ForumPostFactory(topic=topic, author=author)
+        topic_report = Report.objects.create(
+            reporter=reporter,
+            reported_user=author,
+            reported_forum_topic=topic,
+            type='spam',
+            description='Spammy topic',
+        )
+        post_report = Report.objects.create(
+            reporter=reporter,
+            reported_user=author,
+            reported_forum_topic=topic,
+            reported_forum_post=post,
+            type='harassment',
+            description='Abusive reply',
+        )
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(author)
+        response = client.delete(self._delete_url(topic.id))
+        assert_api_response(response, 204)
+
+        # Both reports remain queryable and still reference the topic row.
+        topic_report.refresh_from_db()
+        post_report.refresh_from_db()
+        assert Report.objects.filter(pk=topic_report.pk).exists()
+        assert Report.objects.filter(pk=post_report.pk).exists()
+        assert topic_report.reported_forum_topic_id == topic.id
+        assert post_report.reported_forum_topic_id == topic.id
+
+    def test_soft_deleted_topic_hidden_from_list(self):
+        """Public list must not return soft-deleted topics."""
+        category = ForumCategoryFactory(is_active=True)
+        live = ForumTopicFactory(category=category, title='Live topic')
+        ForumTopicFactory(category=category, title='Removed topic', is_deleted=True)
+
+        response = APIClient().get('/api/forum/topics/')
+        assert_api_response(response, 200)
+
+        ids = [t['id'] for t in response.data['results']]
+        assert str(live.id) in ids
+        # Removed topic is hidden
+        for entry in response.data['results']:
+            assert entry['title'] != 'Removed topic'
+
+    def test_soft_deleted_topic_returns_404_on_detail(self):
+        """GET /api/forum/topics/<pk>/ on a soft-deleted topic returns 404."""
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(category=category, is_deleted=True)
+
+        response = APIClient().get(f'/api/forum/topics/{topic.id}/')
+        assert_problem_detail(response, 404)
+
+    def test_soft_deleted_topic_blocks_post_creation(self):
+        """POST /api/forum/topics/<pk>/posts/ on a soft-deleted topic returns 404."""
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(category=category, is_deleted=True)
+        user = UserFactory()
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+        response = client.post(f'/api/forum/topics/{topic.id}/posts/', {'body': 'Hi'})
+
+        assert_problem_detail(response, 404)
+
+    def test_soft_deleted_topic_hides_posts_from_listing(self):
+        """GET posts on a soft-deleted topic returns 404 (topic not visible)."""
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(category=category, is_deleted=True)
+        ForumPostFactory(topic=topic)
+
+        response = APIClient().get(f'/api/forum/topics/{topic.id}/posts/')
+        assert_problem_detail(response, 404)
+
+    def test_unauthorized_delete_does_not_soft_delete(self):
+        """A non-author/non-admin DELETE returns 403 and the topic stays live."""
+        author = UserFactory()
+        other = UserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(author=author, category=category)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(other)
+
+        response = client.delete(self._delete_url(topic.id))
+        assert_problem_detail(response, 403)
+
+        topic.refresh_from_db()
+        assert topic.is_deleted is False
+
+    def test_admin_can_soft_delete_any_topic(self):
+        """Admins can soft-delete topics they did not author."""
+        author = UserFactory()
+        admin = AdminUserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(author=author, category=category)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(admin)
+
+        response = client.delete(self._delete_url(topic.id))
+        assert_api_response(response, 204)
+
+        topic.refresh_from_db()
+        assert topic.is_deleted is True
+
+    def test_double_delete_returns_404(self):
+        """Re-deleting an already soft-deleted topic returns 404 (not visible)."""
+        author = UserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(author=author, category=category, is_deleted=True)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(author)
+
+        response = client.delete(self._delete_url(topic.id))
+        assert_problem_detail(response, 404)

--- a/backend/api/tests/integration/test_forum_api.py
+++ b/backend/api/tests/integration/test_forum_api.py
@@ -1438,3 +1438,39 @@ class TestForumTopicSoftDelete:
 
         response = client.delete(self._delete_url(topic.id))
         assert_problem_detail(response, 404)
+
+    def test_staff_can_retrieve_soft_deleted_topic(self):
+        """Staff can GET /api/forum/topics/<pk>/ on a soft-deleted topic.
+
+        Soft-deleted topics are hidden from the public surface, but moderators
+        need a way to inspect the original content of a deleted topic when
+        triaging the surviving Report.reported_forum_topic rows. Staff bypass
+        the is_deleted filter on list/retrieve.
+        """
+        admin = AdminUserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        topic = ForumTopicFactory(category=category, title='Removed', is_deleted=True)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(admin)
+
+        response = client.get(f'/api/forum/topics/{topic.id}/')
+        assert_api_response(response, 200)
+        assert response.data['id'] == str(topic.id)
+        assert response.data['is_deleted'] is True
+
+    def test_staff_list_includes_soft_deleted_topics(self):
+        """Staff list response surfaces soft-deleted topics for moderation review."""
+        admin = AdminUserFactory()
+        category = ForumCategoryFactory(is_active=True)
+        live = ForumTopicFactory(category=category, title='Live')
+        removed = ForumTopicFactory(category=category, title='Removed', is_deleted=True)
+
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(admin)
+        response = client.get('/api/forum/topics/')
+        assert_api_response(response, 200)
+
+        ids = {t['id'] for t in response.data['results']}
+        assert str(live.id) in ids
+        assert str(removed.id) in ids

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7140,7 +7140,12 @@ class ForumCategoryViewSet(viewsets.ModelViewSet):
 
         # Annotate counts and last_activity inline so the serializer doesn't fan
         # out into per-category queries. Subqueries keep this O(1) total.
-        # Soft-deleted topics (and posts on them) are excluded from public counts.
+        # Soft-deleted topics (and posts on them) are excluded from these counts
+        # for every caller, including staff. Staff still see inactive categories
+        # (toggled above), but the counts here describe the public surface —
+        # admin moderation goes through AdminReportViewSet, which references the
+        # surviving Report rows directly, so surfacing soft-deleted topics in
+        # category aggregates would be misleading rather than useful.
         latest_post_at = (
             ForumPost.objects
             .filter(

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7140,21 +7140,32 @@ class ForumCategoryViewSet(viewsets.ModelViewSet):
 
         # Annotate counts and last_activity inline so the serializer doesn't fan
         # out into per-category queries. Subqueries keep this O(1) total.
+        # Soft-deleted topics (and posts on them) are excluded from public counts.
         latest_post_at = (
             ForumPost.objects
-            .filter(topic__category=OuterRef('pk'), is_deleted=False)
+            .filter(
+                topic__category=OuterRef('pk'),
+                topic__is_deleted=False,
+                is_deleted=False,
+            )
             .order_by('-created_at')
             .values('created_at')[:1]
         )
         latest_topic_at = (
             ForumTopic.objects
-            .filter(category=OuterRef('pk'))
+            .filter(category=OuterRef('pk'), is_deleted=False)
             .order_by('-created_at')
             .values('created_at')[:1]
         )
         queryset = queryset.annotate(
-            topic_count_annotated=Count('topics', distinct=True),
-            post_count_annotated=Count('topics__posts', filter=Q(topics__posts__is_deleted=False), distinct=True),
+            topic_count_annotated=Count(
+                'topics', filter=Q(topics__is_deleted=False), distinct=True
+            ),
+            post_count_annotated=Count(
+                'topics__posts',
+                filter=Q(topics__posts__is_deleted=False, topics__is_deleted=False),
+                distinct=True,
+            ),
             last_activity_annotated=Coalesce(
                 Greatest(Subquery(latest_post_at), Subquery(latest_topic_at)),
                 Subquery(latest_post_at),
@@ -7262,7 +7273,10 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
         return [permissions.IsAuthenticated()]
     
     def get_queryset(self):
-        queryset = ForumTopic.objects.select_related('author', 'category')
+        # Hide soft-deleted topics from public list/retrieve. Reports filed
+        # against them still reference the row in the database; only the
+        # public surface is suppressed.
+        queryset = ForumTopic.objects.select_related('author', 'category').filter(is_deleted=False)
 
         # Filter by category if provided
         category_slug = self.request.query_params.get('category')
@@ -7350,14 +7364,14 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
     def partial_update(self, request, pk=None):
         """Update a forum topic (author or admin only)"""
         try:
-            topic = ForumTopic.objects.get(pk=pk)
+            topic = ForumTopic.objects.get(pk=pk, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
                 code=ErrorCodes.NOT_FOUND,
                 status_code=status.HTTP_404_NOT_FOUND
             )
-        
+
         # Check permissions
         if topic.author != request.user and not request.user.is_staff:
             return create_error_response(
@@ -7365,28 +7379,35 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
                 code=ErrorCodes.PERMISSION_DENIED,
                 status_code=status.HTTP_403_FORBIDDEN
             )
-        
+
         # Only allow editing title and body
         allowed_fields = {'title', 'body'}
         update_data = {k: v for k, v in request.data.items() if k in allowed_fields}
-        
+
         serializer = self.get_serializer(topic, data=update_data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
-    
+
     @track_performance
     def destroy(self, request, pk=None):
-        """Delete a forum topic (author or admin only)"""
+        """Soft-delete a forum topic (author or admin only).
+
+        The topic row is preserved (with is_deleted=True) so that any
+        Report.reported_forum_topic rows pointing at it survive — the
+        FK uses on_delete=CASCADE, so a hard delete would wipe the
+        moderation trail. The topic is hidden from public list/detail
+        querysets via the is_deleted=False filter.
+        """
         try:
-            topic = ForumTopic.objects.get(pk=pk)
+            topic = ForumTopic.objects.get(pk=pk, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
                 code=ErrorCodes.NOT_FOUND,
                 status_code=status.HTTP_404_NOT_FOUND
             )
-        
+
         # Check permissions
         if topic.author != request.user and not request.user.is_staff:
             return create_error_response(
@@ -7394,8 +7415,11 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
                 code=ErrorCodes.PERMISSION_DENIED,
                 status_code=status.HTTP_403_FORBIDDEN
             )
-        
-        topic.delete()
+
+        # Soft delete — preserve reports filed against this topic.
+        topic.is_deleted = True
+        topic.deleted_at = timezone.now()
+        topic.save(update_fields=['is_deleted', 'deleted_at', 'updated_at'])
         return Response(status=status.HTTP_204_NO_CONTENT)
     
     @action(detail=True, methods=['post'])
@@ -7403,30 +7427,30 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
     def pin(self, request, pk=None):
         """Pin or unpin a topic (admin only)"""
         try:
-            topic = ForumTopic.objects.get(pk=pk)
+            topic = ForumTopic.objects.get(pk=pk, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
                 code=ErrorCodes.NOT_FOUND,
                 status_code=status.HTTP_404_NOT_FOUND
             )
-        
+
         topic.is_pinned = not topic.is_pinned
         topic.save(update_fields=['is_pinned'])
 
         if request.user.role in ADMIN_ROLES:
             state = 'Pinned' if topic.is_pinned else 'Unpinned'
             log_admin_action(request.user, 'pin_topic', 'forum_topic', topic, state)
-        
+
         serializer = self.get_serializer(topic)
         return Response(serializer.data)
-    
+
     @action(detail=True, methods=['post'])
     @track_performance
     def lock(self, request, pk=None):
         """Lock or unlock a topic (admin only)"""
         try:
-            topic = ForumTopic.objects.get(pk=pk)
+            topic = ForumTopic.objects.get(pk=pk, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
@@ -7449,7 +7473,7 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
     def report(self, request, pk=None):
         """Report a forum topic for moderation."""
         try:
-            topic = ForumTopic.objects.get(pk=pk, category__is_active=True)
+            topic = ForumTopic.objects.get(pk=pk, category__is_active=True, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
@@ -7526,6 +7550,7 @@ class ForumActivityView(APIView):
         topic_queryset = ForumTopic.objects.filter(
             author=request.user,
             category__is_active=True,
+            is_deleted=False,
         )
         open_topic_queryset = (
             topic_queryset
@@ -7540,6 +7565,7 @@ class ForumActivityView(APIView):
                 'my_replies': ForumPost.objects.filter(
                     topic__author=request.user,
                     topic__category__is_active=True,
+                    topic__is_deleted=False,
                     is_deleted=False,
                 ).count(),
                 'open_topics': topic_queryset.filter(is_locked=False).count(),
@@ -7578,7 +7604,11 @@ class ForumPostViewSet(viewsets.ViewSet):
         from .serializers import ForumRecentPostSerializer
 
         posts = (
-            ForumPost.objects.filter(is_deleted=False, topic__category__is_active=True)
+            ForumPost.objects.filter(
+                is_deleted=False,
+                topic__category__is_active=True,
+                topic__is_deleted=False,
+            )
             .select_related('author', 'topic', 'topic__category')
             .order_by('-created_at')
         )
@@ -7597,7 +7627,7 @@ class ForumPostViewSet(viewsets.ViewSet):
     def list(self, request, topic_id=None):
         """List posts in a forum topic"""
         try:
-            topic = ForumTopic.objects.get(pk=topic_id, category__is_active=True)
+            topic = ForumTopic.objects.get(pk=topic_id, category__is_active=True, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
@@ -7623,7 +7653,7 @@ class ForumPostViewSet(viewsets.ViewSet):
     def create(self, request, topic_id=None):
         """Create a new post in a forum topic"""
         try:
-            topic = ForumTopic.objects.get(pk=topic_id, category__is_active=True)
+            topic = ForumTopic.objects.get(pk=topic_id, category__is_active=True, is_deleted=False)
         except ForumTopic.DoesNotExist:
             return create_error_response(
                 'Topic not found',
@@ -7726,7 +7756,11 @@ class ForumPostViewSet(viewsets.ViewSet):
     def report(self, request, pk=None):
         """Report a forum post/reply for moderation."""
         try:
-            post = ForumPost.objects.select_related('topic', 'author').get(pk=pk, topic__category__is_active=True)
+            post = ForumPost.objects.select_related('topic', 'author').get(
+                pk=pk,
+                topic__category__is_active=True,
+                topic__is_deleted=False,
+            )
         except ForumPost.DoesNotExist:
             return create_error_response(
                 'Post not found',

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7278,10 +7278,15 @@ class ForumTopicViewSet(viewsets.ModelViewSet):
         return [permissions.IsAuthenticated()]
     
     def get_queryset(self):
-        # Hide soft-deleted topics from public list/retrieve. Reports filed
-        # against them still reference the row in the database; only the
-        # public surface is suppressed.
-        queryset = ForumTopic.objects.select_related('author', 'category').filter(is_deleted=False)
+        # Hide soft-deleted topics from the public list/retrieve. Reports filed
+        # against them still reference the row in the database; only the public
+        # surface is suppressed. Staff/admin callers see soft-deleted topics so
+        # they can navigate to a specific deleted topic and review its content
+        # for moderation (the destroy/edit/pin/lock/report paths still 404 on
+        # soft-deleted rows because they query is_deleted=False directly).
+        queryset = ForumTopic.objects.select_related('author', 'category')
+        if not self.request.user.is_staff:
+            queryset = queryset.filter(is_deleted=False)
 
         # Filter by category if provided
         category_slug = self.request.query_params.get('category')


### PR DESCRIPTION
## Bug

`ForumTopicViewSet.destroy` (`backend/api/views.py:7222-7242`) called `topic.delete()` and hard-deleted the row. `Report.reported_forum_topic` is declared `on_delete=models.CASCADE` (`backend/api/models.py:728`), so removing a forum topic also wiped every `Report` filed against the topic and against any of its posts. Removing a single bad reply already preserved its reports via `ForumPost.is_deleted`; topics had no equivalent path, so admins lost the moderation trail the moment a topic was deleted.

Closes #542.

## Root cause

`ForumTopic` has no soft-delete flag, and the destroy path executes a SQL `DELETE`. The cascading FK on `Report.reported_forum_topic` then propagates the delete to every related report row.

## Fix approach — Path A (soft-delete the topic)

Picked Path A from the issue brief because it is the smaller, safer change: it mirrors the existing `ForumPost.is_deleted` pattern, requires no schema migration on `Report`, and keeps the FK semantics intact. Path B (snapshot + `SET_NULL`) would have required a `Report` schema change and signal/snapshotting wiring, with no real upside for this codebase.

What changed:

- `ForumTopic` gains `is_deleted` (default `False`) and `deleted_at` (nullable). New index on `(category, is_deleted, -created_at)`.
- `ForumTopicViewSet.destroy` flips `is_deleted=True` and stamps `deleted_at` instead of deleting the row.
- All public-facing topic and post querysets filter `is_deleted=False`, so soft-deleted topics disappear from list/detail/recent posts/my-activity/category counts.
- `pin`, `lock`, `report`, and `partial_update` on the topic view, plus the post `list`/`create`/`report` paths, return 404 on a soft-deleted topic.
- `ForumCategoryViewSet` annotations and `ForumCategorySerializer` counts (`topic_count`, `post_count`, `last_activity`) exclude soft-deleted topics so the public surface matches. Counts always exclude soft-deleted topics, including for staff requests, since admin moderation reaches deleted topics through the admin reports queue rather than category aggregates.
- `ForumTopicSerializer` exposes `is_deleted` (read-only) for admin consumers.
- `ForumTopicViewSet.get_queryset` skips the `is_deleted=False` filter when `request.user.is_staff`, so moderators can navigate to a specific deleted topic and review its content for the trail. The destroy/edit/pin/lock/report paths still query `is_deleted=False` directly, so they continue to 404 on soft-deleted topics for everyone.
- The admin moderation queue still resolves the topic title via the existing `ReportSerializer.get_reported_forum_topic_title` because the FK is no longer broken.

## Out-of-scope hitchhiker: calendar history flake

`backend/api/tests/integration/test_calendar_api.py::test_includes_completed_handshakes_for_history_calendar` is unrelated to forum soft-delete, but it was the only other integration failure showing up on this branch's CI run. The test asserted that a completed handshake's calendar `start` date matches `completed_at.date()`; the calendar models a completed session as ending at `completed_at` and starting `duration` hours earlier, so when CI runs in the small hours of UTC the computed start crossed midnight and landed on the previous day. Pinning `completed_at` to noon makes the assertion deterministic across CI launch windows.

The same fix is also landing on PR #571; bringing it onto this branch keeps this PR's integration matrix green so the assert-sweep job is the only signal we read.

## Files changed

- `backend/api/models.py` — `ForumTopic.is_deleted`, `deleted_at`, new composite index.
- `backend/api/migrations/0080_forumtopic_soft_delete.py` — new migration adding the two fields and the index.
- `backend/api/views.py` — `ForumTopicViewSet.destroy` soft-deletes; list/detail filter `is_deleted=False` for non-staff; edit/pin/lock/report filter `is_deleted=False` directly; `ForumPostViewSet` and `ForumActivityView` exclude soft-deleted topics; `ForumCategoryViewSet` annotations updated.
- `backend/api/serializers.py` — `ForumCategorySerializer` counts exclude soft-deleted topics; `ForumTopicSerializer` exposes `is_deleted`.
- `backend/api/tests/integration/test_forum_api.py` — new `TestForumTopicSoftDelete` class with the regression test plus supporting cases (including staff-can-retrieve and staff-list coverage). Updated `TestForumPostRestore` docstring to reflect the new behaviour.
- `backend/api/tests/integration/test_calendar_api.py` — pin `completed_at` to noon in the history-calendar test (out-of-scope flake fix, see section above).

## Verification

```
cd backend
.venv/bin/python -m pytest api/tests/integration/test_forum_api.py --no-cov -q
# all forum integration tests pass, including the new soft-delete class

.venv/bin/python -m pytest api/tests/integration/test_forum_api.py api/tests/integration/test_calendar_api.py --no-cov
# 110 passed locally
```

## Manual verification steps

1. As any user, open a topic in an active category and confirm it appears in `GET /api/forum/topics/`.
2. File a report against the topic via `POST /api/forum/topics/<pk>/report/`.
3. Delete the topic with `DELETE /api/forum/topics/<pk>/` as the author.
4. Confirm:
   - `GET /api/forum/topics/<pk>/` returns 404 for unauthenticated/non-staff callers.
   - `GET /api/forum/topics/<pk>/` returns 200 for staff so the deleted topic can be reviewed.
   - The topic no longer appears in `GET /api/forum/topics/` for non-staff callers.
   - The admin moderation queue (`GET /api/admin/reports/`) still shows the report row, with the topic title still populated via `reported_forum_topic_title`.
5. Confirm `POST /api/forum/topics/<pk>/posts/` on the soft-deleted topic returns 404.

Closes #542