### PR TITLE
fix: backend reliability and perf hardening (round 3)

### DIFF
--- a/backend/api/tests/integration/test_admin_management_api.py
+++ b/backend/api/tests/integration/test_admin_management_api.py
@@ -108,6 +108,35 @@ class TestAdminManagementApi:
         target_user.refresh_from_db()
         assert target_user.karma_score == 7
 
+    def test_warn_user_response_includes_inline_audit_log_entry(self):
+        """NFR-03b: the warn endpoint must return the freshly-appended audit
+        log entry inline so moderation consoles can update their view
+        without a follow-up GET that may race the writer."""
+        admin = AdminUserFactory()
+        target_user = UserFactory(is_active=True)
+
+        client = AuthenticatedAPIClient().authenticate_admin(admin)
+        response = client.post(
+            f'/api/admin/users/{target_user.id}/warn/',
+            {'message': 'Please follow community guidelines.'},
+            format='json',
+        )
+
+        assert_api_response(response, 200)
+        body = response.json()
+        assert 'audit_log' in body, 'warn response must include the inline audit-log entry'
+        entry = body['audit_log']
+        assert entry['action_type'] == 'warn_user'
+        assert entry['target_entity'] == 'user'
+        assert entry['target_id'] == str(target_user.id)
+        assert entry['reason'] == 'Please follow community guidelines.'
+        # The id must match the row that landed in the database, so
+        # consumers can use it as a stable React key without a refetch.
+        persisted = AdminAuditLog.objects.get(
+            action_type='warn_user', target_id=target_user.id
+        )
+        assert entry['id'] == str(persisted.id)
+
     def test_admin_audit_logs_requires_authentication(self):
         response = APIClient().get('/api/admin/audit-logs/')
         assert_problem_detail(response, 401)

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -922,3 +922,95 @@ class TestServiceRetrieveStatusVisibility:
         assert service.session_exact_location_lat == Decimal('40.987654')
         assert service.session_exact_location_lng == Decimal('29.123456')
         assert service.session_location_guide == 'Veterinerin olduğu bina'
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestServiceDetailQueryCount:
+    """Pin the detail-route query count so a regressed serializer cannot
+    silently re-introduce N+1 against comments / saves / dismissals.
+
+    NFR-13a: the service-detail page exceeded the 2 s budget on Docker CI
+    because `comment_count`, `is_saved`, and `is_dismissed` each fired a
+    per-row query on the detail path. The retrieve queryset now annotates
+    those alongside the existing user / tags / handshakes prefetches.
+    Cap the absolute count generously so unrelated middleware queries
+    don't make this brittle, but reject growth that scales with the row
+    counts of related tables (comments, saved-services, dismissals).
+    """
+
+    def test_detail_query_count_is_constant_across_comment_volume(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from api.models import Comment
+
+        owner = UserFactory()
+        viewer = UserFactory()
+        small_service = ServiceFactory(user=owner, status='Active')
+        large_service = ServiceFactory(user=owner, status='Active')
+
+        # Seed differing comment volumes so per-row N+1 would show up as
+        # a query-count delta tracking the comment counts.
+        Comment.objects.create(service=small_service, user=viewer, body='one')
+        for i in range(15):
+            Comment.objects.create(
+                service=large_service, user=viewer, body=f'c{i}'
+            )
+
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+
+        # Warm caches and module imports so first-hit work doesn't skew the
+        # second observation.
+        client.get(f'/api/services/{small_service.id}/')
+
+        with CaptureQueriesContext(connection) as ctx_small:
+            resp = client.get(f'/api/services/{small_service.id}/')
+            assert_api_response(resp, 200)
+
+        with CaptureQueriesContext(connection) as ctx_large:
+            resp = client.get(f'/api/services/{large_service.id}/')
+            assert_api_response(resp, 200)
+
+        # Detail must not scale with comment volume. Allow a tiny constant
+        # delta for jitter (auth caching, throttle bookkeeping) but reject
+        # anything that grows roughly linearly with the 14-row gap.
+        assert len(ctx_large) - len(ctx_small) <= 2, (
+            f'detail query count grew from {len(ctx_small)} to {len(ctx_large)} '
+            f'when comment volume rose from 1 to 15 — N+1 likely back'
+        )
+        # Hard cap to prevent silent regressions stacking up across releases.
+        assert len(ctx_large) <= 25, (
+            f'detail query count {len(ctx_large)} exceeds the 25-query cap; '
+            f'review the retrieve queryset / serializer'
+        )
+
+    def test_detail_query_count_does_not_scale_with_saved_or_dismissed_volume(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from api.models import SavedService, ServiceDismissal
+
+        viewer = UserFactory()
+        target = ServiceFactory(status='Active')
+
+        # Pollute the SavedService / ServiceDismissal tables for unrelated
+        # services to confirm the per-viewer is_saved / is_dismissed paths
+        # are using EXISTS subqueries rather than per-row table scans.
+        for _ in range(20):
+            other = ServiceFactory(status='Active')
+            SavedService.objects.create(user=viewer, service=other)
+            ServiceDismissal.objects.create(viewer=viewer, service=other)
+
+        client = APIClient()
+        client.force_authenticate(user=viewer)
+        # Warm.
+        client.get(f'/api/services/{target.id}/')
+
+        with CaptureQueriesContext(connection) as ctx:
+            resp = client.get(f'/api/services/{target.id}/')
+            assert_api_response(resp, 200)
+
+        assert len(ctx) <= 25, (
+            f'detail query count {len(ctx)} exceeds the 25-query cap '
+            f'in the presence of unrelated SavedService / Dismissal rows'
+        )

--- a/backend/api/tests/unit/test_wikidata.py
+++ b/backend/api/tests/unit/test_wikidata.py
@@ -443,3 +443,213 @@ def test_classify_and_filter_results_does_not_fan_out_per_qid(mock_get):
     assert mock_get.call_count == 1
     assert len(classified) == 5
     assert all(item['entity_type'] == 'technology' for item in classified)
+
+
+# ── fetch_wikidata_claims_batch — branch coverage ────────────────────────────
+# The following cases exercise the input-normalisation and fail-open branches
+# in fetch_wikidata_claims_batch + classify_and_filter_results that the happy
+# path tests above don't reach. Each case isolates one branch so a regression
+# breaks exactly one assertion.
+
+
+def test_fetch_wikidata_claims_batch_empty_input_returns_empty_dict():
+    """No QIDs in → no upstream call, empty mapping out."""
+    from api.wikidata import fetch_wikidata_claims_batch
+    assert fetch_wikidata_claims_batch([]) == {}
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_claims_batch_skips_falsy_and_non_qid_input(mock_get):
+    """Empty strings, None, and labels that don't look like QIDs are dropped."""
+    from django.core.cache import cache
+    from api.wikidata import fetch_wikidata_claims_batch
+    cache.clear()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'entities': {
+        'Q42': {'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q5'}}}}]}},
+    }}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    result = fetch_wikidata_claims_batch(['', None, 'not-a-qid', 'Q42', 'q42'])
+
+    # Only the de-duped, normalised QID makes it into the result mapping.
+    assert set(result.keys()) == {'Q42'}
+    assert result['Q42']['instance_of'] == ['Q5']
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_claims_batch_upstream_failure_returns_none_per_qid(mock_get):
+    """When the upstream call returns None, every requested QID maps to None."""
+    import requests as _requests
+    from django.core.cache import cache
+    from api.wikidata import fetch_wikidata_claims_batch
+    cache.clear()
+
+    # _wikidata_get catches RequestException + ValueError and returns None;
+    # the batch helper must then leave every input QID mapped to None.
+    mock_get.side_effect = _requests.RequestException('upstream is down')
+
+    result = fetch_wikidata_claims_batch(['Q1', 'Q2'])
+
+    assert result == {'Q1': None, 'Q2': None}
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_claims_batch_handles_partial_response(mock_get):
+    """When wbgetentities omits a requested entity, that QID stays None."""
+    from django.core.cache import cache
+    from api.wikidata import fetch_wikidata_claims_batch
+    cache.clear()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'entities': {
+        'Q1': {'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q5'}}}}]}},
+        # Q2 is missing entirely
+    }}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    result = fetch_wikidata_claims_batch(['Q1', 'Q2'])
+
+    assert result['Q1'] is not None
+    assert result['Q1']['instance_of'] == ['Q5']
+    assert result['Q2'] is None
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_claims_batch_skips_malformed_claim_payload(mock_get):
+    """Claims with missing mainsnak / datavalue / value are skipped, not raised."""
+    from django.core.cache import cache
+    from api.wikidata import fetch_wikidata_claims_batch
+    cache.clear()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'entities': {
+        'Q1': {'claims': {'P31': [
+            {'mainsnak': {'datavalue': {'value': {'id': 'Q5'}}}},   # well-formed
+            {'mainsnak': {}},                                        # missing datavalue (KeyError)
+            {'no_mainsnak': True},                                   # missing mainsnak entirely (KeyError)
+        ]}},
+    }}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    result = fetch_wikidata_claims_batch(['Q1'])
+
+    # Only the well-formed claim contributes a target id.
+    assert result['Q1']['instance_of'] == ['Q5']
+
+
+# ── classify_and_filter_results — branch coverage ────────────────────────────
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+def test_classify_and_filter_results_skips_items_without_qid(_mock_batch, mock_fetch):
+    """Result rows with no `id` field are dropped before any upstream call."""
+    from api.wikidata import classify_and_filter_results
+    classified = classify_and_filter_results([{'label': 'no qid here'}])
+    assert classified == []
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_classify_and_filter_results_fails_open_when_claims_unavailable(
+    mock_fetch, _mock_batch,
+):
+    """Fail-open: if claims can't be fetched, the row is kept without entity_type."""
+    from api.wikidata import classify_and_filter_results
+    mock_fetch.return_value = None
+
+    classified = classify_and_filter_results([{'id': 'Q123', 'label': 'Mystery'}])
+
+    assert len(classified) == 1
+    assert classified[0]['id'] == 'Q123'
+    assert 'entity_type' not in classified[0]
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_classify_and_filter_results_drops_blocked_entity_types(
+    mock_fetch, _mock_batch,
+):
+    """A QID with a blocked P31 (e.g. country / human) is filtered out."""
+    from api.wikidata import classify_and_filter_results, BLOCKED_ENTITY_QIDS
+    blocked_qid = next(iter(BLOCKED_ENTITY_QIDS))
+    mock_fetch.return_value = {'instance_of': [blocked_qid], 'subclass_of': []}
+
+    classified = classify_and_filter_results([{'id': 'Q999', 'label': 'Blocked'}])
+
+    assert classified == []
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_classify_and_filter_results_falls_back_to_p279_when_p31_not_mapped(
+    mock_fetch, _mock_batch,
+):
+    """If P31 doesn't match the entity-type map, P279 (subclass_of) is consulted."""
+    from api.wikidata import classify_and_filter_results, ENTITY_TYPE_MAP
+    mapped_qid = next(iter(ENTITY_TYPE_MAP))
+    expected_type = ENTITY_TYPE_MAP[mapped_qid]
+    mock_fetch.return_value = {
+        'instance_of': ['Q9999999'],   # not in ENTITY_TYPE_MAP, not blocked
+        'subclass_of': [mapped_qid],
+    }
+
+    classified = classify_and_filter_results([{'id': 'Q42', 'label': 'P279 fallback'}])
+
+    assert len(classified) == 1
+    assert classified[0]['entity_type'] == expected_type
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+@patch('api.wikidata.fetch_wikidata_claims')
+def test_classify_and_filter_results_emits_none_entity_type_when_unmapped(
+    mock_fetch, _mock_batch,
+):
+    """No P31 / P279 match → row keeps `entity_type=None`, still included."""
+    from api.wikidata import classify_and_filter_results
+    mock_fetch.return_value = {
+        'instance_of': ['Q9999999'],
+        'subclass_of': ['Q9999998'],
+    }
+
+    classified = classify_and_filter_results([{'id': 'Q777', 'label': 'Mystery'}])
+
+    assert len(classified) == 1
+    assert classified[0]['entity_type'] is None
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.fetch_wikidata_claims')
+@patch('api.wikidata.fetch_wikidata_claims_batch')
+def test_classify_and_filter_results_swallows_batch_warmer_failure(
+    mock_batch, mock_fetch,
+):
+    """The batch warm-up is an optimisation; raising must not break classification."""
+    from api.wikidata import classify_and_filter_results
+    mock_batch.side_effect = RuntimeError('redis fell over')
+    mock_fetch.return_value = {
+        'instance_of': [],
+        'subclass_of': [],
+    }
+
+    classified = classify_and_filter_results([{'id': 'Q1', 'label': 'Will it crash?'}])
+
+    # Classification still ran via the per-id helper; row passes through with
+    # entity_type=None because nothing matched the type map.
+    assert len(classified) == 1
+    assert classified[0]['entity_type'] is None

--- a/backend/api/tests/unit/test_wikidata.py
+++ b/backend/api/tests/unit/test_wikidata.py
@@ -350,3 +350,96 @@ def test_wikidata_search_allows_normal_usage(mock_search, search_env):
     for _ in range(5):
         response = search_env.client.get(search_env.url, {'q': 'test'})
         assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# #525 — Wikidata tag search performance: cache + batched claim lookups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_search_wikidata_items_returns_cached_payload_without_upstream_call(mock_get):
+    """A repeated query must hit the Django cache, not the wbsearchentities API."""
+    from django.core.cache import cache
+
+    cache.clear()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'search': [
+            {'id': 'Q28865', 'label': 'Python', 'description': 'high-level programming language'},
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    first = search_wikidata_items('cachehit-python', limit=5)
+    second = search_wikidata_items('cachehit-python', limit=5)
+
+    assert first == second
+    # The upstream wbsearchentities endpoint should fire exactly once
+    # across the two calls -- the second one is served from the cache.
+    assert mock_get.call_count == 1
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_fetch_wikidata_claims_batch_uses_single_upstream_call(mock_get):
+    """Batched claim resolution issues one wbgetentities request, not N."""
+    from django.core.cache import cache
+    from api.wikidata import fetch_wikidata_claims_batch
+
+    cache.clear()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'entities': {
+            'Q28865': {'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q9143'}}}}]}},
+            'Q2005': {'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q9143'}}}}]}},
+            'Q17195715': {'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q1914636'}}}}]}},
+        },
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    result = fetch_wikidata_claims_batch(['Q28865', 'Q2005', 'Q17195715'])
+
+    assert mock_get.call_count == 1
+    assert set(result.keys()) == {'Q28865', 'Q2005', 'Q17195715'}
+    assert result['Q28865']['instance_of'] == ['Q9143']
+    assert result['Q2005']['instance_of'] == ['Q9143']
+    assert result['Q17195715']['instance_of'] == ['Q1914636']
+
+    # A second batch call for the same QIDs is satisfied entirely from
+    # the cache populated above.
+    cached = fetch_wikidata_claims_batch(['Q28865', 'Q2005', 'Q17195715'])
+    assert cached == result
+    assert mock_get.call_count == 1
+
+
+@pytest.mark.django_db
+@patch('api.wikidata.requests.get')
+def test_classify_and_filter_results_does_not_fan_out_per_qid(mock_get):
+    """The classification step must not fan out one HTTP call per result."""
+    from django.core.cache import cache
+    from api.wikidata import classify_and_filter_results
+
+    cache.clear()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'entities': {
+            f'Q{1000 + i}': {
+                'claims': {'P31': [{'mainsnak': {'datavalue': {'value': {'id': 'Q9143'}}}}]}
+            }
+            for i in range(5)
+        },
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    raw = [{'id': f'Q{1000 + i}', 'label': f'Item {i}'} for i in range(5)]
+    classified = classify_and_filter_results(raw)
+
+    # One batched wbgetentities call covers all five rows.
+    assert mock_get.call_count == 1
+    assert len(classified) == 5
+    assert all(item['entity_type'] == 'technology' for item in classified)

--- a/backend/api/tests/unit/test_wikidata.py
+++ b/backend/api/tests/unit/test_wikidata.py
@@ -14,6 +14,12 @@ from api.serializers import TagSerializer
 from api.wikidata import fetch_wikidata_item, search_wikidata_items
 
 
+# CI splits the suite by marker (`-m unit` / `-m integration`); without a
+# module-level marker every test in this file is silently deselected and
+# wikidata.py drops out of the unit-suite coverage.
+pytestmark = pytest.mark.unit
+
+
 @pytest.fixture
 def search_env():
     return SimpleNamespace(client=APIClient(), url=reverse('wikidata-search'))

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -23,7 +23,7 @@ from datetime import timedelta
 import logging
 import os
 import bleach
-from typing import List
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -166,10 +166,19 @@ def _require_verified_email(request, action_clause: str = 'to continue'):
 ADMIN_ROLES = frozenset(('admin', 'super_admin', 'moderator'))
 
 
-def log_admin_action(admin_user, action_type: str, target_entity: str, target_obj, reason: str = '') -> None:
-    """Best-effort admin audit logging for moderation actions."""
+def log_admin_action(admin_user, action_type: str, target_entity: str, target_obj, reason: str = '') -> Optional['AdminAuditLog']:
+    """Best-effort admin audit logging for moderation actions.
+
+    Returns the persisted ``AdminAuditLog`` row so the caller can surface
+    the new entry inline in the action response (NFR-03b: spares the
+    moderation UI a follow-up GET /api/admin/audit-logs/, which previously
+    raced the writer in setups where the audit list reads from a follower
+    replica). Returns ``None`` only when the persistence step itself
+    raised — moderation actions still succeed in that case, but the
+    response simply won't carry the inline log row.
+    """
     try:
-        AdminAuditLog.objects.create(
+        return AdminAuditLog.objects.create(
             admin=admin_user,
             action_type=action_type,
             target_entity=target_entity,
@@ -178,6 +187,7 @@ def log_admin_action(admin_user, action_type: str, target_entity: str, target_ob
         )
     except Exception as exc:
         logger.warning('Admin audit log failed for %s (%s): %s', action_type, target_entity, exc)
+        return None
 
 
 def _send_email_async(to_email: str, subject: str, html: str) -> None:
@@ -5779,7 +5789,7 @@ class AdminUserViewSet(viewsets.ViewSet):
             message=request.data.get('message', 'You have received a formal warning from an administrator.'),
         )
 
-        log_admin_action(
+        audit_entry = log_admin_action(
             request.user,
             'warn_user',
             'user',
@@ -5787,7 +5797,13 @@ class AdminUserViewSet(viewsets.ViewSet):
             request.data.get('message', ''),
         )
 
-        return Response({'status': 'success', 'message': 'Warning issued'})
+        # NFR-03b: surface the appended audit-log row inline so moderation
+        # consoles don't have to chase a follow-up GET that may race the
+        # writer behind a follower replica.
+        payload = {'status': 'success', 'message': 'Warning issued'}
+        if audit_entry is not None:
+            payload['audit_log'] = AdminAuditLogSerializer(audit_entry).data
+        return Response(payload)
 
     @action(detail=True, methods=['post'], url_path='ban', throttle_classes=[ConfirmationThrottle])
     def ban_user(self, request, pk=None):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2700,7 +2700,14 @@ class ServiceViewSet(viewsets.ModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         """Return a single service regardless of status so owners and participants
-        can view Agreed/Completed/Cancelled services from their history."""
+        can view Agreed/Completed/Cancelled services from their history.
+
+        NFR-13a: the detail page hit a 2 s budget on Docker CI because the
+        serializer was issuing a per-card query for `comment_count`,
+        `is_saved`, and `is_dismissed` even on the single-row detail route.
+        Annotate those alongside the prefetches so the request is constant
+        in the number of related objects rather than O(comments + saves +
+        dismissals)."""
         user_badges_prefetch = Prefetch(
             'user__badges',
             queryset=UserBadge.objects.select_related('badge')
@@ -2714,6 +2721,7 @@ class ServiceViewSet(viewsets.ModelViewSet):
         )
         queryset = (
             Service.objects
+            .annotate(comment_count=Count('comments', filter=Q(comments__is_deleted=False)))
             .select_related('user', 'event_evaluation_summary')
             .prefetch_related(
                 'tags',
@@ -2722,6 +2730,25 @@ class ServiceViewSet(viewsets.ModelViewSet):
                 capacity_handshakes_prefetch,
             )
         )
+
+        # Per-viewer annotations match the list path so the serializer's
+        # is_saved / is_dismissed methods read an annotation instead of
+        # firing one query per service.
+        from .models import SavedService, ServiceDismissal
+        if request.user.is_authenticated:
+            queryset = queryset.annotate(
+                is_saved_anno=Exists(
+                    SavedService.objects.filter(
+                        user=request.user, service=OuterRef('pk'),
+                    ),
+                ),
+                is_dismissed_anno=Exists(
+                    ServiceDismissal.objects.filter(
+                        viewer=request.user, service=OuterRef('pk'),
+                    ),
+                ),
+            )
+
         instance = get_object_or_404(queryset, pk=kwargs['pk'])
 
         # For You click attribution (#481): when the detail page is reached

--- a/backend/api/wikidata.py
+++ b/backend/api/wikidata.py
@@ -383,6 +383,87 @@ BLOCKED_ENTITY_QIDS = frozenset({
 })
 
 
+def fetch_wikidata_claims_batch(qids: List[str]) -> Dict[str, Optional[Dict]]:
+    """
+    Resolve P31 / P279 claims for many QIDs in a single ``wbgetentities``
+    call instead of one HTTP round-trip per id.
+
+    Issue #525: typing into the tag picker fanned out N upstream calls per
+    keystroke (one per autocomplete row) the first time a query was typed,
+    which compounded the wbsearchentities call and pushed total response
+    time well past the 1 s budget. The MediaWiki API accepts up to 50
+    comma-separated ids on ``wbgetentities``, so the cold-cache cost is
+    one round-trip regardless of result count.
+
+    Returns a ``{qid: claims-dict-or-None}`` mapping covering every input
+    QID. Already-cached entries are taken from the local cache and the
+    cache is populated for any QID resolved through the upstream call.
+    Unknown / invalid QIDs map to ``None`` so callers can fail-open the
+    same way the per-id helper does.
+    """
+    if not qids:
+        return {}
+
+    # Keep insertion order while removing dupes; normalise upper-case so
+    # the cache key matches the per-id helper.
+    seen: Dict[str, None] = {}
+    for raw in qids:
+        if not raw:
+            continue
+        norm = str(raw).strip().upper()
+        if norm.startswith('Q') and norm not in seen:
+            seen[norm] = None
+
+    out: Dict[str, Optional[Dict]] = {q: None for q in seen}
+
+    # Pull from cache first. Anything still missing goes upstream in one
+    # shot, batched up to the wbgetentities 50-id ceiling.
+    missing: List[str] = []
+    for qid in seen:
+        cached = cache.get(f'wikidata:claims:{qid}')
+        if cached is not None:
+            out[qid] = cached
+        else:
+            missing.append(qid)
+
+    BATCH_SIZE = 50
+    for chunk_start in range(0, len(missing), BATCH_SIZE):
+        chunk = missing[chunk_start:chunk_start + BATCH_SIZE]
+        data = _wikidata_get({
+            'action': 'wbgetentities',
+            'ids': '|'.join(chunk),
+            'props': 'claims',
+            'format': 'json',
+        })
+        if data is None:
+            # Upstream failed for this chunk -- caller will get None for
+            # each id and fail-open downstream.
+            continue
+
+        entities = data.get('entities', {}) or {}
+        for qid in chunk:
+            entity = entities.get(qid)
+            if not entity:
+                continue
+            claims = entity.get('claims', {}) or {}
+            result: Dict[str, List] = {'instance_of': [], 'subclass_of': []}
+            for prop, key in [('P31', 'instance_of'), ('P279', 'subclass_of')]:
+                for claim in claims.get(prop, []):
+                    try:
+                        value = claim['mainsnak']['datavalue']['value']
+                        target_id = value.get('id')
+                        if target_id:
+                            result[key].append(target_id)
+                    except (KeyError, TypeError):
+                        continue
+            cache.set(
+                f'wikidata:claims:{qid}', result, _CLAIMS_CACHE_TTL_SECONDS
+            )
+            out[qid] = result
+
+    return out
+
+
 def classify_and_filter_results(results: List[Dict]) -> List[Dict]:
     """
     Classify WikiData search results by entity type and filter out
@@ -394,6 +475,19 @@ def classify_and_filter_results(results: List[Dict]) -> List[Dict]:
     Returns:
         Filtered list with 'entity_type' added to each result.
     """
+    # #525: warm the per-QID claim cache in a single round-trip so the
+    # per-row fetch_wikidata_claims calls below collapse to cache hits.
+    # Done as a side-effect (rather than swapping out the per-id helper)
+    # so existing callers and tests that mock fetch_wikidata_claims keep
+    # observing the same surface.
+    qids = [item.get('id') for item in results if item.get('id')]
+    if qids:
+        try:
+            fetch_wikidata_claims_batch(qids)
+        except Exception:
+            # Batched warm-up is an optimisation, not a correctness path.
+            pass
+
     filtered = []
     for item in results:
         qid = item.get('id')

--- a/backend/api/wikidata.py
+++ b/backend/api/wikidata.py
@@ -392,14 +392,16 @@ def fetch_wikidata_claims_batch(qids: List[str]) -> Dict[str, Optional[Dict]]:
     keystroke (one per autocomplete row) the first time a query was typed,
     which compounded the wbsearchentities call and pushed total response
     time well past the 1 s budget. The MediaWiki API accepts up to 50
-    comma-separated ids on ``wbgetentities``, so the cold-cache cost is
+    pipe-separated ids on ``wbgetentities``, so the cold-cache cost is
     one round-trip regardless of result count.
 
-    Returns a ``{qid: claims-dict-or-None}`` mapping covering every input
-    QID. Already-cached entries are taken from the local cache and the
-    cache is populated for any QID resolved through the upstream call.
-    Unknown / invalid QIDs map to ``None`` so callers can fail-open the
-    same way the per-id helper does.
+    Returns a ``{qid: claims-dict-or-None}`` mapping. Only inputs that
+    normalise to a ``Q...`` identifier appear in the output — falsy and
+    non-``Q`` inputs are dropped before the upstream call. Already-cached
+    entries are taken from the local cache and the cache is populated for
+    any QID resolved through the upstream call. Resolved QIDs that the
+    upstream call cannot answer map to ``None`` so callers can fail-open
+    the same way the per-id helper does.
     """
     if not qids:
         return {}

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -6,7 +6,7 @@ Creates authentic demo data with Turkish users, realistic services, and proper s
 Final demo balances (after all handshakes settle):
 
   - Cem (cem@demo.com)       : 5.00h  ← pinned sub-10h fixture for FR-07i
-  - Other Turkish demo users : varies between 4-9h after handshakes
+  - Other Turkish demo users : varies after handshakes settle
   - Admin / superadmin       : 10.00h
 
 Cem is the canonical low-balance fixture: end-to-end flows that exercise

--- a/backend/setup_demo.py
+++ b/backend/setup_demo.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
 """
 Enhanced demo setup script for The Hive
-Creates authentic demo data with Turkish users, realistic services, and proper system workflows
+Creates authentic demo data with Turkish users, realistic services, and proper system workflows.
+
+Final demo balances (after all handshakes settle):
+
+  - Cem (cem@demo.com)       : 5.00h  ← pinned sub-10h fixture for FR-07i
+  - Other Turkish demo users : varies between 4-9h after handshakes
+  - Admin / superadmin       : 10.00h
+
+Cem is the canonical low-balance fixture: end-to-end flows that exercise
+"insufficient TimeBank balance" paths look him up explicitly so the spec
+is independent of how the wider seed evolves.
 """
 import os
 import django
@@ -3321,6 +3331,15 @@ add_group_chat_messages(demo_fest_done, [
     (zeynep, "Get well soon Cem, health comes first."),
 ], now - timedelta(days=4))
 print(f"  Created: {demo_fest_done.title} (completed, Ayse+Burak attended, Cem no-show, evaluation window open)")
+
+# FR-07i: pin Cem's final balance below the 10-hour threshold so E2E flows
+# that need a sub-10h demo account ("can't afford this Need" scenarios,
+# atomic-rollback checks) always have a deterministic fixture. Done after
+# every handshake-driven balance change so it isn't undone downstream.
+cem.refresh_from_db(fields=['timebank_balance'])
+cem.timebank_balance = Decimal('5.00')
+cem.save(update_fields=['timebank_balance'])
+print(f"  Pinned: Cem's TimeBank balance to 5.00h (FR-07i fixture)")
 
 print("\n" + "=" * 60)
 print("Demo setup complete!")

--- a/frontend/src/components/ServiceEvaluationModal.tsx
+++ b/frontend/src/components/ServiceEvaluationModal.tsx
@@ -213,19 +213,24 @@ export default function ServiceEvaluationModal({
       }
     }
 
-    // Upload photos. On failure keep the modal open so the user can adjust and retry.
+    // Upload photos. The evaluation itself has already persisted at this
+    // point, so a photo-upload failure must not block the success path or
+    // strand the user in the modal. Surface the failure as a non-blocking
+    // warning toast and close the modal as if the submission succeeded
+    // (NFR-14d). The user can retry attaching photos later via the
+    // Reviews tab without losing the trait/comment they already submitted.
+    let photoUploadFailed = false
     if (images.length > 0) {
       try {
         await reputationAPI.attachReviewImages(handshakeId, images)
       } catch (error) {
+        photoUploadFailed = true
         const status = (error as { response?: { status?: number } })?.response?.status
         if (status === 413) {
-          toast.error('Photos could not be uploaded because the files are too large. Remove or replace them and try again.')
+          toast.error('Photo upload failed: files are too large. Your evaluation was saved without photos.')
         } else {
-          toast.error('Photo upload failed. Remove the images or try again.')
+          toast.error('Photo upload failed. Your evaluation was saved without photos — you can retry attaching them later.')
         }
-        setSubmitting(false)
-        return
       }
     }
 
@@ -234,6 +239,10 @@ export default function ServiceEvaluationModal({
     reset()
     onClose()
     setSubmitting(false)
+    // Reset evaluationSubmitted explicitly so a future open of the same modal
+    // doesn't skip the create call. (reset() above already covers this, but
+    // photoUploadFailed kept here for future telemetry hooks.)
+    void photoUploadFailed
   }
 
   return (

--- a/frontend/src/components/ServiceEvaluationModal.tsx
+++ b/frontend/src/components/ServiceEvaluationModal.tsx
@@ -219,12 +219,10 @@ export default function ServiceEvaluationModal({
     // warning toast and close the modal as if the submission succeeded
     // (NFR-14d). The user can retry attaching photos later via the
     // Reviews tab without losing the trait/comment they already submitted.
-    let photoUploadFailed = false
     if (images.length > 0) {
       try {
         await reputationAPI.attachReviewImages(handshakeId, images)
       } catch (error) {
-        photoUploadFailed = true
         const status = (error as { response?: { status?: number } })?.response?.status
         if (status === 413) {
           toast.error('Photo upload failed: files are too large. Your evaluation was saved without photos.')
@@ -239,10 +237,6 @@ export default function ServiceEvaluationModal({
     reset()
     setSubmitting(false)
     onClose()
-    // Reset evaluationSubmitted explicitly so a future open of the same modal
-    // doesn't skip the create call. (reset() above already covers this, but
-    // photoUploadFailed kept here for future telemetry hooks.)
-    void photoUploadFailed
   }
 
   return (

--- a/frontend/src/components/ServiceEvaluationModal.tsx
+++ b/frontend/src/components/ServiceEvaluationModal.tsx
@@ -237,8 +237,8 @@ export default function ServiceEvaluationModal({
     toast.success('Evaluation submitted. Thank you for your feedback!')
     await onSubmitted?.()
     reset()
-    onClose()
     setSubmitting(false)
+    onClose()
     // Reset evaluationSubmitted explicitly so a future open of the same modal
     // doesn't skip the create call. (reset() above already covers this, but
     // photoUploadFailed kept here for future telemetry hooks.)

--- a/frontend/src/test/components/ServiceEvaluationModal.test.tsx
+++ b/frontend/src/test/components/ServiceEvaluationModal.test.tsx
@@ -1,5 +1,6 @@
 import { ChakraProvider } from '@chakra-ui/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ServiceEvaluationModal from '@/components/ServiceEvaluationModal'
@@ -33,7 +34,7 @@ vi.mock('sonner', () => ({
   toast: { success: toastSuccessMock, error: toastErrorMock },
 }))
 
-function renderModal(props: Partial<React.ComponentProps<typeof ServiceEvaluationModal>> = {}) {
+function renderModal(props: Partial<ComponentProps<typeof ServiceEvaluationModal>> = {}) {
   const onClose = props.onClose ?? vi.fn()
   const onSubmitted = props.onSubmitted ?? vi.fn()
   const utils = render(

--- a/frontend/src/test/components/ServiceEvaluationModal.test.tsx
+++ b/frontend/src/test/components/ServiceEvaluationModal.test.tsx
@@ -1,0 +1,150 @@
+import { ChakraProvider } from '@chakra-ui/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ServiceEvaluationModal from '@/components/ServiceEvaluationModal'
+import system from '@/theme'
+
+/**
+ * NFR-14d — when a photo upload fails after the evaluation itself has
+ * persisted, the modal must close with a non-blocking warning toast
+ * (instead of stranding the user with a generic error and an open modal
+ * that no longer needs their attention). These tests pin both the
+ * generic-failure and the file-too-large (413) paths.
+ */
+
+const { submitCombinedMock, attachReviewImagesMock, toastSuccessMock, toastErrorMock } =
+  vi.hoisted(() => ({
+    submitCombinedMock: vi.fn(),
+    attachReviewImagesMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+  }))
+
+vi.mock('@/services/reputationAPI', () => ({
+  reputationAPI: {
+    submitCombined: submitCombinedMock,
+    submitCombinedEvent: vi.fn(),
+    attachReviewImages: attachReviewImagesMock,
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: toastSuccessMock, error: toastErrorMock },
+}))
+
+function renderModal(props: Partial<React.ComponentProps<typeof ServiceEvaluationModal>> = {}) {
+  const onClose = props.onClose ?? vi.fn()
+  const onSubmitted = props.onSubmitted ?? vi.fn()
+  const utils = render(
+    <ChakraProvider value={system}>
+      <ServiceEvaluationModal
+        isOpen
+        onClose={onClose}
+        onSubmitted={onSubmitted}
+        handshakeId="hs-1"
+        counterpartName="Cem"
+        {...props}
+      />
+    </ChakraProvider>,
+  )
+  return { ...utils, onClose, onSubmitted }
+}
+
+function attachOneImage(): void {
+  // The modal renders an <input type="file"> hidden behind the "Add photos"
+  // button. Drive it directly via fireEvent so we don't need user-event's
+  // pointer simulation.
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement | null
+  expect(input).not.toBeNull()
+  const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' })
+  fireEvent.change(input!, { target: { files: [file] } })
+}
+
+function selectFirstPositiveTrait(): void {
+  // Trait toggles are buttons with their label text. "Punctual" is the
+  // first positive service trait and is always rendered.
+  fireEvent.click(screen.getByRole('button', { name: /Punctual/i }))
+}
+
+async function clickSubmit(): Promise<void> {
+  const submit = await screen.findByRole('button', { name: /submit evaluation/i })
+  fireEvent.click(submit)
+}
+
+describe('ServiceEvaluationModal — photo upload failure (NFR-14d)', () => {
+  beforeEach(() => {
+    submitCombinedMock.mockReset().mockResolvedValue(undefined)
+    attachReviewImagesMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('closes the modal with a non-blocking warning when the upload fails generically', async () => {
+    attachReviewImagesMock.mockRejectedValue(new Error('network'))
+    const { onClose, onSubmitted } = renderModal()
+
+    selectFirstPositiveTrait()
+    attachOneImage()
+    await clickSubmit()
+
+    await waitFor(() => {
+      expect(submitCombinedMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(attachReviewImagesMock).toHaveBeenCalledTimes(1)
+    })
+
+    // The warning toast must explicitly say the evaluation persisted so
+    // the user knows the trait/comment they typed is not lost.
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled()
+    })
+    const errorMsg = toastErrorMock.mock.calls.at(-1)?.[0] as string
+    expect(errorMsg).toMatch(/your evaluation was saved/i)
+
+    // The success path still fires (close + onSubmitted) — that's the
+    // behavioural contract NFR-14d asserts.
+    expect(toastSuccessMock).toHaveBeenCalled()
+    expect(onSubmitted).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('uses the file-too-large copy when the upload returns 413', async () => {
+    attachReviewImagesMock.mockRejectedValue({ response: { status: 413 } })
+    const { onClose } = renderModal()
+
+    selectFirstPositiveTrait()
+    attachOneImage()
+    await clickSubmit()
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled()
+    })
+    const errorMsg = toastErrorMock.mock.calls.at(-1)?.[0] as string
+    expect(errorMsg).toMatch(/files are too large/i)
+    expect(errorMsg).toMatch(/your evaluation was saved without photos/i)
+
+    // Close path still runs — same NFR-14d contract.
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not call attachReviewImages when no images are attached', async () => {
+    const { onSubmitted, onClose } = renderModal()
+
+    selectFirstPositiveTrait()
+    await clickSubmit()
+
+    await waitFor(() => {
+      expect(submitCombinedMock).toHaveBeenCalledTimes(1)
+    })
+    expect(attachReviewImagesMock).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalled()
+    expect(onSubmitted).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/e2e/feature-14/11-nfr-14d.spec.ts
+++ b/frontend/tests/e2e/feature-14/11-nfr-14d.spec.ts
@@ -13,14 +13,7 @@ import {
  * separately (warning toast), then close the modal.
  */
 
-// Category C: ServiceEvaluationModal does not close or fire the
-// "Evaluation submitted" success toast when the image upload step fails;
-// it surfaces an error toast and keeps the modal open so the user can
-// retry. The spec asserts a fire-and-forget recovery flow that is not the
-// product's behavior — coverage of "evaluation persisted, photo failed
-// separately" should sit in a backend/integration test once the desired
-// UX is settled.
-test.skip('NFR-14d: evaluation is saved even when image upload fails', async ({ page }) => {
+test('NFR-14d: evaluation is saved even when image upload fails', async ({ page }) => {
   const title = uniqueTitle('NFR-14d Upload Fail')
   const provider = USERS.elif
   const requester = USERS.ayse
@@ -76,10 +69,7 @@ test.skip('NFR-14d: evaluation is saved even when image upload fails', async ({ 
   expect(repExists, 'Reputation record must exist even when image upload failed').toBeTruthy()
 })
 
-// Category C: same modal-flow mismatch as the test above — when the photo
-// upload errors out the modal intentionally stays open with the Submit
-// Evaluation button visible so the user can fix and retry.
-test.skip('NFR-14d: evaluation modal closes after submission regardless of image upload outcome', async ({ page }) => {
+test('NFR-14d: evaluation modal closes after submission regardless of image upload outcome', async ({ page }) => {
   const title = uniqueTitle('NFR-14d Modal Close')
   const provider = USERS.elif
   const requester = USERS.ayse

--- a/frontend/tests/e2e/feature-7/09-fr-07i.spec.ts
+++ b/frontend/tests/e2e/feature-7/09-fr-07i.spec.ts
@@ -6,14 +6,7 @@ import {
   loginAsUserWithBalanceBelow,
 } from '../helpers'
 
-test.skip('FR-07i: failed Time Share operations do not partially commit balance or ledger changes', async ({ page }) => {
-  // Category C: loginAsUserWithBalanceBelow(page, 10) iterates seeded demo
-  // users until one has < 10 hours. After the demo seed was rebalanced the
-  // condition is never satisfied, so the helper throws "Could not find a
-  // demo user with balance below 10" before the spec body runs (every
-  // attempt fails in ~10s). Either re-seed a guaranteed low-balance user
-  // or rewrite the spec to call /api/e2e/set-balance/ before posting.
-
+test('FR-07i: failed Time Share operations do not partially commit balance or ledger changes', async ({ page }) => {
   // Pick a user who cannot afford the requested duration so the create flow must fail.
   const { balance: startingBalance } = await loginAsUserWithBalanceBelow(page, 10)
   const beforeTransactions = await listTransactions(page)


### PR DESCRIPTION
## Summary

Closes #525.

Cleanup PR covering five separate items the e2e suite or recent triage flagged. Each one is small enough to land independently; bundled here because none of them justify a PR on their own and reviewer context is the same backend slice for four of the five.

- Service detail page was N+1 on `comment_count`, `is_saved`, and `is_dismissed` — those are `SerializerMethodField`s that fall through to per-row queries when the queryset isn't annotated. The list path already annotated them; the retrieve path didn't. Adding the same annotations on retrieve keeps query count flat as comment volume / save / dismissal tables grow. Pinned by a query-count regression test.
- Wikidata tag autocomplete fanned out one `wbgetentities` round-trip per result row to classify the entity type, on top of the initial `wbsearchentities`. New `fetch_wikidata_claims_batch` collapses up to 50 ids into a single call (the API's hard ceiling) and warms the existing per-QID cache, so the per-row helper inside `classify_and_filter_results` becomes a cache hit. Helper signature is unchanged; existing tests that mock the per-id helper still work.
- Demo seed: `setup_demo.py` had drifted into giving every account ≥10h after the handshake settlement step. The `feature-7/09-fr-07i` spec needs at least one sub-10h account to verify the "post a Need that costs more than your balance is rejected" flow, so it was skipped. Pinned Cem to 5h after handshakes settle and updated the script's docstring table; spec un-skipped.
- `ServiceEvaluationModal` was treating a photo-upload failure as a fatal error, but the trait/comment evaluation has already persisted at that point — keeping the modal open with a generic error toast confused users and stranded them on a workflow they couldn't usefully continue. Photo upload is now best-effort: on failure we surface a non-blocking warning that explicitly tells the user the evaluation was saved and they can retry attaching photos later, then close the modal. Different copy for the 413 (file too large) path so the user knows what to fix. The two `feature-14/11-nfr-14d` specs are un-skipped.
- `log_admin_action` was returning `None` and the admin endpoints re-queried the audit log to render the freshly-appended row. There's a real read-after-write window — small in dev, larger if admin reads ever go through a follower replica — where the row hasn't propagated yet. Now `log_admin_action` returns the row it just persisted, and `warn_user` includes it inline as `audit_log` in the response so the moderation console can update its list locally without a follow-up GET.

## Changes

**Backend**
- `ServiceViewSet.get_queryset` retrieve branch: add `Count('comments', filter=Q(is_deleted=False))` annotation; add `Exists(SavedService)` and `Exists(ServiceDismissal)` for authenticated viewers.
- `api/wikidata.py`: new `fetch_wikidata_claims_batch(qids)` (single `wbgetentities` for up to 50 ids, populates the per-QID cache); `classify_and_filter_results` calls the batch warmer before iterating.
- `api/views.py::log_admin_action` returns the persisted `AdminAuditLog`.
- `api/views.py::warn_user` adds `audit_log` to the response payload (serialized via `AdminAuditLogSerializer`).
- `setup_demo.py`: pin Cem's `timebank_balance` to 5.00 after the handshake/transaction seeding step; document Cem as the canonical low-balance demo account in the docstring users table.

**Frontend**
- `ServiceEvaluationModal.tsx`: photo upload failure no longer aborts the success path. Closes the modal, fires both the success toast and a separate non-blocking warning toast (different copy for 413 vs generic).

**Tests**
- `test_service_api.py::TestServiceDetailQueryCount` — query count must not grow when comment volume rises 1 → 15, and when SavedService / ServiceDismissal tables fill with unrelated rows. Hard cap at 25 queries per detail hit.
- `test_wikidata.py` — cache hit returns the payload without re-calling `wbsearchentities`; batched lookup uses one upstream call for three ids; classification step does not fan out per QID.
- `test_admin_management_api.py::test_warn_user_response_includes_inline_audit_log_entry` — response carries the entry; its `id` matches the persisted row.
- `ServiceEvaluationModal.test.tsx` (new) — generic upload failure still calls `onClose` + `onSubmitted` with the "saved without photos" warning; 413 uses the file-too-large copy; no images path doesn't call `attachReviewImages`.

**Specs un-skipped**
- `feature-7/09-fr-07i.spec.ts` (insufficient-balance Need creation)
- `feature-14/11-nfr-14d.spec.ts` (both cases — evaluation persists on photo failure)

## Out of scope

- **FR-14g (review thumbnail render).** The skip reason is the cross-feature multi-user login throttle, not the thumbnail pipeline. Backend coverage in `test_review_photos_api.py` already exercises the thumbnail surface; the UI assertion needs the multi-user fixture refactor that's deferred separately.
- **NFR-08a / NFR-10a (WebSocket cold-handshake latency).** Real, but Docker-CI-amplified and not an obvious one-spot fix without tracing Channels/Redis startup.
- **`feature-5/16-nfr-05d` (concurrent-edit safety).** Still deferred behind in-flight PR #563. Pick up with an ETag/version PR after #563 lands.

## Test plan

- [ ] `cd backend && python manage.py test api.tests.integration.test_service_api api.tests.unit.test_wikidata api.tests.integration.test_admin_management_api`
- [ ] `cd frontend && npm run lint && npx tsc --noEmit -p tsconfig.app.json && npm test -- --run`
- [ ] `feature-7/09-fr-07i` and `feature-14/11-nfr-14d` pass against a fresh `make setup-demo` stack.