### PR TITLE
fix(events): surface attendance-QR generation errors via toast

### DIFF
--- a/backend/api/tests/unit/test_event_service.py
+++ b/backend/api/tests/unit/test_event_service.py
@@ -451,6 +451,24 @@ class TestGenerateQRToken:
         with pytest.raises(ValueError, match='does not require'):
             EventHandshakeService.generate_qr_token(service, organizer)
 
+    def test_cannot_generate_outside_lockdown_window(self):
+        """Pin the 24-hour lockdown gate.
+
+        Generation must raise ``ValueError`` with the user-readable message
+        when the event is more than 24h away. The frontend depends on this
+        exact message to surface "Could not generate the attendance QR" via
+        the ServerError toast (EventRosterModal); silently swallowing the
+        error in the FE used to leave the button stuck on "Generating...".
+        """
+        organizer = UserFactory()
+        service = _qr_event(organizer=organizer, hours_until_start=48)
+        assert not service.is_in_lockdown_window
+        with pytest.raises(
+            ValueError,
+            match='QR token can only be generated within 24 hours',
+        ):
+            EventHandshakeService.generate_qr_token(service, organizer)
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/frontend/src/components/EventRosterModal.tsx
+++ b/frontend/src/components/EventRosterModal.tsx
@@ -2,9 +2,11 @@ import { type ReactNode, useState, useEffect, useRef, useCallback } from 'react'
 import { Box, Flex, Stack, Text } from '@chakra-ui/react'
 import { FiX, FiCheckCircle, FiAlertCircle, FiUsers } from 'react-icons/fi'
 import { QRCodeSVG } from 'qrcode.react'
+import { toast } from 'sonner'
 import type { Service } from '@/types'
 import type { Handshake } from '@/services/handshakeAPI'
 import { serviceAPI } from '@/services/serviceAPI'
+import { extractTopLevelDetail } from '@/utils/formErrors'
 
 import {
   GREEN, GREEN_LT,
@@ -73,8 +75,15 @@ export function EventRosterPanel({ service, handshakes, onComplete, onMarkAttend
       if (msUntilExpiry > 0) {
         qrTimerRef.current = setTimeout(() => generateQr(), msUntilExpiry)
       }
-    } catch {
-      // silent — user can retry
+    } catch (err: unknown) {
+      // Backend rejects QR generation outside the 24-hour lockdown window
+      // (see EventHandshakeService.generate_qr_token). Surfacing the
+      // server's detail message tells the organizer why nothing happened
+      // instead of leaving the button stuck on "Generating…".
+      const data = (err as { response?: { data?: unknown } })?.response?.data
+      const detail = extractTopLevelDetail(data)
+        ?? (err instanceof Error ? err.message : null)
+      toast.error(detail || 'Could not generate the attendance QR. Please try again.')
     } finally {
       setQrLoading(false)
     }

--- a/frontend/src/test/components/EventRosterModal.test.tsx
+++ b/frontend/src/test/components/EventRosterModal.test.tsx
@@ -1,0 +1,98 @@
+import { ChakraProvider } from '@chakra-ui/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EventRosterPanel } from '@/components/EventRosterModal'
+import type { Service } from '@/types'
+import system from '@/theme'
+
+const { toastErrorMock, generateQRTokenMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+  generateQRTokenMock: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('@/services/serviceAPI', () => ({
+  serviceAPI: { generateQRToken: generateQRTokenMock },
+}))
+
+function buildService(overrides: Partial<Service> = {}): Service {
+  return {
+    id: 'svc-event-1',
+    title: 'Saturday meetup',
+    description: '',
+    type: 'Event',
+    status: 'Active',
+    requires_qr_checkin: true,
+    schedule_type: 'One-Time',
+    duration: 1,
+    max_participants: 10,
+    user: { id: 'organizer-1', first_name: 'O', last_name: 'O' },
+    ...overrides,
+  } as unknown as Service
+}
+
+function renderPanel(service: Service) {
+  return render(
+    <ChakraProvider value={system}>
+      <EventRosterPanel
+        service={service}
+        handshakes={[]}
+        onComplete={vi.fn()}
+        onMarkAttended={vi.fn()}
+        completing={false}
+      />
+    </ChakraProvider>,
+  )
+}
+
+describe('EventRosterPanel — QR generation error feedback', () => {
+  beforeEach(() => {
+    toastErrorMock.mockClear()
+    generateQRTokenMock.mockReset()
+  })
+
+  it('surfaces the lockdown-window error via toast.error when generation fails', async () => {
+    // Backend rejects QR generation outside the 24h lockdown window with a
+    // ValueError that the DRF exception handler renders as a 400 carrying
+    // {detail: '...'}. The FE used to swallow this in a silent catch and
+    // leave the user without any feedback.
+    const lockdownDetail = 'QR token can only be generated within 24 hours of the event start.'
+    generateQRTokenMock.mockRejectedValueOnce({
+      response: { data: { detail: lockdownDetail } },
+    })
+
+    renderPanel(buildService())
+    const trigger = await screen.findByRole('button', { name: /show attendance qr/i })
+    await userEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(generateQRTokenMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(lockdownDetail)
+    })
+  })
+
+  it('falls back to a generic toast message when the error has no detail', async () => {
+    // Network blip / non-DRF-shape error: the toast still fires so the
+    // user knows the click did something.
+    generateQRTokenMock.mockRejectedValueOnce(new Error('boom'))
+
+    renderPanel(buildService())
+    await userEvent.click(await screen.findByRole('button', { name: /show attendance qr/i }))
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    })
+    // Either the Error message or the generic fallback is acceptable, both
+    // satisfy the contract "user sees feedback".
+    const arg = toastErrorMock.mock.calls[0][0]
+    expect(typeof arg).toBe('string')
+    expect((arg as string).length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

The roster modal swallowed every error from `generateQRToken` in a silent catch, so when the backend rejected generation outside the 24-hour lockdown window the organizer saw the button flicker through "Generating…" and revert with no feedback. The backend gate is intentional product policy — the fix is purely the user-feedback layer.

## What changed

- `frontend/src/components/EventRosterModal.tsx:76` — replace `catch { /* silent */ }` with a `toast.error` that prefers the server's `detail` (via the existing `extractTopLevelDetail` helper) and falls back to a generic message for non-DRF errors.
- `frontend/src/test/components/EventRosterModal.test.tsx` — vitest pinning both the DRF-shaped lockdown rejection and the generic network-shape fallback.
- `backend/api/tests/unit/test_event_service.py` — pytest case asserting the `ValueError` message the FE depends on, so a future backend rewording fails the unit test before it reaches users.

## What's NOT changed

- The 24-hour lockdown gate itself (intentional).
- Any of the QR token rotation / persistence logic.
- Service-side QR (different code path; not affected).

## Test plan

- [ ] `cd backend && pytest api/tests/unit/test_event_service.py::TestGenerateQRToken` — green.
- [ ] `cd frontend && npm test -- src/test/components/EventRosterModal.test.tsx` — green.
- [ ] Manual: open an event >24h away, click "Show Attendance QR" — toast appears with the lockdown-window message.
- [ ] Manual: open an event <24h away, click — QR renders as before.