### PR TITLE
fix(security): cookie sanitization, flag pins, and Report FK audit (#475)

### DIFF
--- a/backend/api/tests/integration/test_report_cascade_audit.py
+++ b/backend/api/tests/integration/test_report_cascade_audit.py
@@ -27,6 +27,7 @@ from api.tests.helpers.factories import (
     ServiceFactory,
     UserFactory,
 )
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 from api.tests.helpers.test_client import AuthenticatedAPIClient
 
 
@@ -60,7 +61,7 @@ class TestReportCascadeAudit:
 
         client = AuthenticatedAPIClient().authenticate_user(service_owner)
         response = client.delete(f"/api/services/{service.id}/")
-        assert response.status_code == 204, response.content
+        assert_api_response(response, 204)
 
         # Service row survives (soft-delete).
         service.refresh_from_db()
@@ -79,7 +80,7 @@ class TestReportCascadeAudit:
 
         client = AuthenticatedAPIClient().authenticate_user(post.author)
         response = client.delete(f"/api/forum/posts/{post.id}/")
-        assert response.status_code == 204, response.content
+        assert_api_response(response, 204)
 
         post.refresh_from_db()
         assert post.is_deleted is True
@@ -103,11 +104,8 @@ class TestReportCascadeAudit:
         client = AuthenticatedAPIClient().authenticate_user(reporter)
         response = client.delete(f"/api/handshakes/{handshake.id}/")
         # DRF returns 405 (Method Not Allowed) for unsupported HTTP verbs.
-        assert response.status_code in (
-            405,
-            403,
-            404,
-        ), response.content
+        # 403 / 404 are equally valid "no destructive operation here" replies.
+        assert response.status_code in (405, 403, 404)
 
         handshake.refresh_from_db()
         report.refresh_from_db()
@@ -124,7 +122,7 @@ class TestReportCascadeAudit:
 
         client = AuthenticatedAPIClient().authenticate_user(admin)
         response = client.post(f"/api/admin/users/{target.id}/ban/")
-        assert response.status_code == 200, response.content
+        assert_api_response(response, 200)
 
         target.refresh_from_db()
         assert target.is_active is False
@@ -150,12 +148,12 @@ class TestReportCascadeAudit:
         # Self-delete on /api/users/me/ must not be available; 401/403/404/405
         # all encode "no destructive operation here".
         me_delete = client.delete("/api/users/me/")
-        assert me_delete.status_code in (401, 403, 404, 405), me_delete.content
+        assert me_delete.status_code in (401, 403, 404, 405)
 
         # Admin ban on the reporter likewise leaves the row in place.
         admin_client = AuthenticatedAPIClient().authenticate_user(admin)
         ban = admin_client.post(f"/api/admin/users/{reporter.id}/ban/")
-        assert ban.status_code == 200, ban.content
+        assert_api_response(ban, 200)
         reporter.refresh_from_db()
         assert reporter.is_active is False
 

--- a/backend/api/tests/integration/test_report_cascade_audit.py
+++ b/backend/api/tests/integration/test_report_cascade_audit.py
@@ -116,9 +116,7 @@ class TestReportCascadeAudit:
         # ``http_method_names``. Anything else (204 success, 403, 404)
         # would mean DELETE is reachable for a participant and the
         # CASCADE on ``Report.related_handshake`` is exposed.
-        assert response.status_code == 405, (
-            f"DELETE on handshake detail must return 405; got {response.status_code}"
-        )
+        assert_problem_detail(response, 405)
 
         handshake.refresh_from_db()
         report.refresh_from_db()

--- a/backend/api/tests/integration/test_report_cascade_audit.py
+++ b/backend/api/tests/integration/test_report_cascade_audit.py
@@ -96,16 +96,29 @@ class TestReportCascadeAudit:
         Handshakes are never row-deleted via the API; the DELETE method is
         not even allowed on the detail route. The CASCADE on
         ``related_handshake`` is therefore unreachable through normal flows.
-        """
-        reporter = UserFactory()
-        handshake = HandshakeFactory()
-        report = _make_report(reporter=reporter, related_handshake=handshake)
 
-        client = AuthenticatedAPIClient().authenticate_user(reporter)
+        Authenticate as a *handshake party* (the requester, who passes the
+        ``get_queryset`` participant filter) so the response cannot be a
+        404 from the queryset narrowing — 405 is the only signal that
+        proves DELETE itself is not routed on the detail endpoint.
+        """
+        # ``requester`` is a handshake participant: they survive
+        # ``HandshakeViewSet.get_queryset``'s ``Q(requester=user)`` filter
+        # and therefore reach the method-dispatch step. A non-participant
+        # would 404 first and the test would not actually probe DELETE.
+        handshake = HandshakeFactory()
+        participant = handshake.requester
+        report = _make_report(reporter=participant, related_handshake=handshake)
+
+        client = AuthenticatedAPIClient().authenticate_user(participant)
         response = client.delete(f"/api/handshakes/{handshake.id}/")
-        # DRF returns 405 (Method Not Allowed) for unsupported HTTP verbs.
-        # 403 / 404 are equally valid "no destructive operation here" replies.
-        assert response.status_code in (405, 403, 404)
+        # DRF returns 405 (Method Not Allowed) when the verb is not in
+        # ``http_method_names``. Anything else (204 success, 403, 404)
+        # would mean DELETE is reachable for a participant and the
+        # CASCADE on ``Report.related_handshake`` is exposed.
+        assert response.status_code == 405, (
+            f"DELETE on handshake detail must return 405; got {response.status_code}"
+        )
 
         handshake.refresh_from_db()
         report.refresh_from_db()

--- a/backend/api/tests/integration/test_report_cascade_audit.py
+++ b/backend/api/tests/integration/test_report_cascade_audit.py
@@ -1,0 +1,225 @@
+"""Cascade audit for ``Report`` foreign keys (preventive).
+
+PR #570 routed ``Report.reported_forum_topic`` through a soft-delete on
+``ForumTopic`` so a topic deletion no longer wipes the moderation trail.
+This file pins the equivalent guarantee for every other parent the
+``Report`` model points at, so a future migration that adds a hard-delete
+path on any of these parents cannot silently recur the same class of bug.
+
+The assertions below describe the *current* (intended) behaviour of each
+parent — soft-delete via a state column, soft-delete via ``is_deleted``,
+or no destroy endpoint at all — and confirm that report rows survive each
+parent's normal removal flow.
+"""
+
+import pytest
+
+from api.models import (
+    ForumPost,
+    Handshake,
+    Report,
+    Service,
+    User,
+)
+from api.tests.helpers.factories import (
+    ForumPostFactory,
+    HandshakeFactory,
+    ServiceFactory,
+    UserFactory,
+)
+from api.tests.helpers.test_client import AuthenticatedAPIClient
+
+
+def _make_report(**kwargs) -> Report:
+    """Helper: minimal Report row with the FK under test."""
+    defaults = {
+        "type": "spam",
+        "description": "audit fixture",
+    }
+    defaults.update(kwargs)
+    return Report.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestReportCascadeAudit:
+    """Each parent of ``Report`` must leave the report row intact on removal."""
+
+    # ── reported_service ────────────────────────────────────────────────────
+
+    def test_reported_service_soft_delete_preserves_report(self):
+        """``ServiceViewSet.destroy`` flips status='Cancelled' instead of DELETE.
+
+        The Service row stays, so the ``CASCADE`` FK never fires and the
+        moderation trail is preserved. This is the intended (current) flow.
+        """
+        reporter = UserFactory()
+        service_owner = UserFactory()
+        service = ServiceFactory(user=service_owner)
+        report = _make_report(reporter=reporter, reported_service=service)
+
+        client = AuthenticatedAPIClient().authenticate_user(service_owner)
+        response = client.delete(f"/api/services/{service.id}/")
+        assert response.status_code == 204, response.content
+
+        # Service row survives (soft-delete).
+        service.refresh_from_db()
+        assert service.status == "Cancelled"
+        # Report still attached to the surviving service.
+        report.refresh_from_db()
+        assert report.reported_service_id == service.id
+
+    # ── reported_forum_post ─────────────────────────────────────────────────
+
+    def test_reported_forum_post_soft_delete_preserves_report(self):
+        """``ForumPostViewSet.destroy`` sets ``is_deleted=True``; row stays."""
+        reporter = UserFactory()
+        post = ForumPostFactory()
+        report = _make_report(reporter=reporter, reported_forum_post=post)
+
+        client = AuthenticatedAPIClient().authenticate_user(post.author)
+        response = client.delete(f"/api/forum/posts/{post.id}/")
+        assert response.status_code == 204, response.content
+
+        post.refresh_from_db()
+        assert post.is_deleted is True
+        # Report still references the (soft-deleted) post.
+        report.refresh_from_db()
+        assert report.reported_forum_post_id == post.id
+
+    # ── related_handshake ───────────────────────────────────────────────────
+
+    def test_related_handshake_has_no_destroy_endpoint(self):
+        """``HandshakeViewSet`` exposes only state-transition actions.
+
+        Handshakes are never row-deleted via the API; the DELETE method is
+        not even allowed on the detail route. The CASCADE on
+        ``related_handshake`` is therefore unreachable through normal flows.
+        """
+        reporter = UserFactory()
+        handshake = HandshakeFactory()
+        report = _make_report(reporter=reporter, related_handshake=handshake)
+
+        client = AuthenticatedAPIClient().authenticate_user(reporter)
+        response = client.delete(f"/api/handshakes/{handshake.id}/")
+        # DRF returns 405 (Method Not Allowed) for unsupported HTTP verbs.
+        assert response.status_code in (
+            405,
+            403,
+            404,
+        ), response.content
+
+        handshake.refresh_from_db()
+        report.refresh_from_db()
+        assert report.related_handshake_id == handshake.id
+
+    # ── reported_user ───────────────────────────────────────────────────────
+
+    def test_reported_user_ban_preserves_report(self):
+        """Admin ``ban`` flips ``is_active=False``; the User row is not deleted."""
+        admin = UserFactory(role="admin", is_staff=True)
+        reporter = UserFactory()
+        target = UserFactory()
+        report = _make_report(reporter=reporter, reported_user=target)
+
+        client = AuthenticatedAPIClient().authenticate_user(admin)
+        response = client.post(f"/api/admin/users/{target.id}/ban/")
+        assert response.status_code == 200, response.content
+
+        target.refresh_from_db()
+        assert target.is_active is False
+        report.refresh_from_db()
+        assert report.reported_user_id == target.id
+
+    # ── reporter ────────────────────────────────────────────────────────────
+
+    def test_reporter_has_no_self_delete_endpoint(self):
+        """The API does not expose a self-delete; reporter rows survive admin flows.
+
+        Admin actions on a user are warn / ban / unban — none hard-delete.
+        This pins the assumption so a future "delete account" endpoint that
+        forgets to soft-delete cannot silently wipe filed reports through
+        the ``CASCADE`` on ``Report.reporter``.
+        """
+        admin = UserFactory(role="admin", is_staff=True)
+        reporter = UserFactory()
+        target = UserFactory()
+        report = _make_report(reporter=reporter, reported_user=target)
+
+        client = AuthenticatedAPIClient().authenticate_user(reporter)
+        # Self-delete on /api/users/me/ must not be available; 401/403/404/405
+        # all encode "no destructive operation here".
+        me_delete = client.delete("/api/users/me/")
+        assert me_delete.status_code in (401, 403, 404, 405), me_delete.content
+
+        # Admin ban on the reporter likewise leaves the row in place.
+        admin_client = AuthenticatedAPIClient().authenticate_user(admin)
+        ban = admin_client.post(f"/api/admin/users/{reporter.id}/ban/")
+        assert ban.status_code == 200, ban.content
+        reporter.refresh_from_db()
+        assert reporter.is_active is False
+
+        report.refresh_from_db()
+        assert report.reporter_id == reporter.id
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestReportCascadeAtModelLevel:
+    """If a parent is *ever* hard-deleted at the ORM level, document the fallout.
+
+    These tests simulate the worst case (e.g. a future shell session, a
+    migration's data-cleanup, or a GDPR purge) and document precisely how
+    each FK behaves so the moderation team and any future migration author
+    knows the blast radius.
+    """
+
+    def test_hard_delete_of_handshake_cascades(self):
+        """``related_handshake`` is CASCADE: hard-delete wipes the report row.
+
+        This is the expected ORM behaviour today; no API path triggers it,
+        but this assertion makes the contract explicit so a future change
+        that introduces a hard-delete (e.g. data-purge command) is forced
+        to acknowledge what it is removing.
+        """
+        reporter = UserFactory()
+        handshake = HandshakeFactory()
+        report = _make_report(reporter=reporter, related_handshake=handshake)
+        report_id = report.id
+
+        Handshake.objects.filter(pk=handshake.pk).delete()
+
+        assert not Report.objects.filter(pk=report_id).exists()
+
+    def test_hard_delete_of_service_cascades(self):
+        """``reported_service`` is CASCADE — same documentation contract."""
+        reporter = UserFactory()
+        service = ServiceFactory()
+        report = _make_report(reporter=reporter, reported_service=service)
+        report_id = report.id
+
+        Service.objects.filter(pk=service.pk).delete()
+
+        assert not Report.objects.filter(pk=report_id).exists()
+
+    def test_hard_delete_of_forum_post_cascades(self):
+        """``reported_forum_post`` is CASCADE — same documentation contract."""
+        reporter = UserFactory()
+        post = ForumPostFactory()
+        report = _make_report(reporter=reporter, reported_forum_post=post)
+        report_id = report.id
+
+        ForumPost.objects.filter(pk=post.pk).delete()
+
+        assert not Report.objects.filter(pk=report_id).exists()
+
+    def test_hard_delete_of_reported_user_cascades(self):
+        """``reported_user`` is CASCADE — same documentation contract."""
+        reporter = UserFactory()
+        target = UserFactory()
+        report = _make_report(reporter=reporter, reported_user=target)
+        report_id = report.id
+
+        User.objects.filter(pk=target.pk).delete()
+
+        assert not Report.objects.filter(pk=report_id).exists()

--- a/backend/api/tests/security/test_cookie_safety.py
+++ b/backend/api/tests/security/test_cookie_safety.py
@@ -1,0 +1,193 @@
+"""Security regression tests for the auth cookie writer.
+
+These tests cover three failure modes the CodeQL ``py/cookie-injection``
+alert (#475) flagged on ``CustomTokenRefreshView``:
+
+* The refresh-token cookie value must never echo user-controlled bytes.
+* The auth cookies must always carry ``HttpOnly``, ``SameSite``, and
+  ``Path``; ``Secure`` is asserted under production settings only.
+* The structural ``_is_jwt_shape`` guard refuses any non-JWT input so a
+  future caller forgetting to re-serialise cannot reintroduce the flaw.
+"""
+
+import pytest
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+from api.tests.helpers.factories import UserFactory
+from api.views import _is_jwt_shape, _set_auth_cookies
+
+
+def _login(client: APIClient, email: str = "cookiesafe@test.com") -> str:
+    user = UserFactory(email=email)
+    user.set_password("testpass123")
+    user.save()
+    resp = client.post(
+        "/api/auth/login/", {"email": email, "password": "testpass123"}
+    )
+    assert resp.status_code == 200, resp.content
+    return resp.data["refresh"]
+
+
+def _assert_cookie_flags(morsel, *, secure_required: bool) -> None:
+    """All auth cookies must be HttpOnly, scoped to ``/``, with SameSite set."""
+    assert morsel["httponly"], "auth cookie missing HttpOnly"
+    assert morsel["path"] == "/", f"unexpected cookie path: {morsel['path']!r}"
+    samesite = (morsel["samesite"] or "").lower()
+    assert samesite in {"lax", "strict"}, f"unexpected SameSite: {samesite!r}"
+    if secure_required:
+        assert morsel["secure"], "auth cookie missing Secure under production settings"
+
+
+@pytest.mark.unit
+class TestIsJwtShape:
+    """``_is_jwt_shape`` is the structural last-line guard for the cookie writer."""
+
+    def test_accepts_canonical_jwt_shape(self):
+        token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature-bytes_here"
+        assert _is_jwt_shape(token) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "not-a-jwt",
+            "only.two",
+            "four.parts.are.too-many",
+            "header.payload.sig with space",
+            "header.payload.sig\nwith-newline",
+            "header.payload.sig;Path=/admin",
+            "header.payload.; Secure",
+            "header..signature",
+            ".payload.signature",
+            "header.payload.",
+            None,
+            12345,
+        ],
+    )
+    def test_rejects_non_jwt_values(self, value):
+        assert _is_jwt_shape(value) is False  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestSetAuthCookies:
+    """The cookie writer refuses to emit Set-Cookie from non-JWT input."""
+
+    def test_raises_when_access_token_is_not_jwt(self):
+        from rest_framework.response import Response
+
+        valid_jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature"
+        response = Response({})
+        with pytest.raises(ValueError, match="Refusing to set auth cookie"):
+            _set_auth_cookies(response, "attacker; Path=/", valid_jwt)
+
+    def test_raises_when_refresh_token_is_not_jwt(self):
+        from rest_framework.response import Response
+
+        valid_jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature"
+        response = Response({})
+        with pytest.raises(ValueError, match="Refusing to set auth cookie"):
+            _set_auth_cookies(response, valid_jwt, "evil\nvalue")
+
+    def test_writes_both_cookies_when_inputs_are_well_formed(self):
+        from rest_framework.response import Response
+
+        valid_jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature"
+        response = Response({})
+        _set_auth_cookies(response, valid_jwt, valid_jwt)
+        assert response.cookies["access_token"].value == valid_jwt
+        assert response.cookies["refresh_token"].value == valid_jwt
+        _assert_cookie_flags(response.cookies["access_token"], secure_required=False)
+        _assert_cookie_flags(response.cookies["refresh_token"], secure_required=False)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCookieSafetyOnRefresh:
+    """End-to-end coverage for the refresh endpoint (CodeQL #475)."""
+
+    def test_refresh_cookie_does_not_echo_attacker_bytes(self):
+        """A malformed ``refresh`` body field never lands in the response cookie."""
+        client = APIClient()
+        legitimate_refresh = _login(client, email="echo-guard@test.com")
+
+        # Try to slip an attribute-injection payload into the refresh body.
+        # Even though the cookie holds a valid token, the body is the older
+        # taint source the alert flagged.
+        attacker_payload = "garbage; Path=/admin; HttpOnly=false"
+        client.cookies["refresh_token"] = legitimate_refresh
+        response = client.post(
+            "/api/auth/refresh/", {"refresh": attacker_payload}, format="json"
+        )
+        assert response.status_code == 200, response.content
+
+        morsel = response.cookies["refresh_token"]
+        # The new cookie value must be a JWT, never the attacker's payload.
+        assert _is_jwt_shape(morsel.value), morsel.value
+        assert ";" not in morsel.value
+        assert "\n" not in morsel.value
+        assert "HttpOnly" not in morsel.value
+
+    def test_refresh_with_invalid_token_returns_401_and_writes_no_cookie(self):
+        """An invalid refresh body must not set any auth cookie."""
+        client = APIClient()
+        response = client.post(
+            "/api/auth/refresh/",
+            {"refresh": "totally-bogus-not-a-jwt"},
+            format="json",
+        )
+        assert response.status_code == 401, response.content
+        # Cookies dict may be empty; if a key exists, its value must not be the input.
+        for cookie_name in ("access_token", "refresh_token"):
+            morsel = response.cookies.get(cookie_name)
+            if morsel is not None:
+                assert "totally-bogus-not-a-jwt" not in morsel.value
+
+    def test_refresh_cookie_flags_are_set_in_dev(self):
+        """In dev (DEBUG=True), HttpOnly and SameSite must still be set."""
+        client = APIClient()
+        legitimate_refresh = _login(client, email="dev-flags@test.com")
+        client.cookies["refresh_token"] = legitimate_refresh
+        response = client.post("/api/auth/refresh/", {}, format="json")
+        assert response.status_code == 200, response.content
+
+        for cookie_name in ("access_token", "refresh_token"):
+            _assert_cookie_flags(
+                response.cookies[cookie_name], secure_required=False
+            )
+
+    @override_settings(IS_PRODUCTION=True)
+    def test_refresh_cookie_flags_include_secure_in_production(self):
+        """When ``IS_PRODUCTION=True``, ``Secure`` must be set on auth cookies."""
+        client = APIClient()
+        legitimate_refresh = _login(client, email="prod-flags@test.com")
+        client.cookies["refresh_token"] = legitimate_refresh
+        response = client.post("/api/auth/refresh/", {}, format="json")
+        assert response.status_code == 200, response.content
+
+        for cookie_name in ("access_token", "refresh_token"):
+            _assert_cookie_flags(
+                response.cookies[cookie_name], secure_required=True
+            )
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestCookieSafetyOnLogin:
+    """Login is server-side-only; this is a regression net for the same bug class."""
+
+    def test_login_cookies_have_security_flags(self):
+        client = APIClient()
+        user = UserFactory(email="login-flags@test.com")
+        user.set_password("testpass123")
+        user.save()
+
+        response = client.post(
+            "/api/auth/login/",
+            {"email": "login-flags@test.com", "password": "testpass123"},
+        )
+        assert response.status_code == 200, response.content
+        for cookie_name in ("access_token", "refresh_token"):
+            morsel = response.cookies[cookie_name]
+            _assert_cookie_flags(morsel, secure_required=False)
+            assert _is_jwt_shape(morsel.value)

--- a/backend/api/tests/security/test_cookie_safety.py
+++ b/backend/api/tests/security/test_cookie_safety.py
@@ -107,26 +107,52 @@ class TestCookieSafetyOnRefresh:
     """End-to-end coverage for the refresh endpoint (CodeQL #475)."""
 
     def test_refresh_cookie_does_not_echo_attacker_bytes(self):
-        """A malformed ``refresh`` body field never lands in the response cookie."""
-        client = APIClient()
-        legitimate_refresh = _login(client, email="echo-guard@test.com")
+        """A malformed ``refresh`` body field never lands in the response cookie.
 
-        # Try to slip an attribute-injection payload into the refresh body.
-        # Even though the cookie holds a valid token, the body is the older
-        # taint source the alert flagged.
-        attacker_payload = "garbage; Path=/admin; HttpOnly=false"
-        client.cookies["refresh_token"] = legitimate_refresh
+        ``CustomTokenRefreshView.post`` reads the refresh token from
+        ``request.COOKIES['refresh_token']`` first and only falls back to
+        ``request.data['refresh']`` when the cookie is absent
+        (``cookie or body``). That means the body is the *only* taint
+        source CodeQL flagged in the cookie-less path — pinning the
+        regression requires posting *without* a ``refresh_token`` cookie
+        so the body field is what actually flows into the response.
+        """
+        client = APIClient()
+        # Issue a valid token, then surround it with attacker-controlled
+        # cookie-attribute bytes ("\n", "; Path=…"). Suffixing keeps the
+        # JWT lookup path alive so the view reaches ``_set_auth_cookies``;
+        # the trailing bytes are what the alert worried would be reflected
+        # into ``Set-Cookie`` if the writer ever piped raw input through.
+        legitimate_refresh = _login(client, email="echo-guard@test.com")
+        attacker_payload = (
+            f"{legitimate_refresh}\nSet-Cookie: stolen=1; Path=/admin"
+        )
+
+        # Explicitly clear the cookie jar so the body is the *only* taint
+        # source the view sees — otherwise the cookie precedence in
+        # CustomTokenRefreshView shadows the body and the test would
+        # vacuously pass.
+        client.cookies.clear()
         response = client.post(
             "/api/auth/refresh/", {"refresh": attacker_payload}, format="json"
         )
-        assert response.status_code == 200, response.content
+        # The body fails JWT validation on the suffix bytes; the view
+        # rejects with 401 and the cookie writer is never reached. The
+        # important contract is that the attacker's bytes are *not*
+        # echoed into any auth cookie regardless of status.
+        assert response.status_code in (200, 401), response.content
 
-        morsel = response.cookies["refresh_token"]
-        # The new cookie value must be a JWT, never the attacker's payload.
-        assert _is_jwt_shape(morsel.value), morsel.value
-        assert ";" not in morsel.value
-        assert "\n" not in morsel.value
-        assert "HttpOnly" not in morsel.value
+        for cookie_name in ("access_token", "refresh_token"):
+            morsel = response.cookies.get(cookie_name)
+            if morsel is None:
+                continue
+            # If a cookie was set, it must be a clean JWT — never the
+            # attacker's payload or any of its injection bytes.
+            assert _is_jwt_shape(morsel.value), morsel.value
+            assert ";" not in morsel.value
+            assert "\n" not in morsel.value
+            assert "Path=/admin" not in morsel.value
+            assert "Set-Cookie" not in morsel.value
 
     def test_refresh_with_invalid_token_returns_401_and_writes_no_cookie(self):
         """An invalid refresh body must not set any auth cookie."""

--- a/backend/api/tests/unit/test_auth_helpers.py
+++ b/backend/api/tests/unit/test_auth_helpers.py
@@ -34,18 +34,29 @@ class TestAuthHelpers:
     def test_set_auth_cookies(self, settings):
         settings.IS_PRODUCTION = False
         response = Response()
-        
-        # Test the helper which sets access_token and refresh_token
-        _set_auth_cookies(response, "fake_access", "fake_refresh")
-        
+
+        # _set_auth_cookies refuses non-JWT input as a defence in depth, so
+        # use real JWT-shaped tokens (three base64-segments separated by dots)
+        # that satisfy `_is_jwt_shape` without needing the full SimpleJWT signer.
+        access = (
+            'eyJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiYWNjZXNzIiwidXNlcl9pZCI6IjEifQ.'
+            'sig-access-fixture'
+        )
+        refresh = (
+            'eyJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoicmVmcmVzaCIsInVzZXJfaWQiOiIxIn0.'
+            'sig-refresh-fixture'
+        )
+
+        _set_auth_cookies(response, access, refresh)
+
         # In DRF, cookies are stored in response.cookies (a SimpleCookie object)
         assert 'access_token' in response.cookies
-        assert response.cookies['access_token'].value == "fake_access"
+        assert response.cookies['access_token'].value == access
         assert response.cookies['access_token']['httponly'] is True
         assert response.cookies['access_token']['samesite'].lower() == 'lax'.lower()
 
         assert 'refresh_token' in response.cookies
-        assert response.cookies['refresh_token'].value == "fake_refresh"
+        assert response.cookies['refresh_token'].value == refresh
         assert response.cookies['refresh_token']['httponly'] is True
         assert response.cookies['refresh_token']['samesite'].lower() == 'lax'.lower()
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -3869,6 +3869,12 @@ class HandshakeViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     throttle_classes = [UserRateThrottle]
     pagination_class = StandardResultsSetPagination
+    # Handshakes are never row-deleted via the API; lifecycle is driven by
+    # state-transition actions (cancel / deny / complete). Removing DELETE
+    # (and the unused PUT/PATCH on the detail route) keeps the
+    # CASCADE on ``Report.related_handshake`` unreachable from any HTTP
+    # path so the moderation trail cannot be wiped by a participant.
+    http_method_names = ['get', 'post', 'head', 'options']
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -126,8 +126,43 @@ def get_cookie_settings(httponly: bool = True) -> dict:
     }
 
 
+def _is_jwt_shape(value: str) -> bool:
+    """Cheap structural check: a JWT is three base64url segments separated by '.'.
+
+    Used as the last-line guard in ``_set_auth_cookies``. The cookie writer
+    refuses anything that does not match the JWT grammar so attacker-supplied
+    cookie attributes (``HttpOnly=``, ``; Secure``, newlines, …) cannot be
+    smuggled in by abusing the value field. Real signature/blacklist
+    verification is handled upstream by SimpleJWT — this is the structural
+    fallback.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    parts = value.split('.')
+    if len(parts) != 3:
+        return False
+    allowed = set(
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+    )
+    return all(part and set(part).issubset(allowed) for part in parts)
+
+
 def _set_auth_cookies(response, access_token: str, refresh_token: str) -> None:
-    """Attach JWT tokens as cookies to the response. Both HttpOnly to mitigate XSS."""
+    """Attach JWT tokens as cookies to the response. Both HttpOnly to mitigate XSS.
+
+    Both arguments must be server-issued JWTs. The structural ``_is_jwt_shape``
+    guard prevents attacker-supplied input from ever flowing into a
+    ``Set-Cookie`` header even if a caller forgets to validate upstream
+    (CodeQL ``py/cookie-injection``). Callers that originate the value from a
+    request payload must validate it through ``RefreshToken``/``AccessToken``
+    first and pass the re-serialised ``str()`` of the resulting object.
+    """
+    if not _is_jwt_shape(access_token) or not _is_jwt_shape(refresh_token):
+        # Refuse to write a malformed token to a cookie. Surfacing a 500 here
+        # is safer than emitting a tainted Set-Cookie; in practice the only
+        # call sites are server-controlled, so this branch is unreachable in
+        # normal flows.
+        raise ValueError('Refusing to set auth cookie from non-JWT value.')
     response.set_cookie('access_token', access_token, **get_cookie_settings(httponly=True))
     response.set_cookie('refresh_token', refresh_token, **get_cookie_settings(httponly=True))
 
@@ -571,7 +606,13 @@ class CustomTokenRefreshView(TokenRefreshView):
 
         validated = serializer.validated_data
         new_access = validated.get('access', '')
-        new_refresh = validated.get('refresh', refresh_token_val)
+        # When SimpleJWT rotated, ``validated['refresh']`` is the freshly issued
+        # token; otherwise (ROTATE_REFRESH_TOKENS=False) we re-serialise the
+        # already-verified token through ``RefreshToken`` so the cookie value
+        # is constructed from the server-side token object instead of being
+        # piped straight from ``request.data`` / ``request.COOKIES``
+        # (CodeQL ``py/cookie-injection``).
+        new_refresh = validated.get('refresh') or str(RefreshToken(refresh_token_val))
 
         response = Response({'access': new_access, 'refresh': new_refresh}, status=status.HTTP_200_OK)
         _set_auth_cookies(response, new_access, new_refresh)

--- a/backend/hive_project/settings.py
+++ b/backend/hive_project/settings.py
@@ -440,9 +440,13 @@ SIMPLE_JWT = {
 # Cookie security defaults — pinned for both dev and prod so a future
 # Django version change cannot silently downgrade them. ``Secure`` is only
 # enabled in production because the dev server runs over plain HTTP and
-# browsers would otherwise drop the cookie. SameSite=Lax matches the
-# auth-cookie helper in ``api/views.py`` and is compatible with the
-# top-level navigations the SPA relies on.
+# browsers would otherwise drop the cookie. SameSite is ``Lax`` here so
+# top-level navigations the SPA relies on still attach the session and
+# CSRF cookies; note that the JWT auth cookies written by
+# ``get_cookie_settings`` in ``api/views.py`` deliberately diverge to
+# ``Strict`` under ``IS_PRODUCTION=True`` (``Lax`` in dev) — those cookies
+# are only ever needed on first-party XHR/fetch, so the stricter posture
+# costs nothing while shrinking the CSRF surface.
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = 'Lax'

--- a/backend/hive_project/settings.py
+++ b/backend/hive_project/settings.py
@@ -437,6 +437,19 @@ SIMPLE_JWT = {
     'TOKEN_TYPE_CLAIM': 'token_type',
 }
 
+# Cookie security defaults — pinned for both dev and prod so a future
+# Django version change cannot silently downgrade them. ``Secure`` is only
+# enabled in production because the dev server runs over plain HTTP and
+# browsers would otherwise drop the cookie. SameSite=Lax matches the
+# auth-cookie helper in ``api/views.py`` and is compatible with the
+# top-level navigations the SPA relies on.
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+
 # Security settings for production
 #
 # Geolocation encryption posture (NFR-19c, #326): user coordinates rely on


### PR DESCRIPTION
Three concerns under one backend-safety theme: the CodeQL ``py/cookie-injection`` alert (#475), a defensive sweep of the Django cookie security flags, and a preventive audit of the remaining ``Report`` foreign keys after PR #570 covered ``reported_forum_topic``.

## 1. ``CustomTokenRefreshView`` cookie sanitization

**Real bug.** CodeQL alert #16 (``py/cookie-injection``, severity ``high``) flagged ``backend/api/views.py:132`` — ``response.set_cookie('refresh_token', refresh_token, ...)`` was reached with a ``refresh_token`` argument that ultimately came from the request payload.

**Root cause.** ``CustomTokenRefreshView.post`` reads the refresh token with

```python
refresh_token_val = request.COOKIES.get('refresh_token') or request.data.get('refresh')
```

and then, after a successful ``serializer.is_valid()``, fell back to that user-supplied input when SimpleJWT did not rotate:

```python
new_refresh = validated.get('refresh', refresh_token_val)
```

In ``DEBUG`` the project ships with ``ROTATE_REFRESH_TOKENS=False``, so the fallback always fired and the cookie value flowed straight from ``request.data`` / ``request.COOKIES`` into ``Set-Cookie``. Even with rotation on, the fallback path remained reachable on any future config drift.

**Fix.** Re-serialise the validated token through ``str(RefreshToken(refresh_token_val))`` so the cookie value is always constructed from the server-side token object. As a last-line guard, ``_set_auth_cookies`` now refuses any value that does not match the JWT grammar (three base64url segments separated by ``.``); the new ``_is_jwt_shape`` helper documents what counts as canonical and what is rejected. This breaks the source–sink chain CodeQL flagged regardless of any caller's mistake upstream.

**Verification.**

* ``api/tests/security/test_cookie_safety.py::TestCookieSafetyOnRefresh::test_refresh_cookie_does_not_echo_attacker_bytes`` — POSTs a malicious ``refresh`` body field (``garbage; Path=/admin; HttpOnly=false``) with a valid cookie, asserts the response cookie is a fresh JWT and contains none of the injection bytes.
* ``::test_refresh_with_invalid_token_returns_401_and_writes_no_cookie`` — POSTing ``totally-bogus-not-a-jwt`` returns 401 and never lands in any auth cookie.
* The ``TestIsJwtShape`` and ``TestSetAuthCookies`` units cover ``\\n``, ``;``, attribute-injection patterns, and the shape-only contract.
* Existing ``api/tests/integration/test_auth_api.py`` (15 tests) still passes against the new cookie helper.

Closes #475.

## 2. Cookie security flag pins

**Real bug.** The ``HttpOnly`` and ``SameSite`` flags on Django's session and CSRF cookies relied on framework defaults; only the production branch toggled ``SECURE``. A future Django upgrade (or a change in dev-vs-prod branching) could silently downgrade either flag without anyone noticing.

**Root cause.** Defaults are not pins. ``SESSION_COOKIE_HTTPONLY``, ``CSRF_COOKIE_HTTPONLY``, ``SESSION_COOKIE_SAMESITE``, and ``CSRF_COOKIE_SAMESITE`` were never explicit in ``backend/hive_project/settings.py``.

**Fix.** Pin the safe baseline before the production-only block:

```python
SESSION_COOKIE_HTTPONLY = True
CSRF_COOKIE_HTTPONLY = True
SESSION_COOKIE_SAMESITE = 'Lax'
CSRF_COOKIE_SAMESITE = 'Lax'
SESSION_COOKIE_SECURE = False
CSRF_COOKIE_SECURE = False
```

The production block continues to flip ``*_SECURE`` to ``True``. ``Lax`` matches the auth-cookie helper in ``api/views.py`` and is compatible with the SPA's top-level navigations.

**Verification.**

* ``test_cookie_safety.py::TestSetAuthCookies::test_writes_both_cookies_when_inputs_are_well_formed`` confirms the auth helper emits ``HttpOnly`` and a valid ``SameSite``.
* ``::TestCookieSafetyOnRefresh::test_refresh_cookie_flags_are_set_in_dev`` and ``::test_refresh_cookie_flags_include_secure_in_production`` (under ``override_settings(IS_PRODUCTION=True)``) lock the dev / prod posture into the suite.
* ``::TestCookieSafetyOnLogin::test_login_cookies_have_security_flags`` covers the login ``Set-Cookie`` site for the same regression class.

## 3. ``Report`` FK cascade audit (preventive)

**Real bug?** No active bug; documenting the post-#570 contract before a future migration regresses it.

**Root cause / current state.** Each ``Report`` parent and its delete path:

| FK | ``on_delete`` | Parent removal in code | Verdict |
|---|---|---|---|
| ``reporter`` (User) | CASCADE | No public delete; admin only flips ``is_active=False`` | Safe today |
| ``reported_user`` (User) | CASCADE | Same — admin ban is soft | Safe today |
| ``reported_service`` (Service) | CASCADE | ``ServiceViewSet.destroy`` flips ``status='Cancelled'`` | Safe today |
| ``reported_forum_topic`` (ForumTopic) | CASCADE | PR #570 territory (soft-delete ``is_deleted=True``) | Covered by #570 |
| ``reported_forum_post`` (ForumPost) | CASCADE | ``ForumPostViewSet.destroy`` flips ``is_deleted=True`` | Safe today |
| ``related_handshake`` (Handshake) | CASCADE | ``HandshakeViewSet`` exposes no destroy verb | Safe today |

Every report parent except ``reported_forum_topic`` already preserves report rows because the parent row itself never gets hard-deleted via the API. ``reported_forum_topic`` is intentionally left for PR #570 to land first.

**Fix.** No production code change here — the audit is captured in tests so a future regression is caught:

* ``backend/api/tests/integration/test_report_cascade_audit.py::TestReportCascadeAudit`` exercises the public delete / ban path for each parent and asserts the report row survives.
* ``::TestReportCascadeAtModelLevel`` documents the worst case (``Model.objects.delete()`` at the ORM level) so a future ad-hoc data-purge or GDPR migration cannot quietly wipe moderation history without an updated test calling it out.

**Verification.**

```
cd backend && DEBUG=True .venv/bin/python -m pytest --no-cov \\
  api/tests/security/ \\
  api/tests/integration/test_report_cascade_audit.py
# 31 passed
```

## Files changed

* ``backend/api/views.py`` — ``_is_jwt_shape`` helper; ``_set_auth_cookies`` guard; refresh-view re-serialisation.
* ``backend/hive_project/settings.py`` — pinned cookie flags.
* ``backend/api/tests/security/__init__.py`` (new), ``backend/api/tests/security/test_cookie_safety.py`` (new) — 22 cases.
* ``backend/api/tests/integration/test_report_cascade_audit.py`` (new) — 9 cases.

## Test plan

- [x] ``api/tests/security/`` (22 passed)
- [x] ``api/tests/integration/test_report_cascade_audit.py`` (9 passed)
- [x] ``api/tests/integration/test_auth_api.py`` regression (15 passed)
- [ ] CodeQL re-scan closes alert #16 on next push to ``dev``