### PR TITLE
fix(api): never 500 on offer create with QID tag collisions (#575)

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1009,6 +1009,84 @@ class ServiceSerializer(serializers.ModelSerializer):
             )
         return data
 
+    # ── Tag upsert helpers (issue #575) ──────────────────────────────────────
+    # These exist so `create()` and `update()` never surface an IntegrityError
+    # to the caller when:
+    #   * a Wikidata-resolved label collides with an existing Tag.name (which
+    #     is unique at the DB level), or
+    #   * a `tag_names` insert races another concurrent insert on the same
+    #     name (rare but observable under load).
+    # The fallback behaviour matches the platform's tag policy: prefer the
+    # already-stored row (by name, case-insensitive), falling back to the QID
+    # row when the QID itself already exists. Returns (tag, created) so the
+    # caller can drive post-create enrichment for genuinely new rows only.
+
+    @staticmethod
+    def _upsert_qid_tag(normalized_qid, tag_name):
+        """Resolve or create a Tag for a Wikidata QID without ever raising
+        IntegrityError on the unique-name index.
+
+        Resolution order:
+          1. Existing Tag with id == QID -> reuse (no rename — caller already
+             handled the stale-name case).
+          2. Existing Tag with name iexact == tag_name -> reuse (this is the
+             #575 collision path; pre-fix we tried INSERT and 500'd).
+          3. Otherwise INSERT a fresh Tag(id=QID, name=tag_name). If the
+             INSERT still races on the unique index, fall back to (2)'s
+             lookup.
+        """
+        from django.db import IntegrityError, transaction as _t
+
+        existing = Tag.objects.filter(id=normalized_qid).first()
+        if existing is not None:
+            return existing, False
+
+        if tag_name:
+            collision = Tag.objects.filter(name__iexact=tag_name).first()
+            if collision is not None:
+                return collision, False
+
+        try:
+            with _t.atomic():
+                return Tag.objects.create(id=normalized_qid, name=tag_name), True
+        except IntegrityError:
+            # Lost a race. Re-resolve.
+            existing = Tag.objects.filter(id=normalized_qid).first()
+            if existing is not None:
+                return existing, False
+            if tag_name:
+                collision = Tag.objects.filter(name__iexact=tag_name).first()
+                if collision is not None:
+                    return collision, False
+            return None, False
+
+    @staticmethod
+    def _upsert_named_tag(tag_name_clean):
+        """Resolve or create a Tag from a free-text name without surfacing
+        an IntegrityError when the unique-name index races.
+
+        Falls back to a slugified id, with a uuid suffix when the slug is
+        already taken. On INSERT IntegrityError (either id or name unique
+        index), re-resolves to the row that won the race.
+        """
+        import uuid as _uuid
+        from django.db import IntegrityError, transaction as _t
+
+        try:
+            return Tag.objects.get(name__iexact=tag_name_clean)
+        except Tag.DoesNotExist:
+            pass
+
+        tag_id = tag_name_clean.lower().replace(' ', '_').replace('-', '_')[:200]
+        if Tag.objects.filter(id=tag_id).exists():
+            tag_id = f"{tag_id}_{str(_uuid.uuid4())[:8]}"
+
+        try:
+            with _t.atomic():
+                return Tag.objects.create(id=tag_id, name=tag_name_clean)
+        except IntegrityError:
+            return Tag.objects.filter(name__iexact=tag_name_clean).first()
+
     def create(self, validated_data):
         # Description is already sanitized in validate_description
         # No need to sanitize again here
@@ -1154,7 +1232,19 @@ class ServiceSerializer(serializers.ModelSerializer):
                     for stale_tag in stale_qid_tags:
                         label = wikidata_labels.get(stale_tag.id.upper())
                         if not label:
-                            wikidata_info = fetch_wikidata_item(stale_tag.id.upper())
+                            # Best-effort enrichment. A failed Wikidata round-trip
+                            # (HTTP error, JSON decode error, transient socket
+                            # error) must not 500 the create call — the QID is
+                            # still attached, just without a friendly label.
+                            try:
+                                wikidata_info = fetch_wikidata_item(stale_tag.id.upper())
+                            except Exception as exc:
+                                wikidata_info = None
+                                logger.warning(
+                                    "Wikidata lookup failed during stale-QID "
+                                    "rename; keeping placeholder name (%s)",
+                                    type(exc).__name__,
+                                )
                             label = (wikidata_info or {}).get('label')
                         if not label:
                             continue
@@ -1180,15 +1270,23 @@ class ServiceSerializer(serializers.ModelSerializer):
                         if label_from_form:
                             tag_name = label_from_form
                         else:
-                            wikidata_info = fetch_wikidata_item(normalized_qid)
+                            try:
+                                wikidata_info = fetch_wikidata_item(normalized_qid)
+                            except Exception as exc:
+                                wikidata_info = None
+                                logger.warning(
+                                    "Wikidata lookup failed for %s; using QID "
+                                    "as placeholder name (%s)",
+                                    normalized_qid, type(exc).__name__,
+                                )
                             if wikidata_info and wikidata_info.get('label'):
                                 tag_name = wikidata_info['label']
                             else:
                                 tag_name = normalized_qid
                                 logger.warning(f"Could not fetch Wikidata info for {normalized_qid}, using QID as name")
-                        tag, created = Tag.objects.get_or_create(
-                            id=normalized_qid, defaults={'name': tag_name}
-                        )
+                        tag, created = self._upsert_qid_tag(normalized_qid, tag_name)
+                        if tag is None:
+                            continue
                         if tag not in tags_to_add:
                             tags_to_add.append(tag)
                         if created:
@@ -1209,16 +1307,8 @@ class ServiceSerializer(serializers.ModelSerializer):
             if tag_names:
                 for tag_name in tag_names:
                     if tag_name and tag_name.strip():
-                        tag_name_clean = tag_name.strip()
-                        try:
-                            tag = Tag.objects.get(name__iexact=tag_name_clean)
-                        except Tag.DoesNotExist:
-                            import uuid as _uuid
-                            tag_id = tag_name_clean.lower().replace(' ', '_').replace('-', '_')[:200]
-                            if Tag.objects.filter(id=tag_id).exists():
-                                tag_id = f"{tag_id}_{str(_uuid.uuid4())[:8]}"
-                            tag = Tag.objects.create(id=tag_id, name=tag_name_clean)
-                        if tag not in tags_to_add:
+                        tag = self._upsert_named_tag(tag_name.strip())
+                        if tag is not None and tag not in tags_to_add:
                             tags_to_add.append(tag)
 
             if tags_to_add:
@@ -1354,16 +1444,8 @@ class ServiceSerializer(serializers.ModelSerializer):
                 for tag_name in tag_names:
                     if not tag_name or not tag_name.strip():
                         continue
-                    tag_name_clean = tag_name.strip()
-                    try:
-                        tag = Tag.objects.get(name__iexact=tag_name_clean)
-                    except Tag.DoesNotExist:
-                        import uuid as _uuid
-                        tag_id = tag_name_clean.lower().replace(' ', '_').replace('-', '_')[:200]
-                        if Tag.objects.filter(id=tag_id).exists():
-                            tag_id = f"{tag_id}_{str(_uuid.uuid4())[:8]}"
-                        tag = Tag.objects.create(id=tag_id, name=tag_name_clean)
-                    if tag not in tags_to_set:
+                    tag = self._upsert_named_tag(tag_name.strip())
+                    if tag is not None and tag not in tags_to_set:
                         tags_to_set.append(tag)
             service.tags.set(tags_to_set)
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1034,8 +1034,16 @@ class ServiceSerializer(serializers.ModelSerializer):
           3. Otherwise INSERT a fresh Tag(id=QID, name=tag_name). If the
              INSERT still races on the unique index, fall back to (2)'s
              lookup.
+
+        Truncates ``tag_name`` to ``Tag.name.max_length`` so a long
+        upstream label cannot 500 the request via a column-length
+        violation when Wikidata returns >100 chars.
         """
         from django.db import IntegrityError, transaction as _t
+
+        if tag_name:
+            max_name_len = Tag._meta.get_field('name').max_length or 100
+            tag_name = tag_name.strip()[:max_name_len] or None
 
         existing = Tag.objects.filter(id=normalized_qid).first()
         if existing is not None:
@@ -1067,15 +1075,27 @@ class ServiceSerializer(serializers.ModelSerializer):
 
         Falls back to a slugified id, with a uuid suffix when the slug is
         already taken. On INSERT IntegrityError (either id or name unique
-        index), re-resolves to the row that won the race.
+        index), re-resolves the row that won the race — first by id (so
+        a slug-collision with a different name is recoverable), then by
+        name. Truncates ``tag_name_clean`` to ``Tag.name.max_length`` so
+        a long input cannot 500 the request via a column-length violation.
         """
         import uuid as _uuid
         from django.db import IntegrityError, transaction as _t
 
-        try:
-            return Tag.objects.get(name__iexact=tag_name_clean)
-        except Tag.DoesNotExist:
-            pass
+        # Tag.name has max_length=100 at the DB level; longer free-text
+        # input would otherwise raise DataError on insert and 500.
+        max_name_len = Tag._meta.get_field('name').max_length or 100
+        tag_name_clean = (tag_name_clean or '').strip()[:max_name_len]
+        if not tag_name_clean:
+            return None
+
+        # Use filter().first() not get() — the DB unique index on name is
+        # case-sensitive in Postgres, so two tags differing only by case
+        # would otherwise raise MultipleObjectsReturned and 500.
+        existing = Tag.objects.filter(name__iexact=tag_name_clean).first()
+        if existing is not None:
+            return existing
 
         tag_id = tag_name_clean.lower().replace(' ', '_').replace('-', '_')[:200]
         if Tag.objects.filter(id=tag_id).exists():
@@ -1085,7 +1105,14 @@ class ServiceSerializer(serializers.ModelSerializer):
             with _t.atomic():
                 return Tag.objects.create(id=tag_id, name=tag_name_clean)
         except IntegrityError:
-            return Tag.objects.filter(name__iexact=tag_name_clean).first()
+            # Race recovery — id-collision can land here when the slug
+            # we generated coincided with a row created mid-flight under
+            # a different name; re-resolve by both keys before falling
+            # back to None.
+            recovered = Tag.objects.filter(name__iexact=tag_name_clean).first()
+            if recovered is not None:
+                return recovered
+            return Tag.objects.filter(id=tag_id).first()
 
     def create(self, validated_data):
         # Description is already sanitized in validate_description
@@ -1270,20 +1297,21 @@ class ServiceSerializer(serializers.ModelSerializer):
                         if label_from_form:
                             tag_name = label_from_form
                         else:
+                            wikidata_info = None
                             try:
                                 wikidata_info = fetch_wikidata_item(normalized_qid)
                             except Exception as exc:
-                                wikidata_info = None
+                                # Log only the exception type to keep
+                                # user-supplied QIDs out of the log line.
                                 logger.warning(
-                                    "Wikidata lookup failed for %s; using QID "
-                                    "as placeholder name (%s)",
-                                    normalized_qid, type(exc).__name__,
+                                    "Wikidata lookup failed (%s); using "
+                                    "QID as placeholder name",
+                                    type(exc).__name__,
                                 )
                             if wikidata_info and wikidata_info.get('label'):
                                 tag_name = wikidata_info['label']
                             else:
                                 tag_name = normalized_qid
-                                logger.warning(f"Could not fetch Wikidata info for {normalized_qid}, using QID as name")
                         tag, created = self._upsert_qid_tag(normalized_qid, tag_name)
                         if tag is None:
                             continue

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -1058,10 +1058,14 @@ class TestOfferCreateTagPayloads:
 
         assert_api_response(response, 201)
         attached_ids = {t['id'] for t in response.data.get('tags', [])}
-        assert attached_ids, 'expected the offer to surface at least one tag'
         # The fix must reuse the existing row by name rather than create
-        # a new row with the same name and 500 on the unique index.
-        assert (existing.id in attached_ids) or ('Q9888' in attached_ids)
+        # a new row with the same name and 500 on the unique index. Pin
+        # to the stored row's id so a regression that resurrects the
+        # parallel-INSERT path is caught — 'Q9888' showing up here would
+        # mean the helper bypassed the name-collision lookup.
+        assert existing.id in attached_ids
+        assert 'Q9888' not in attached_ids
+        assert not Tag.objects.filter(id='Q9888').exists()
 
     @patch('api.wikidata.fetch_wikidata_claims', return_value=None)
     @patch('api.wikidata.fetch_wikidata_item', return_value=None)

--- a/backend/api/tests/integration/test_service_api.py
+++ b/backend/api/tests/integration/test_service_api.py
@@ -2,6 +2,8 @@
 Integration tests for service API endpoints
 """
 import pytest
+import requests
+from unittest.mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
 from decimal import Decimal
@@ -11,7 +13,7 @@ from django.utils import timezone
 from api.tests.helpers.factories import UserFactory, ServiceFactory, TagFactory, HandshakeFactory
 from api.tests.helpers.factories import AdminUserFactory
 from api.tests.helpers.test_client import AuthenticatedAPIClient
-from api.models import Service, Notification, TransactionHistory
+from api.models import Service, Notification, TransactionHistory, Tag
 from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
@@ -922,3 +924,167 @@ class TestServiceRetrieveStatusVisibility:
         assert service.session_exact_location_lat == Decimal('40.987654')
         assert service.session_exact_location_lng == Decimal('29.123456')
         assert service.session_location_guide == 'Veterinerin olduğu bina'
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestOfferCreateTagPayloads:
+    """Regression tests for issue #575 — POST /api/services/ must never 500
+    based on the contents of `tag_ids` or `tag_names`.
+
+    The pre-fix create path raised on three legitimate inputs:
+
+    1. A QID in `tag_ids` that did not yet exist as a Tag, where the
+       Wikidata label happened to collide with an existing tag's `name`
+       (`Tag.name` is unique). `Tag.objects.get_or_create(id=...,
+       defaults={'name': label})` then surfaced an `IntegrityError` as
+       a 500.
+    2. A QID in `tag_ids` that did not yet exist as a Tag, where the
+       Wikidata fetch raised an exception not caught upstream (anything
+       that wasn't `RequestException / KeyError / ValueError`).
+    3. The `tag_names` flow, where `Tag.objects.create(...)` raced with
+       a concurrent insert on the unique `name` index.
+
+    Each test below expects the create call to succeed with 201, with
+    unresolvable QIDs silently dropped from the response payload. The
+    pre-fix behaviour was 500.
+    """
+
+    def _payload(self, tag_ids=None, tag_names=None, wikidata_labels_json=None):
+        body = {
+            'title': 'Tag Payload Offer',
+            'description': 'Exercises the tag-creation path on /api/services/.',
+            'type': 'Offer',
+            'duration': 1.0,
+            'location_type': 'Online',
+            'max_participants': 1,
+            'schedule_type': 'One-Time',
+            'status': 'Active',
+        }
+        if tag_ids is not None:
+            body['tag_ids'] = tag_ids
+        if tag_names is not None:
+            body['tag_names'] = tag_names
+        if wikidata_labels_json is not None:
+            body['wikidata_labels_json'] = wikidata_labels_json
+        return body
+
+    def _client(self):
+        user = UserFactory(is_verified=True)
+        client = AuthenticatedAPIClient()
+        client.authenticate_user(user)
+        return client
+
+    def test_create_with_valid_tag_ids_returns_201(self):
+        """Baseline: existing tag id resolves and is attached."""
+        tag = TagFactory()
+        client = self._client()
+
+        response = client.post('/api/services/', self._payload(tag_ids=[tag.id]))
+
+        assert_api_response(response, 201)
+        attached = {t['id'] for t in response.data.get('tags', [])}
+        assert tag.id in attached
+
+    def test_create_with_empty_tag_ids_returns_201(self):
+        """Empty tag list must not regress the create path."""
+        client = self._client()
+
+        response = client.post('/api/services/', self._payload(tag_ids=[]))
+
+        assert_api_response(response, 201)
+        assert response.data.get('tags', []) == []
+
+    @patch('api.wikidata.fetch_wikidata_claims', return_value=None)
+    @patch('api.wikidata.fetch_wikidata_item', return_value=None)
+    def test_create_with_mixed_valid_and_unknown_tag_ids_returns_201(
+        self, _mock_item, _mock_claims
+    ):
+        """Mixed payload: valid tag survives, unknown non-QID id is dropped."""
+        tag = TagFactory()
+        client = self._client()
+
+        response = client.post(
+            '/api/services/',
+            self._payload(tag_ids=[tag.id, 'not-a-real-tag-id-xyz']),
+        )
+
+        assert_api_response(response, 201)
+        attached = {t['id'] for t in response.data.get('tags', [])}
+        assert tag.id in attached
+        assert 'not-a-real-tag-id-xyz' not in attached
+
+    @patch(
+        'api.wikidata.fetch_wikidata_item',
+        side_effect=requests.RequestException('wikidata down'),
+    )
+    def test_create_with_qid_when_wikidata_raises_returns_201(self, _mock_item):
+        """If Wikidata is down (raises RequestException), the create
+        endpoint must still succeed — the QID is best-effort enrichment.
+
+        Pre-fix this path 500'd because the exception propagated out of
+        `ServiceSerializer.create`. The fix wraps the lookup in a
+        defensive try/except so the create transaction commits and the
+        caller gets 201.
+        """
+        client = self._client()
+
+        response = client.post('/api/services/', self._payload(tag_ids=['Q424242']))
+
+        assert_api_response(response, 201)
+
+    @patch('api.wikidata.fetch_wikidata_claims', return_value=None)
+    def test_create_with_qid_label_colliding_with_existing_tag_returns_201(
+        self, _mock_claims
+    ):
+        """Reproduces the original #575 500: a fresh QID whose Wikidata
+        label collides with an existing `Tag.name` triggered an
+        IntegrityError on the unique-name index from
+        `Tag.objects.get_or_create(id=..., defaults={'name': label})`.
+
+        Post-fix the create succeeds and the existing tag is reused.
+        """
+        existing = Tag.objects.create(id='hand_made_tag', name='Yoga')
+        client = self._client()
+
+        with patch(
+            'api.wikidata.fetch_wikidata_item',
+            return_value={'id': 'Q9888', 'label': 'Yoga'},
+        ):
+            response = client.post(
+                '/api/services/',
+                self._payload(tag_ids=['Q9888']),
+            )
+
+        assert_api_response(response, 201)
+        attached_ids = {t['id'] for t in response.data.get('tags', [])}
+        assert attached_ids, 'expected the offer to surface at least one tag'
+        # The fix must reuse the existing row by name rather than create
+        # a new row with the same name and 500 on the unique index.
+        assert (existing.id in attached_ids) or ('Q9888' in attached_ids)
+
+    @patch('api.wikidata.fetch_wikidata_claims', return_value=None)
+    @patch('api.wikidata.fetch_wikidata_item', return_value=None)
+    def test_create_with_tag_names_reuses_existing_row_returns_201(
+        self, _mock_item, _mock_claims
+    ):
+        """`tag_names` flow must reuse an existing tag with the same
+        case-insensitive name instead of attempting a fresh INSERT
+        (which 500'd via IntegrityError on the unique name index in the
+        race window).
+        """
+        existing = Tag.objects.create(id='photography_seed', name='Photography')
+        client = self._client()
+
+        # Different casing — pre-fix the case-insensitive lookup found
+        # the row, but in the race between get() and create() the INSERT
+        # would still fire and 500 on the unique name index. Post-fix the
+        # create path uses a save-pointed get_or_create equivalent.
+        response = client.post(
+            '/api/services/',
+            self._payload(tag_names=['photography']),
+        )
+
+        assert_api_response(response, 201)
+        attached_ids = {t['id'] for t in response.data.get('tags', [])}
+        assert existing.id in attached_ids

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -818,3 +818,149 @@ class TestParticipantCountField:
         assert len(handshake_queries) == 0, (
             f"Expected no Handshake queries when prefetched, got {len(handshake_queries)}"
         )
+
+
+@pytest.mark.django_db
+@pytest.mark.unit
+class TestServiceSerializerTagUpsertHelpers:
+    """Direct coverage for the #575 tag-upsert helpers — every branch.
+
+    Routing through `ServiceSerializer.create` only reaches the happy
+    paths because IntegrityError fallbacks need a racing concurrent
+    insert; mocking `Tag.objects.create` here lets each branch be tested
+    in isolation without hitting the DB twice.
+    """
+
+    def test_upsert_qid_returns_existing_row_when_qid_already_present(self):
+        """Branch 1: existing Tag(id=QID) is returned without rename or insert."""
+        existing = Tag.objects.create(id='Q9999', name='Stored Label')
+        tag, created = ServiceSerializer._upsert_qid_tag('Q9999', 'Different Label')
+        assert created is False
+        assert tag.id == existing.id
+        # No rename — branch is "found by id, return as-is".
+        assert tag.name == 'Stored Label'
+
+    def test_upsert_qid_returns_existing_name_when_id_misses_but_label_collides(self):
+        """Branch 2 (the #575 collision path): same label exists under a
+        different id; prefer the stored row over inserting a duplicate."""
+        existing = Tag.objects.create(id='manual-tag', name='Yoga')
+        tag, created = ServiceSerializer._upsert_qid_tag('Q11111', 'Yoga')
+        assert created is False
+        assert tag.id == existing.id
+
+    def test_upsert_qid_inserts_a_fresh_row_when_no_collision(self):
+        """Branch 3: id and name both free — create a brand new row."""
+        tag, created = ServiceSerializer._upsert_qid_tag('Q22222', 'Brand New Tag')
+        assert created is True
+        assert tag.id == 'Q22222'
+        assert tag.name == 'Brand New Tag'
+
+    def test_upsert_qid_recovers_when_insert_races(self):
+        """Branch 4: INSERT lost a race; helper re-resolves to the winner."""
+        from django.db import IntegrityError
+        # Simulate the race: another writer landed the same QID first.
+        Tag.objects.create(id='Q33333', name='Race Winner')
+        with patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag, created = ServiceSerializer._upsert_qid_tag('Q33333', 'Race Loser')
+        assert created is False
+        assert tag.id == 'Q33333'
+        # Helper picked up the existing row, didn't try a second insert.
+        assert tag.name == 'Race Winner'
+
+    def test_upsert_qid_recovers_via_name_lookup_when_id_race_misses(self):
+        """Branch 4-name: race fell to neither id nor a fresh insert; the
+        recovery path looks up by name as the secondary fallback."""
+        from django.db import IntegrityError
+        Tag.objects.create(id='other-id', name='Race Pottery')
+        with patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag, created = ServiceSerializer._upsert_qid_tag('Q44444', 'Race Pottery')
+        assert created is False
+        assert tag.id == 'other-id'
+
+    def test_upsert_qid_returns_none_when_every_lookup_misses(self):
+        """Branch 4-give-up: race left no row to attach to (extremely rare,
+        but the helper must return None instead of raising)."""
+        from django.db import IntegrityError
+        with patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag, created = ServiceSerializer._upsert_qid_tag('Q55555', 'Nothing Here')
+        assert tag is None
+        assert created is False
+
+    def test_upsert_named_returns_existing_name_when_present(self):
+        """Branch 1: name already exists — re-use it."""
+        existing = Tag.objects.create(id='woodworking', name='Woodworking')
+        tag = ServiceSerializer._upsert_named_tag('Woodworking')
+        assert tag.id == existing.id
+
+    def test_upsert_named_creates_fresh_when_name_unique(self):
+        """Branch 2: brand-new name slugifies to a free id — INSERT it."""
+        tag = ServiceSerializer._upsert_named_tag('Backyard Beekeeping')
+        assert tag.id == 'backyard_beekeeping'
+        assert tag.name == 'Backyard Beekeeping'
+
+    def test_upsert_named_disambiguates_slug_when_id_collides(self):
+        """Branch 3: slug clashes with an existing id; helper appends a
+        uuid suffix so the INSERT does not 500."""
+        Tag.objects.create(id='cooking', name='Already Taken')
+        tag = ServiceSerializer._upsert_named_tag('Cooking')
+        assert tag.name == 'Cooking'
+        # Suffixed id so the unique-id index is honoured.
+        assert tag.id != 'cooking'
+        assert tag.id.startswith('cooking_')
+
+    def test_upsert_named_recovers_when_insert_races(self):
+        """Branch 4: INSERT raced and lost; recovery picks the winner up
+        via name lookup. The entry-point ``.get(name)`` must miss so we
+        actually reach the try/except (otherwise the helper short-
+        circuits at line 1076). Patching ``.get`` to raise simulates the
+        race window: at entry no row, by INSERT-time another writer
+        landed."""
+        from django.db import IntegrityError
+        existing = Tag.objects.create(id='knitting', name='Knitting')
+        with patch('api.serializers.Tag.objects.get', side_effect=Tag.DoesNotExist), \
+             patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag = ServiceSerializer._upsert_named_tag('Knitting')
+        assert tag is not None
+        assert tag.id == existing.id
+
+    # The last two recovery branches in `_upsert_qid_tag` (post-
+    # IntegrityError, found-by-id and post-IntegrityError, found-by-
+    # name) need a queryset whose ``.first()`` returns different values
+    # across calls — the entry-time check must miss while the recovery
+    # check finds the racing row. Savepoint rollback prevents arranging
+    # this with a real DB row, so the queryset is mocked outright.
+
+    def test_upsert_qid_recovery_returns_id_match_after_race(self):
+        """Cover the post-IntegrityError 'found by id' return path."""
+        from django.db import IntegrityError
+        from unittest.mock import MagicMock
+        race_winner = Tag(id='Q88888', name='Race Winner')
+        qs = MagicMock()
+        # Two .first() calls happen with tag_name=None: entry-by-id and
+        # recovery-by-id. Entry misses, recovery finds the winner.
+        qs.first.side_effect = [None, race_winner]
+        with patch('api.serializers.Tag.objects.filter', return_value=qs), \
+             patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag, created = ServiceSerializer._upsert_qid_tag('Q88888', None)
+        assert created is False
+        assert tag is race_winner
+
+    def test_upsert_qid_recovery_returns_name_match_after_race(self):
+        """Cover the post-IntegrityError 'found by name' return path —
+        id recovery still misses but the unique-name index still has a
+        row to attach to."""
+        from django.db import IntegrityError
+        from unittest.mock import MagicMock
+        race_winner = Tag(id='other-id', name='Race Pottery')
+        qs = MagicMock()
+        # .first() call sequence with tag_name set:
+        #   1. entry-by-id  -> None
+        #   2. entry-by-name -> None
+        #   3. recovery-by-id -> None
+        #   4. recovery-by-name -> winner
+        qs.first.side_effect = [None, None, None, race_winner]
+        with patch('api.serializers.Tag.objects.filter', return_value=qs), \
+             patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag, created = ServiceSerializer._upsert_qid_tag('Q99999', 'Race Pottery')
+        assert created is False
+        assert tag is race_winner

--- a/backend/api/tests/unit/test_serializers.py
+++ b/backend/api/tests/unit/test_serializers.py
@@ -964,3 +964,61 @@ class TestServiceSerializerTagUpsertHelpers:
             tag, created = ServiceSerializer._upsert_qid_tag('Q99999', 'Race Pottery')
         assert created is False
         assert tag is race_winner
+
+    def test_upsert_qid_truncates_long_label_to_column_length(self):
+        """Wikidata can return labels longer than ``Tag.name.max_length``;
+        the helper must clamp them so a fresh INSERT doesn't raise
+        DataError on the column-length check."""
+        max_len = Tag._meta.get_field('name').max_length or 100
+        long_label = 'a' * (max_len + 50)
+        tag, created = ServiceSerializer._upsert_qid_tag('Qlongq', long_label)
+        assert created is True
+        assert len(tag.name) == max_len
+
+    def test_upsert_named_truncates_long_name_to_column_length(self):
+        """Same column-length guarantee for the free-text name path."""
+        max_len = Tag._meta.get_field('name').max_length or 100
+        tag = ServiceSerializer._upsert_named_tag('b' * (max_len + 50))
+        assert tag is not None
+        assert len(tag.name) == max_len
+
+    def test_upsert_named_returns_none_for_blank_input(self):
+        """Whitespace-only input cannot become a tag — a row with
+        ``name=''`` would also collide with future blank submissions on
+        the unique-name index."""
+        assert ServiceSerializer._upsert_named_tag('   ') is None
+        assert ServiceSerializer._upsert_named_tag('') is None
+
+    def test_upsert_named_handles_case_variants_via_filter_not_get(self):
+        """Postgres unique-name index is case-sensitive, so two tags
+        differing only by case are legal at the DB level. The helper
+        must use ``filter(...).first()`` rather than ``.get(...)`` so
+        ``MultipleObjectsReturned`` cannot 500 the request — pick the
+        first matching row deterministically."""
+        Tag.objects.create(id='cooking_a', name='cooking')
+        Tag.objects.create(id='cooking_b', name='Cooking')
+        # Either match is acceptable; the contract is "no 500".
+        tag = ServiceSerializer._upsert_named_tag('COOKING')
+        assert tag is not None
+        assert tag.name.lower() == 'cooking'
+
+    def test_upsert_named_recovery_falls_through_to_id_lookup(self):
+        """When the IntegrityError was raised by an id-collision rather
+        than a name-collision, the recovery filter(name) misses but
+        filter(id) finds the racing row — the helper must return that
+        instead of None."""
+        from django.db import IntegrityError
+        from unittest.mock import MagicMock
+        race_by_id = Tag(id='knit_id', name='Different Name')
+        # filter() call sequence under a blank DB:
+        #   1. entry filter(name).first() -> None
+        #   2. entry filter(id).exists()  -> False
+        #   3. recovery filter(name).first() -> None
+        #   4. recovery filter(id).first()   -> race_by_id
+        qs = MagicMock()
+        qs.first.side_effect = [None, None, race_by_id]
+        qs.exists.return_value = False
+        with patch('api.serializers.Tag.objects.filter', return_value=qs), \
+             patch('api.serializers.Tag.objects.create', side_effect=IntegrityError('uniq')):
+            tag = ServiceSerializer._upsert_named_tag('Knit')
+        assert tag is race_by_id


### PR DESCRIPTION
## Bug

`POST /api/services/` returned 500 on a payload that included a Wikidata QID in `tag_ids` whose resolved label collided with an existing `Tag.name`. Issue #575 was filed with only a screenshot, so I reproduced from the code path first and walked the failure modes.

Closes #575.

## Reproduction

Two distinct shapes both surface the 500:

1. **Label collision on the unique-name index** — most likely the original report:
   - Pre-existing `Tag(id='hand_made_tag', name='Yoga')`.
   - Client posts an offer with `tag_ids=['Q9888']`. `Q9888` does not yet exist as a row.
   - `fetch_wikidata_item('Q9888')` resolves to `{'label': 'Yoga'}`.
   - The pre-fix code calls `Tag.objects.get_or_create(id='Q9888', defaults={'name': 'Yoga'})`. The `id` lookup misses, so it tries `INSERT`. PostgreSQL rejects on `api_tag_name_key` because the name `Yoga` is already taken. `IntegrityError` propagates out of `ServiceSerializer.create` as a 500.

2. **Unhandled exception from the Wikidata round-trip**:
   - `tag_ids=['Q424242']` for a QID not present locally.
   - `fetch_wikidata_item(...)` raises an exception not in its catch tuple (`RequestException / KeyError / ValueError`). The pre-fix code has no try/except around the call, and the exception leaves `serializers.py:1183` unhandled.

The `tag_names` flow had a parallel race: `Tag.objects.create(id=slug, name=label)` could lose to a concurrent insert on the unique name index. Same shape of 500.

## Root cause

`backend/api/serializers.py::ServiceSerializer.create` lines ~1153-1158 and ~1183-1190 trusted upstream. There was no defensive boundary around either:
- the Wikidata lookup (any uncaught exception escapes the create path), or
- the `Tag.objects.get_or_create(id=QID, ...)` call (the unique name index sits orthogonal to the lookup key).

## Fix

Two small static helpers on `ServiceSerializer`:

| Helper | Resolution order |
|---|---|
| `_upsert_qid_tag(qid, name)` | (1) `Tag.id == qid` (2) `Tag.name iexact == name` (3) savepointed INSERT, IntegrityError demotes back to (1) and (2). |
| `_upsert_named_tag(name)` | (1) `Tag.name iexact == name` (2) savepointed INSERT with a slugified id (uuid suffix on slug collision). IntegrityError re-resolves by name. |

The savepoint scope means the surrounding `transaction.atomic()` opened by the create flow is never poisoned by a lost race.

`fetch_wikidata_item(...)` calls now sit inside `try/except Exception` with a `WARN` log carrying only the exception type — no user-supplied content goes into the log message.

The `update()` path's `tag_names` flow now uses the same helper.

Files: `backend/api/serializers.py` (107 insertions, 25 deletions).

## Tests

`backend/api/tests/integration/test_service_api.py::TestOfferCreateTagPayloads` (six cases):

- 201 with valid `tag_ids` (baseline)
- 201 with empty `tag_ids` (regression check)
- 201 with mixed valid + non-existent `tag_ids`; non-existent silently dropped
- 201 when `fetch_wikidata_item` raises `RequestException`
- 201 when a QID's Wikidata label collides with an existing `Tag.name` (the original repro)
- 201 when `tag_names` supplies a case-variant of an existing name

Verified the two new-bug tests **fail** on `origin/dev` (500 + IntegrityError on the unique-name index, and uncaught RequestException) and **pass** with the fix. Full file: 56 tests, all green. Wikidata-related unit tests: 73 tests, all green.

## Mobile build verification

The plan called for a clean-checkout mobile build sanity. Verified on a fresh worktree at `origin/dev` (`b6dacd8`):

```
cd mobile-client
rm -rf node_modules
npm ci                                     # 568 packages, clean
npx tsc --noEmit                           # exit 0
npm test -- --ci                           # 25 suites, 173 tests, all pass
EXPO_PUBLIC_API_URL=http://localhost:8000/api npx expo export --platform ios
                                           # bundles cleanly (4.85 MB hbc)
```

Mobile builds cleanly on `origin/dev`. The local breakage some have seen is a stale-tree artifact — `git checkout -- mobile-client/` in the working copy is enough to recover.

## Verification

```bash
cd backend && python manage.py test api.tests.integration.test_service_api::TestOfferCreateTagPayloads  # 6/6
cd backend && python manage.py test api.tests.integration.test_service_api                              # 56/56
```