### PR TITLE
fix(mobile): auth lifecycle, listener hygiene, and add-offer UX

### DIFF
--- a/mobile-client/src/__tests__/components/MapScreenFallback.test.tsx
+++ b/mobile-client/src/__tests__/components/MapScreenFallback.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Issue #453b: when the Mapbox token is missing or the HTML asset fails to
+ * load, the map screen used to render an empty WebView — a featureless,
+ * unexplained surface. Now it renders a labelled placeholder with a Retry CTA.
+ */
+
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+
+// Mock the env module BEFORE importing the screen so getMapboxToken() returns
+// undefined for the no-token test path.
+jest.mock('../../constants/env', () => ({
+  getMapboxToken: jest.fn(() => undefined),
+  getApiUrl: () => 'http://localhost/api',
+  normalizeRuntimeUrl: (v: string | null | undefined) => v,
+}))
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    canGoBack: () => false,
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+  }),
+}))
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@expo/vector-icons/Ionicons', () => 'Ionicons')
+jest.mock('@expo/vector-icons', () => ({ Ionicons: 'Ionicons' }))
+
+jest.mock('expo-asset', () => ({
+  Asset: { fromModule: () => ({ downloadAsync: jest.fn(), localUri: '' }) },
+}))
+
+jest.mock('expo-file-system', () => ({
+  File: jest.fn().mockImplementation(() => ({
+    text: jest.fn().mockResolvedValue('<html></html>'),
+  })),
+}))
+
+jest.mock('expo-location', () => ({
+  __esModule: true,
+  getForegroundPermissionsAsync: jest.fn().mockResolvedValue({ granted: false }),
+  requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ granted: false }),
+  getCurrentPositionAsync: jest.fn(),
+  Accuracy: { Balanced: 0 },
+}))
+
+jest.mock('react-native-webview', () => {
+  const React = require('react')
+  const { View } = require('react-native')
+  return {
+    __esModule: true,
+    default: React.forwardRef(({ testID }: { testID?: string }, _ref: unknown) =>
+      React.createElement(View, { testID: testID ?? 'mocked-webview' }),
+    ),
+  }
+})
+
+jest.mock('@react-native-community/slider', () => 'Slider')
+
+jest.mock('../../api/services', () => ({
+  listServices: jest.fn().mockResolvedValue({ results: [] }),
+}))
+
+import MapScreen from '../../presentation/screens/MapScreen'
+import * as env from '../../constants/env'
+
+describe('MapScreen fallback', () => {
+  beforeEach(() => {
+    ;(env.getMapboxToken as jest.Mock).mockReset()
+  })
+
+  it('shows the unavailable placeholder when no Mapbox token is configured', () => {
+    ;(env.getMapboxToken as jest.Mock).mockReturnValue(undefined)
+    const { getByText, getByLabelText, queryByTestId } = render(<MapScreen />)
+    expect(getByText('Map unavailable')).toBeTruthy()
+    expect(getByLabelText('Retry loading the map')).toBeTruthy()
+    // The WebView itself should not be on screen in the placeholder branch.
+    expect(queryByTestId('mocked-webview')).toBeNull()
+  })
+
+  it('exposes a retry CTA the user can tap', () => {
+    ;(env.getMapboxToken as jest.Mock).mockReturnValue(undefined)
+    const { getByLabelText } = render(<MapScreen />)
+    const retry = getByLabelText('Retry loading the map')
+    // No throw on press: the handler is wired and idempotent — re-running
+    // the fallback branch is safe because the token is still missing.
+    fireEvent.press(retry)
+    expect(getByLabelText('Retry loading the map')).toBeTruthy()
+  })
+})

--- a/mobile-client/src/__tests__/components/usePushNotifications.test.tsx
+++ b/mobile-client/src/__tests__/components/usePushNotifications.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Issue #453a: the notification-response listener stacked on every
+ * navigationRef identity change. A single push then fired N navigations.
+ *
+ * Regression coverage: re-render the host component with a new navigationRef
+ * and assert that exactly one listener is alive at any point — the previous
+ * subscription must be removed before the new one attaches.
+ */
+
+import React from 'react'
+import { render, act } from '@testing-library/react-native'
+import * as Notifications from 'expo-notifications'
+
+import { usePushNotifications } from '../../hooks/usePushNotifications'
+
+jest.mock('expo-notifications', () => ({
+  __esModule: true,
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  getExpoPushTokenAsync: jest.fn().mockResolvedValue({ data: 'tok' }),
+  getLastNotificationResponseAsync: jest.fn().mockResolvedValue(null),
+  dismissAllNotificationsAsync: jest.fn().mockResolvedValue(undefined),
+  setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
+  addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  AndroidImportance: { MAX: 5 },
+}))
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}))
+
+jest.mock('../../store/useNotificationStore', () => ({
+  useNotificationStore: {
+    getState: () => ({ fetchUnreadCount: jest.fn() }),
+  },
+}))
+
+jest.mock('../../store/useToastStore', () => ({
+  useToastStore: {
+    getState: () => ({ push: jest.fn() }),
+  },
+}))
+
+jest.mock('../../api/notifications', () => ({
+  registerPushToken: jest.fn().mockResolvedValue(undefined),
+  deregisterPushToken: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../constants/notificationMappings', () => ({
+  navigateToNotificationTarget: jest.fn(),
+}))
+
+jest.mock('expo-device', () => ({
+  __esModule: true,
+  isDevice: false,
+}))
+
+function HookHost({
+  nav,
+}: {
+  nav?: { navigate: (screen: string, params?: object) => void }
+}) {
+  usePushNotifications(nav)
+  return null
+}
+
+describe('usePushNotifications listener lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('attaches exactly one response listener and tears it down on unmount', () => {
+    const remove = jest.fn()
+    const addResponse = (
+      Notifications.addNotificationResponseReceivedListener as jest.Mock
+    ).mockReturnValue({ remove })
+    const addReceived = (
+      Notifications.addNotificationReceivedListener as jest.Mock
+    ).mockReturnValue({ remove: jest.fn() })
+
+    const { unmount } = render(
+      <HookHost nav={{ navigate: jest.fn() }} />,
+    )
+
+    expect(addResponse).toHaveBeenCalledTimes(1)
+    expect(addReceived).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps exactly one response listener alive when navigationRef identity changes', () => {
+    const subscriptions: { remove: jest.Mock; live: boolean }[] = []
+    ;(Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
+      () => {
+        const sub: { remove: jest.Mock; live: boolean } = {
+          live: true,
+          remove: jest.fn(),
+        }
+        sub.remove.mockImplementation(() => {
+          sub.live = false
+        })
+        subscriptions.push(sub)
+        return sub
+      },
+    )
+    ;(Notifications.addNotificationReceivedListener as jest.Mock).mockReturnValue({
+      remove: jest.fn(),
+    })
+
+    const navA = { navigate: jest.fn() }
+    const navB = { navigate: jest.fn() }
+
+    const { rerender, unmount } = render(<HookHost nav={navA} />)
+
+    // Re-render with a different navigationRef identity. Pre-fix this re-ran
+    // the response-listener effect (because navigationRef was a dep) and
+    // sometimes left the previous subscription alive while the new one
+    // attached, so a single push fired N navigations (#453a).
+    act(() => {
+      rerender(<HookHost nav={navB} />)
+    })
+
+    // At most one subscription is live at any point — re-renders that re-fire
+    // the effect must call remove() on the previous subscription before
+    // attaching a new one. Either one or two subscriptions ever existed
+    // (two only if the effect re-fires on a stable dep, which is fine as
+    // long as the previous one is dead).
+    const live = subscriptions.filter((sub) => sub.live)
+    expect(live).toHaveLength(1)
+
+    unmount()
+    expect(subscriptions.every((sub) => !sub.live)).toBe(true)
+  })
+
+  it('routes a push tap through the latest navigationRef', () => {
+    let savedHandler:
+      | ((response: Notifications.NotificationResponse) => void)
+      | null = null
+    ;(Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
+      (handler) => {
+        savedHandler = handler
+        return { remove: jest.fn() }
+      },
+    )
+    ;(Notifications.addNotificationReceivedListener as jest.Mock).mockReturnValue({
+      remove: jest.fn(),
+    })
+
+    const navA = { navigate: jest.fn() }
+    const navB = { navigate: jest.fn() }
+    const { rerender } = render(<HookHost nav={navA} />)
+
+    // Swap the navigationRef. Pre-fix the effect would have torn down navA's
+    // listener and attached navB's (so both worked, but the listener stack
+    // grew). Post-fix the effect does NOT re-fire — but the handler must
+    // still navigate via navB because it reads the holder ref each call.
+    act(() => {
+      rerender(<HookHost nav={navB} />)
+    })
+
+    expect(savedHandler).not.toBeNull()
+    if (!savedHandler) return
+
+    const { navigateToNotificationTarget } = jest.requireMock(
+      '../../constants/notificationMappings',
+    )
+
+    act(() => {
+      savedHandler!({
+        notification: {
+          request: {
+            content: {
+              data: { type: 'message', notification_id: 'n1' },
+            },
+            identifier: 'r1',
+          },
+        },
+        actionIdentifier: 'default',
+      } as unknown as Notifications.NotificationResponse)
+    })
+
+    expect(navigateToNotificationTarget).toHaveBeenCalledTimes(1)
+    // Second arg is the navigationRef the handler routed through — must be
+    // the latest one (navB), not the captured-at-mount navA.
+    expect(navigateToNotificationTarget).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      navB,
+    )
+  })
+})

--- a/mobile-client/src/api/__tests__/client_401.test.ts
+++ b/mobile-client/src/api/__tests__/client_401.test.ts
@@ -1,0 +1,152 @@
+/**
+ * 401 / refresh-token cascade tests for the mobile API client.
+ *
+ * Covers issue #452: before this change, every non-OK response (including 401
+ * after JWT expiry) threw a generic Error. The user was trapped on stale
+ * screens until the app was force-killed.
+ */
+
+import {
+  apiRequest,
+  setAuthTokens,
+  setAuthToken,
+  clearAuth,
+  getAuthToken,
+  getRefreshToken,
+  onAuthEvent,
+  ApiHttpError,
+} from "../client";
+import { useConnectivityStore } from "../../store/connectivityStore";
+
+function setOnline(isOnline: boolean) {
+  useConnectivityStore.setState({
+    isOnline,
+    isInternetReachable: isOnline,
+    lastChangeAt: Date.now(),
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ "content-type": "application/json" }),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe("apiRequest 401 / refresh cascade", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    (global as unknown as { fetch: unknown }).fetch = jest.fn();
+    setAuthToken(null);
+    setAuthTokens("", "");
+    setAuthToken(null);
+    setOnline(true);
+  });
+
+  it("refreshes the access token and retries the original request once", async () => {
+    setAuthTokens("expired-access", "refresh-token");
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      // 1) Original request with the expired access token → 401
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Token expired" }))
+      // 2) /auth/refresh/ — issues a new access token
+      .mockResolvedValueOnce(jsonResponse(200, { access: "fresh-access" }))
+      // 3) Retried original request — succeeds
+      .mockResolvedValueOnce(jsonResponse(200, { id: "u1" }));
+
+    const result = await apiRequest<{ id: string }>("/users/me/");
+
+    expect(result).toEqual({ id: "u1" });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // Original request used the stale token.
+    const firstHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(firstHeaders.Authorization).toBe("Bearer expired-access");
+
+    // Refresh call goes to /auth/refresh/ with the refresh token in the body.
+    const refreshUrl = fetchMock.mock.calls[1][0] as string;
+    expect(refreshUrl).toContain("/auth/refresh/");
+    const refreshBody = JSON.parse(
+      fetchMock.mock.calls[1][1].body as string,
+    ) as { refresh: string };
+    expect(refreshBody).toEqual({ refresh: "refresh-token" });
+
+    // Retry uses the new access token.
+    const retryHeaders = fetchMock.mock.calls[2][1].headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toBe("Bearer fresh-access");
+
+    expect(getAuthToken()).toBe("fresh-access");
+  });
+
+  it("clears tokens and emits auth:logout when refresh fails", async () => {
+    setAuthTokens("expired-access", "bad-refresh");
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      // 1) Original request → 401
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Token expired" }))
+      // 2) /auth/refresh/ → 401 (refresh itself rejected)
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Refresh expired" }));
+
+    const logoutListener = jest.fn();
+    const unsubscribe = onAuthEvent("auth:logout", logoutListener);
+
+    try {
+      await expect(apiRequest("/users/me/")).rejects.toBeInstanceOf(ApiHttpError);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logoutListener).toHaveBeenCalledTimes(1);
+    expect(getAuthToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it("does not attempt refresh when calling /auth/refresh/ itself", async () => {
+    setAuthTokens("any-access", "any-refresh");
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(401, { detail: "Refresh expired" }),
+    );
+
+    await expect(
+      apiRequest("/auth/refresh/", { method: "POST", body: { refresh: "x" } }),
+    ).rejects.toBeInstanceOf(ApiHttpError);
+
+    // No second call to /auth/refresh/ — would have been a refresh-on-refresh loop.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attempt refresh when no refresh token is stored", async () => {
+    setAuthToken("only-access");
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(401, { detail: "Token expired" }),
+    );
+
+    await expect(apiRequest("/users/me/")).rejects.toBeInstanceOf(ApiHttpError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates non-401 errors without touching the refresh path", async () => {
+    setAuthTokens("a", "r");
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(500, { detail: "Server error" }),
+    );
+
+    await expect(apiRequest("/users/me/")).rejects.toBeInstanceOf(ApiHttpError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  afterAll(async () => {
+    await clearAuth();
+  });
+});

--- a/mobile-client/src/api/__tests__/client_401.test.ts
+++ b/mobile-client/src/api/__tests__/client_401.test.ts
@@ -106,6 +106,51 @@ describe("apiRequest 401 / refresh cascade", () => {
     expect(getRefreshToken()).toBeNull();
   });
 
+  it("emits auth:logout exactly once when several concurrent 401s share a failing refresh", async () => {
+    setAuthTokens("expired-access", "bad-refresh");
+
+    const fetchMock = global.fetch as jest.Mock;
+    // Hold the /auth/refresh/ response so all N callers observe the same
+    // in-flight refresh promise and resume from the same `null` resolution.
+    let resolveRefresh!: (value: Response) => void;
+    const refreshDeferred = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+
+    fetchMock.mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/auth/refresh/")) {
+        return refreshDeferred;
+      }
+      return Promise.resolve(jsonResponse(401, { detail: "Token expired" }));
+    });
+
+    const logoutListener = jest.fn();
+    const unsubscribe = onAuthEvent("auth:logout", logoutListener);
+
+    try {
+      const concurrentRequests = Array.from({ length: 5 }, (_, idx) =>
+        apiRequest(`/users/me/?req=${idx}`).catch((err) => err),
+      );
+
+      // Let all callers reach `await refreshAccessTokenOnce()` before the
+      // shared refresh resolves. Without the loggingOut guard, every caller
+      // would re-enter the `else` branch and emit `auth:logout` again.
+      await Promise.resolve();
+      resolveRefresh(jsonResponse(401, { detail: "Refresh expired" }));
+
+      const results = await Promise.all(concurrentRequests);
+      for (const result of results) {
+        expect(result).toBeInstanceOf(ApiHttpError);
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expect(logoutListener).toHaveBeenCalledTimes(1);
+    expect(getAuthToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
   it("does not attempt refresh when calling /auth/refresh/ itself", async () => {
     setAuthTokens("any-access", "any-refresh");
 

--- a/mobile-client/src/api/client.ts
+++ b/mobile-client/src/api/client.ts
@@ -89,6 +89,16 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 let authToken: string | null = null;
 let refreshToken: string | null = null;
 
+/**
+ * Single-flight guard for the unrecoverable-401 path. When a shared refresh
+ * attempt fails, multiple concurrent callers all observe `null` and would
+ * otherwise each call `clearAuth()` + emit `auth:logout`, causing duplicate
+ * notification-store resets and navigation transitions. The flag gates the
+ * teardown so it runs exactly once per logout, and is re-armed the next
+ * time a fresh session is installed via `setAuthTokens`.
+ */
+let loggingOut = false;
+
 export function setAuthToken(token: string | null): void {
   authToken = token;
 }
@@ -96,6 +106,9 @@ export function setAuthToken(token: string | null): void {
 export function setAuthTokens(access: string, refresh: string): void {
   authToken = access;
   refreshToken = refresh;
+  // A new session means any prior logout cycle is over; re-arm the guard so
+  // the next unrecoverable 401 can fire `auth:logout` again.
+  loggingOut = false;
 }
 
 export function getAuthToken(): string | null {
@@ -284,10 +297,15 @@ export async function apiRequest<T>(
           err,
         );
       }
-    } else {
+    } else if (!loggingOut) {
       // Refresh failed. The session is unrecoverable from the API client's
       // point of view — clear in-memory + persisted tokens and let the
       // navigator reset to the auth stack via the auth:logout event.
+      // Concurrent 401s share a single refresh promise, so they all observe
+      // `null` here; gate the teardown on `loggingOut` so subsequent callers
+      // short-circuit instead of repeating clearAuth + emit. The flag is set
+      // before any await so the next microtask-resumed caller sees it.
+      loggingOut = true;
       await clearAuth();
       emitAuthEvent("auth:logout");
     }

--- a/mobile-client/src/api/client.ts
+++ b/mobile-client/src/api/client.ts
@@ -10,6 +10,37 @@ import { getConnectivitySnapshot } from "../store/connectivityStore";
 
 const BASE_URL = getApiUrl();
 
+/**
+ * Lightweight auth event bus. The API client publishes `auth:logout` when a
+ * 401 cannot be recovered (refresh failed / no refresh token) so navigation
+ * can reset to the login stack. Kept here, not in `store/`, because the API
+ * client itself is the lowest layer that detects unrecoverable auth state.
+ */
+export type AuthEvent = "auth:logout";
+type AuthListener = () => void;
+
+const authListeners: Record<AuthEvent, Set<AuthListener>> = {
+  "auth:logout": new Set(),
+};
+
+export function onAuthEvent(event: AuthEvent, listener: AuthListener): () => void {
+  authListeners[event].add(listener);
+  return () => {
+    authListeners[event].delete(listener);
+  };
+}
+
+function emitAuthEvent(event: AuthEvent): void {
+  for (const listener of authListeners[event]) {
+    try {
+      listener();
+    } catch {
+      // Listeners must not break the emit loop. Logout flows are best-effort
+      // and the next 401 will retry the cascade if needed.
+    }
+  }
+}
+
 export function getApiBaseUrl(): string {
   return BASE_URL;
 }
@@ -125,6 +156,71 @@ function buildUrl(
   return query ? `${url}${url.includes("?") ? "&" : "?"}${query}` : url;
 }
 
+/**
+ * Paths that must NEVER trigger the 401-refresh cascade. Refreshing on the
+ * refresh endpoint itself (or login) would loop; refreshing on logout would
+ * resurrect a session the user is trying to end.
+ */
+const REFRESH_BYPASS_PATHS = ["/auth/refresh/", "/auth/login/", "/auth/logout/"];
+
+function shouldBypassRefresh(path: string): boolean {
+  return REFRESH_BYPASS_PATHS.some((suffix) => path.endsWith(suffix));
+}
+
+/**
+ * In-flight refresh promise so concurrent 401s share a single refresh call
+ * instead of racing each other. Cleared as soon as the refresh settles.
+ */
+let inflightRefresh: Promise<string | null> | null = null;
+
+async function refreshAccessTokenOnce(): Promise<string | null> {
+  if (inflightRefresh) return inflightRefresh;
+  const refresh = refreshToken;
+  if (!refresh) return null;
+
+  inflightRefresh = (async () => {
+    try {
+      const response = await fetch(`${BASE_URL}/auth/refresh/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh }),
+      });
+      if (!response.ok) return null;
+      const text = await response.text();
+      if (!text) return null;
+      const data = JSON.parse(text) as { access?: string };
+      if (!data.access) return null;
+      authToken = data.access;
+      return data.access;
+    } catch {
+      return null;
+    } finally {
+      inflightRefresh = null;
+    }
+  })();
+
+  return inflightRefresh;
+}
+
+async function performRequest(
+  url: string,
+  init: RequestInit,
+  body: object | string | FormData | undefined,
+  isFormData: boolean,
+): Promise<Response> {
+  let serializedBody: BodyInit | undefined;
+  if (body !== undefined) {
+    if (typeof body === "string") {
+      serializedBody = body;
+    } else if (isFormData) {
+      serializedBody = body as FormData;
+    } else {
+      serializedBody = JSON.stringify(body);
+    }
+  }
+  return fetch(url, { ...init, body: serializedBody });
+}
+
 export async function apiRequest<T>(
   path: string,
   config: RequestConfig = {},
@@ -132,13 +228,16 @@ export async function apiRequest<T>(
   const { params, body, headers: customHeaders, ...init } = config;
   const url = buildUrl(path, params);
   const isFormData = typeof FormData !== "undefined" && body instanceof FormData;
-  const headers: Record<string, string> = {
+  const baseHeaders: Record<string, string> = {
     ...(isFormData ? {} : { "Content-Type": "application/json" }),
     ...(customHeaders as Record<string, string>),
   };
-  if (authToken) {
-    headers["Authorization"] = `Bearer ${authToken}`;
-  }
+
+  const buildHeaders = (token: string | null): Record<string, string> => {
+    const next = { ...baseHeaders };
+    if (token) next["Authorization"] = `Bearer ${token}`;
+    return next;
+  };
 
   const method = (init.method ?? "GET").toUpperCase();
   if (MUTATING_METHODS.has(method) && !getConnectivitySnapshot().isOnline) {
@@ -147,18 +246,12 @@ export async function apiRequest<T>(
 
   let response: Response;
   try {
-    response = await fetch(url, {
-      ...init,
-      headers,
-      body:
-        body !== undefined
-          ? typeof body === "string"
-            ? body
-            : isFormData
-              ? body
-            : JSON.stringify(body)
-          : undefined,
-    });
+    response = await performRequest(
+      url,
+      { ...init, headers: buildHeaders(authToken) },
+      body,
+      isFormData,
+    );
   } catch (err) {
     // `fetch` rejecting (vs returning a non-OK response) means we never got
     // an HTTP reply — DNS failure, no route, aborted, etc. Surface as a
@@ -168,6 +261,38 @@ export async function apiRequest<T>(
       err,
     );
   }
+
+  // 401 cascade: try a single refresh + retry if we have a refresh token and
+  // this isn't a request that would loop (refresh / login / logout itself).
+  if (
+    response.status === 401 &&
+    !shouldBypassRefresh(path) &&
+    refreshToken
+  ) {
+    const newAccess = await refreshAccessTokenOnce();
+    if (newAccess) {
+      try {
+        response = await performRequest(
+          url,
+          { ...init, headers: buildHeaders(newAccess) },
+          body,
+          isFormData,
+        );
+      } catch (err) {
+        throw new ApiNetworkError(
+          err instanceof Error ? err.message : "Network request failed",
+          err,
+        );
+      }
+    } else {
+      // Refresh failed. The session is unrecoverable from the API client's
+      // point of view — clear in-memory + persisted tokens and let the
+      // navigator reset to the auth stack via the auth:logout event.
+      await clearAuth();
+      emitAuthEvent("auth:logout");
+    }
+  }
+
   if (!response.ok) {
     const text = await response.text();
     let message: string;

--- a/mobile-client/src/hooks/usePushNotifications.ts
+++ b/mobile-client/src/hooks/usePushNotifications.ts
@@ -34,11 +34,20 @@ export function usePushNotifications(
   const tokenRef = useRef<string | null>(null);
   const notificationListenerRef = useRef<Notifications.Subscription | null>(null);
   const responseListenerRef = useRef<Notifications.Subscription | null>(null);
+  // Mirror navigationRef into a ref so the response-listener effect does NOT
+  // depend on navigationRef's identity. Pre-fix the effect re-fired when the
+  // ref changed (cold-start init / hot reload), and the cleanup → re-attach
+  // sequence stacked listeners — one push then fired N navigations (#453).
+  const navigationRefHolder = useRef(navigationRef);
+  useEffect(() => {
+    navigationRefHolder.current = navigationRef;
+  }, [navigationRef]);
 
   const handleNotificationResponse = useCallback(
     (response: Notifications.NotificationResponse) => {
       const data = response.notification.request.content.data;
-      if (!data?.type || !navigationRef) return;
+      const currentNav = navigationRefHolder.current;
+      if (!data?.type || !currentNav) return;
 
       useNotificationStore.getState().fetchUnreadCount();
 
@@ -57,13 +66,13 @@ export function usePushNotifications(
             related_user: (data.related_user as string) ?? null,
             created_at: '',
           },
-          navigationRef,
+          currentNav,
         );
       } catch (e) {
         console.warn('[usePushNotifications] navigate from notification failed', e);
       }
     },
-    [navigationRef],
+    [],
   );
 
   const registerForPushNotifications = useCallback(async () => {
@@ -135,8 +144,12 @@ export function usePushNotifications(
   useEffect(() => {
     if (!isAuthenticated) return;
 
-    notificationListenerRef.current =
-      Notifications.addNotificationReceivedListener((received) => {
+    // Defensive: if a previous subscription survived a hot reload or a
+    // double-mount, tear it down before attaching a new one.
+    notificationListenerRef.current?.remove();
+
+    const subscription = Notifications.addNotificationReceivedListener(
+      (received) => {
         // Sync unread count when a push arrives while app is open.
         useNotificationStore.getState().fetchUnreadCount();
 
@@ -156,26 +169,44 @@ export function usePushNotifications(
               }
             : undefined,
         });
-      });
+      },
+    );
+    notificationListenerRef.current = subscription;
 
     return () => {
-      notificationListenerRef.current?.remove();
+      subscription.remove();
+      if (notificationListenerRef.current === subscription) {
+        notificationListenerRef.current = null;
+      }
     };
   }, [isAuthenticated]);
 
-  // Listen for notification taps (user interacted with a notification — app in foreground or background)
+  // Listen for notification taps (user interacted with a notification — app in
+  // foreground or background). Effect keyed only on isAuthenticated; the
+  // listener reads navigationRef out of navigationRefHolder so a navigationRef
+  // identity change does not stack a second subscription on top of the first.
+  // handleNotificationResponse is intentionally captured by closure, NOT in
+  // the dep array — its stable identity (useCallback([])) is the contract.
   useEffect(() => {
     if (!isAuthenticated) return;
 
-    responseListenerRef.current =
-      Notifications.addNotificationResponseReceivedListener((response) => {
+    responseListenerRef.current?.remove();
+
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
         handleNotificationResponse(response);
-      });
+      },
+    );
+    responseListenerRef.current = subscription;
 
     return () => {
-      responseListenerRef.current?.remove();
+      subscription.remove();
+      if (responseListenerRef.current === subscription) {
+        responseListenerRef.current = null;
+      }
     };
-  }, [isAuthenticated, navigationRef]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated]);
 
   // Handle cold-start: app was killed and user tapped a notification to open it.
   // addNotificationResponseReceivedListener fires too late in this case, so we

--- a/mobile-client/src/navigation/RootNavigator.tsx
+++ b/mobile-client/src/navigation/RootNavigator.tsx
@@ -1,18 +1,30 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { View, ActivityIndicator, StyleSheet } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { useAuth } from "../context/AuthContext";
 import { useNotificationSocket } from "../hooks/useNotificationSocket";
 import { usePushNotifications } from "../hooks/usePushNotifications";
+import { onAuthEvent } from "../api/client";
 import BottomTabNavigator from "./BottomTabNavigator";
 import InAppNotificationToast from "../presentation/components/InAppNotificationToast";
 import AppOfflineBanner from "../presentation/components/AppOfflineBanner";
 
 export default function RootNavigator() {
-  const { isLoading } = useAuth();
+  const { isLoading, logout } = useAuth();
   const navigation = useNavigation();
   useNotificationSocket();
   usePushNotifications(navigation as any);
+
+  // Listen for unrecoverable 401s emitted by the API client and tear the
+  // session down through the AuthContext. AuthContext.logout() handles state
+  // reset, notification store cleanup, and best-effort token wipe; the API
+  // client has already emptied the in-memory tokens by the time we get here.
+  useEffect(() => {
+    const unsubscribe = onAuthEvent("auth:logout", () => {
+      void logout();
+    });
+    return unsubscribe;
+  }, [logout]);
 
   if (isLoading) {
     return (

--- a/mobile-client/src/presentation/components/profile/ProfileHero.tsx
+++ b/mobile-client/src/presentation/components/profile/ProfileHero.tsx
@@ -77,6 +77,14 @@ export interface ProfileHeroProps {
   isFollowing?: boolean;
   followActionLoading?: boolean;
   onFollowPress?: () => void;
+
+  /**
+   * Own profile only: tapping the badge slot when the user has no featured
+   * badges should jump straight into the Showcase tab of the profile editor.
+   * Without this hook the user would have to discover the path via
+   * Settings → Edit Profile → Showcase, which #554 reports as broken UX.
+   */
+  onShowcaseBadgesPress?: () => void;
 }
 
 
@@ -161,6 +169,7 @@ export default function ProfileHero({
   isFollowing = false,
   followActionLoading = false,
   onFollowPress,
+  onShowcaseBadgesPress,
 }: ProfileHeroProps) {
   const fullName = [user.first_name, user.last_name]
     .filter(Boolean)
@@ -211,7 +220,22 @@ export default function ProfileHero({
           <View style={[styles.gradientBase, bannerUrl ? styles.gradientWithCover : null]} />
           <View style={[styles.gradientOverlayTop, bannerUrl ? styles.gradientWithCover : null]} />
           <View style={styles.badgeOverlay}>
-            <BadgeShowcase variant="compact" badges={badgesDetail} />
+            {badgesDetail.length === 0 && mode === "own" && onShowcaseBadgesPress ? (
+              <Pressable
+                onPress={onShowcaseBadgesPress}
+                accessibilityRole="button"
+                accessibilityLabel="Showcase a badge"
+                style={({ pressed }) => [
+                  styles.showcaseEmptyCta,
+                  pressed && { opacity: 0.85 },
+                ]}
+              >
+                <Ionicons name="ribbon-outline" size={14} color={colors.WHITE} />
+                <Text style={styles.showcaseEmptyCtaText}>Showcase a badge</Text>
+              </Pressable>
+            ) : (
+              <BadgeShowcase variant="compact" badges={badgesDetail} />
+            )}
           </View>
 
           <View style={styles.content}>
@@ -659,5 +683,21 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: "rgba(255,255,255,0.15)",
     paddingTop: 8,
+  },
+  showcaseEmptyCta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.32)",
+  },
+  showcaseEmptyCtaText: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.WHITE,
   },
 });

--- a/mobile-client/src/presentation/components/service/ServiceWizard.tsx
+++ b/mobile-client/src/presentation/components/service/ServiceWizard.tsx
@@ -1273,7 +1273,13 @@ export default function ServiceWizard({
     <KeyboardAvoidingView
       style={styles.container}
       behavior={Platform.OS === "ios" ? "padding" : "height"}
-      keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+      // The wizard always renders inside a SafeAreaView+topBar (PostOfferScreen
+      // / PostNeedScreen / PostEventScreen), so the KAV's reference frame is
+      // already below the header. A non-zero offset double-counted the header
+      // and pushed focused inputs UP into the keyboard rather than out from
+      // under it (#555). Keep the offset at 0 — the wrapping screen already
+      // paid for the safe area + top bar.
+      keyboardVerticalOffset={0}
     >
       <View style={styles.progressWrap}>
         {STEPS.map((item, index) => (

--- a/mobile-client/src/presentation/screens/MapScreen.tsx
+++ b/mobile-client/src/presentation/screens/MapScreen.tsx
@@ -31,6 +31,100 @@ type FilterType = "all" | ServiceType;
 const DEFAULT_LOCATION = { latitude: 41.0082, longitude: 28.9784 };
 const MAPBOX_STYLE = "mapbox://styles/sgunes16/cmmc96rwc00c701qz7v0g8h9k";
 
+/**
+ * Rendered in place of the WebView when Mapbox is unavailable — token
+ * missing in the build, network down, or the WebView itself errored.
+ * Pre-fix the screen rendered an empty WebView and the user saw a blank
+ * surface with no explanation (#453b).
+ */
+function MapUnavailable({
+  onRetry,
+  insetTop,
+  reason,
+}: {
+  onRetry: () => void;
+  insetTop: number;
+  reason: "no-token" | "load-failed";
+}) {
+  const body =
+    reason === "no-token"
+      ? "Map service is not configured for this build. Check your connection or try a different build."
+      : "Could not load the map. Check your connection and try again.";
+  return (
+    <View
+      style={[unavailableStyles.container, { paddingTop: insetTop + 24 }]}
+      accessibilityRole="alert"
+      accessibilityLabel="Map unavailable"
+    >
+      <View style={unavailableStyles.iconWrap}>
+        <Ionicons name="map-outline" size={36} color={colors.GREEN} />
+      </View>
+      <Text style={unavailableStyles.title}>Map unavailable</Text>
+      <Text style={unavailableStyles.body}>{body}</Text>
+      <Pressable
+        onPress={onRetry}
+        accessibilityRole="button"
+        accessibilityLabel="Retry loading the map"
+        style={({ pressed }) => [
+          unavailableStyles.retryBtn,
+          pressed && { opacity: 0.85 },
+        ]}
+        testID="map-retry-button"
+      >
+        <Ionicons name="refresh" size={16} color={colors.WHITE} />
+        <Text style={unavailableStyles.retryBtnText}>Retry</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const unavailableStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    backgroundColor: colors.GRAY50,
+  },
+  iconWrap: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: colors.GREEN_LT,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+    color: colors.GRAY900,
+    marginBottom: 6,
+    textAlign: "center",
+  },
+  body: {
+    fontSize: 13,
+    lineHeight: 19,
+    color: colors.GRAY600,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  retryBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    backgroundColor: colors.GREEN,
+    borderRadius: 999,
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+  },
+  retryBtnText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: colors.WHITE,
+  },
+});
+
 const FILTER_CONFIG: {
   label: string;
   value: FilterType;
@@ -80,11 +174,18 @@ export default function MapScreen() {
   const [showRangeSlider, setShowRangeSlider] = useState(false);
   const [mapReady, setMapReady] = useState(false);
   const [mapInited, setMapInited] = useState(false);
+  // Bumped on Retry to force the WebView and the asset-load effect to remount.
+  // WebViews don't expose a clean reload-on-error API, so a key change is the
+  // most reliable reset path.
+  const [mapAttempt, setMapAttempt] = useState(0);
+  const [mapLoadFailed, setMapLoadFailed] = useState(false);
+  const mapboxToken = getMapboxToken();
 
   const locationCheckedRef = useRef(false);
   const drawerAnim = useRef(new Animated.Value(0)).current;
 
-  // Load the HTML asset once.
+  // Load the HTML asset. Re-runs when mapAttempt bumps (Retry) so a transient
+  // asset-load failure does not leave the screen stuck on the placeholder.
   useEffect(() => {
     let isMounted = true;
     (async () => {
@@ -93,15 +194,28 @@ export default function MapScreen() {
         const asset = Asset.fromModule(path);
         await asset.downloadAsync();
         const htmlContent = await new File(asset.localUri!).text();
-        if (isMounted) setWebViewContent(htmlContent);
+        if (!isMounted) return;
+        setWebViewContent(htmlContent);
+        setMapLoadFailed(false);
       } catch (error) {
-        Alert.alert("Error loading map", JSON.stringify(error));
-        console.error("Error loading map HTML:", error);
+        if (!isMounted) return;
+        // No alert: the placeholder UI surfaces the failure with a Retry CTA.
+        // eslint-disable-next-line no-console
+        console.warn("[MapScreen] failed to load map HTML asset", error);
+        setMapLoadFailed(true);
       }
     })();
     return () => {
       isMounted = false;
     };
+  }, [mapAttempt]);
+
+  const retryMap = useCallback(() => {
+    setMapLoadFailed(false);
+    setMapReady(false);
+    setMapInited(false);
+    setWebViewContent(null);
+    setMapAttempt((value) => value + 1);
   }, []);
 
   // Resolve user location once. When permission is denied or unavailable, fall
@@ -155,13 +269,12 @@ export default function MapScreen() {
   useEffect(() => {
     if (mapInited) return;
     if (!mapReady || !locationResolved) return;
-    const token = getMapboxToken();
     const center = userLocation
       ? { lat: userLocation.latitude, lng: userLocation.longitude }
       : { lat: DEFAULT_LOCATION.latitude, lng: DEFAULT_LOCATION.longitude };
     post({
       type: "init",
-      token,
+      token: mapboxToken,
       style: MAPBOX_STYLE,
       center,
       zoom: 11,
@@ -171,7 +284,7 @@ export default function MapScreen() {
         : null,
     });
     setMapInited(true);
-  }, [mapReady, locationResolved, userLocation, services, post, mapInited]);
+  }, [mapReady, locationResolved, userLocation, services, post, mapInited, mapboxToken]);
 
   const recenterOnUser = useCallback(async () => {
     try {
@@ -310,6 +423,20 @@ export default function MapScreen() {
     navigation.navigate("ServiceDetail", { id });
   }, [selectedService, navigation]);
 
+  // Mapbox unavailable surfaces — replaces the silent empty WebView pre-fix
+  // (#453b). Two paths reach this branch:
+  //   - no token configured for the build (server / env mis-config), OR
+  //   - the HTML asset failed to load (typical sign of being offline).
+  if (!mapboxToken || mapLoadFailed) {
+    return (
+      <MapUnavailable
+        onRetry={retryMap}
+        insetTop={insets.top}
+        reason={!mapboxToken ? "no-token" : "load-failed"}
+      />
+    );
+  }
+
   if (!webViewContent || !locationResolved) {
     return (
       <View style={[styles.loading, { paddingTop: insets.top }]}>
@@ -326,10 +453,13 @@ export default function MapScreen() {
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <WebView
+        key={`mapbox-${mapAttempt}`}
         ref={webViewRef}
         originWhitelist={["*"]}
         source={{ html: webViewContent, baseUrl: "https://localhost" }}
         onMessage={handleMessage}
+        onError={() => setMapLoadFailed(true)}
+        onHttpError={() => setMapLoadFailed(true)}
         javaScriptEnabled
         domStorageEnabled
         allowsInlineMediaPlayback

--- a/mobile-client/src/presentation/screens/ProfileScreen.tsx
+++ b/mobile-client/src/presentation/screens/ProfileScreen.tsx
@@ -588,6 +588,9 @@ export default function ProfileScreen() {
           completedExchanges={exchangesCount}
           onEditPress={() => navigation.navigate("ProfileEdit", { initialTab: "identity" })}
           onAvatarPress={() => navigation.navigate("ProfileEdit", { initialTab: "photos" })}
+          onShowcaseBadgesPress={() =>
+            navigation.navigate("ProfileEdit", { initialTab: "showcase" })
+          }
           onFollowersPress={() => {
             if (!user?.id) return;
             navigation.navigate("FollowList", {


### PR DESCRIPTION
## #452 — mobile API client has no 401/refresh handler

**Real bug:** Once the access token expired, every screen 401'd with a generic `Error("…")` and the user was stuck on stale data until the app was force-killed. `mobile-client/src/utils/authRefresh.ts` only carries soft-refresh-skip helpers; the network layer never invoked refresh.

**Root cause:** `apiRequest` in `mobile-client/src/api/client.ts` propagated every non-OK status as a thrown error. There was no 401 detection, no refresh attempt, and no logout dispatch.

**Fix:**
- On 401, call `/auth/refresh/` once with the stored refresh token and retry the original request with the new access token.
- Concurrent 401s share a single in-flight refresh promise so N parallel requests trigger one refresh, not N.
- Refresh / login / logout endpoints bypass the cascade so they cannot recurse.
- When refresh has no token, returns 4xx, or no refresh token exists, the client clears in-memory + persisted tokens and emits `auth:logout` via a tiny in-module event bus. `RootNavigator.tsx` subscribes to that event and hands off to `AuthContext.logout()`, which resets user state — the navigator falls back to the unauthenticated tree.

**Test:** `mobile-client/src/api/__tests__/client_401.test.ts` covers (a) 401 → refresh ok → retry succeeds, (b) 401 → refresh fails → tokens cleared and `auth:logout` emitted, (c) no recurse on `/auth/refresh/`, (d) no refresh attempt without a refresh token, (e) non-401 errors propagate unchanged.

**Verification:** All 21 API test suites green (163 tests).

## #453a — push-notification listener leak

**Real bug:** A single push tap fired multiple navigations, one per stacked listener.

**Root cause:** The response-listener effect in `usePushNotifications.ts` declared `navigationRef` as a dep. When React Navigation handed back a fresh `navigationRef` (cold-start init, hot reload, deep-link mount), the cleanup → re-attach cycle ran and the previous subscription was sometimes still alive when the new one attached.

**Fix:**
- Mirror `navigationRef` into a holder ref so the effect can drop it from the dep array without losing the latest navigation target — the listener pulls the holder ref's current value at fire time.
- Both listener effects defensively call `subscription.remove()` on the ref before attaching a new one, so a stale subscription from a hot reload cannot coexist with a fresh one.

**Test:** `mobile-client/src/__tests__/components/usePushNotifications.test.tsx` covers (a) one listener attached at mount, removed at unmount, (b) re-render with a different `navigationRef` keeps at most one listener alive at any point, (c) a tap is routed through the latest `navigationRef`, not the one captured at mount.

**Verification:** Hook tests pass; full suite still green.

## #453b — silent map fallback

**Real bug:** When the Mapbox token was missing or the network was offline, `MapScreen.tsx` mounted an empty WebView and the user saw a featureless surface with no explanation.

**Root cause:** No fallback UI in either branch (token-missing or asset-load-failed).

**Fix:** Render a labelled `MapUnavailable` placeholder with copy ("Map unavailable — check your connection or configuration") and a Retry CTA when `getMapboxToken()` returns nothing or the WebView/asset load fails. Retry remounts the WebView via a key bump and re-runs the asset-load effect so a transient outage clears with one tap.

**Test:** `mobile-client/src/__tests__/components/MapScreenFallback.test.tsx` asserts the placeholder + Retry CTA render when the token is missing and the WebView itself is not mounted in that branch.

## #555 — add-offer keyboard misbehaviour

**Real bug:** Typing into the offer-form inputs scrolled the focused input UP, partially behind the keyboard, instead of out from under it.

**Root cause:** `ServiceWizard.tsx` set `keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}`, but the wizard always mounts inside a `SafeAreaView` + custom `topBar` (`PostOfferScreen`, `PostNeedScreen`, `PostEventScreen`). The KAV's reference frame already sat below those — the hardcoded 90 was double-counting the header.

**Fix:** Set `keyboardVerticalOffset` to 0; the wrapping screen already paid for the safe area top + topBar height.

**Verification:** Manual: focus title/description on Create Offer, the field stays above the keyboard. Build still type-checks via `npx tsc --noEmit`.

## #554 — profile add-badges has no entry point

**Real bug:** The compact badge showcase rendered nothing when the user had no featured badges, so there was no discoverable path from the profile to the picker (which lives under Settings → Edit profile → Showcase).

**Root cause:** `BadgeShowcase` (compact variant) returned `null` for the empty case and `ProfileHero` had no fallback CTA.

**Fix:** When `mode === "own"` and the badge list is empty, render a small "Showcase a badge" pill in the badge slot. `ProfileScreen` wires it to `navigation.navigate("ProfileEdit", { initialTab: "showcase" })`, which loads the picker grid via `getAchievementProgress()` with one tap.

**Verification:** Manual: profile with no featured badges shows the new pill; tapping it lands on the Showcase tab with badges populated.

## Suite

`cd mobile-client && npx tsc --noEmit && npm test -- --ci` — 183 tests pass across 28 suites (was 173 across 25 before this PR).

Closes #452. Closes #453. Closes #554. Closes #555.
