### PR TITLE
feat(frontend): owner-side manual Mark-as-Complete fallback (#300)

### DIFF
--- a/frontend/src/components/service-detail/InterestRequesterRow.tsx
+++ b/frontend/src/components/service-detail/InterestRequesterRow.tsx
@@ -21,17 +21,32 @@ function getInitials(name: string): string {
 type Props = {
   handshake: Handshake
   isOwner: boolean
+  /**
+   * Service location_type from the parent listing. Required so the
+   * row can apply the #300 / FR-13m eligibility gate (in-person only)
+   * without needing to fetch the service itself. Online exchanges have
+   * the chat-based dual-confirmation flow as their existing path.
+   */
+  serviceLocationType?: 'In-Person' | 'Online' | null
   onAccept?: () => void
   onReject?: () => void
   /**
    * #300 / FR-13m — owner-side manual Mark-as-Complete fallback. Wires
    * to `handshakeAPI.confirm` so the dual-confirmation flow can be
-   * driven from the interests panel without navigating to chat.
+   * driven from the interests panel without navigating to chat. Only
+   * surfaced for in-person exchanges per the SRS scope.
    */
   onMarkComplete?: () => void
 }
 
-const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject, onMarkComplete }: Props) => {
+const InterestRequesterRow = ({
+  handshake,
+  isOwner,
+  serviceLocationType,
+  onAccept,
+  onReject,
+  onMarkComplete,
+}: Props) => {
   // Defensive: only render for owners
   if (!isOwner) return null
 
@@ -53,14 +68,17 @@ const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject, onMarkCo
   const cfg = HS_BADGE[handshake.status] ?? { label: handshake.status, ...STATUS_FALLBACK }
   const isPending = handshake.status === 'pending'
   const isActive = ['pending', 'accepted'].includes(handshake.status)
-  // Owner can mark complete on an accepted exchange that the owner has
-  // not yet confirmed. The button simply records the owner's half of
-  // the dual-confirmation; the row stays "accepted" until the requester
-  // also confirms (or the action is repeated through chat). Hiding the
-  // button after the owner already confirmed prevents double-clicks.
+  // Owner can mark complete on an accepted in-person exchange that
+  // they have not yet confirmed. The button records the owner's half
+  // of the dual-confirmation; the row stays "accepted" until the
+  // requester also confirms (or the action is repeated through chat).
+  // Hiding it after the owner already confirmed prevents double-clicks.
+  // Per #300 / FR-13m the fallback is in-person only — online exchanges
+  // already have the chat-based confirmation surface as their path.
   const canMarkComplete =
     handshake.status === 'accepted'
     && !handshake.provider_confirmed_complete
+    && serviceLocationType === 'In-Person'
     && Boolean(onMarkComplete)
 
   const profileUrl = `/public-profile/${requesterId}`

--- a/frontend/src/components/service-detail/InterestRequesterRow.tsx
+++ b/frontend/src/components/service-detail/InterestRequesterRow.tsx
@@ -23,9 +23,15 @@ type Props = {
   isOwner: boolean
   onAccept?: () => void
   onReject?: () => void
+  /**
+   * #300 / FR-13m — owner-side manual Mark-as-Complete fallback. Wires
+   * to `handshakeAPI.confirm` so the dual-confirmation flow can be
+   * driven from the interests panel without navigating to chat.
+   */
+  onMarkComplete?: () => void
 }
 
-const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject }: Props) => {
+const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject, onMarkComplete }: Props) => {
   // Defensive: only render for owners
   if (!isOwner) return null
 
@@ -47,6 +53,15 @@ const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject }: Props)
   const cfg = HS_BADGE[handshake.status] ?? { label: handshake.status, ...STATUS_FALLBACK }
   const isPending = handshake.status === 'pending'
   const isActive = ['pending', 'accepted'].includes(handshake.status)
+  // Owner can mark complete on an accepted exchange that the owner has
+  // not yet confirmed. The button simply records the owner's half of
+  // the dual-confirmation; the row stays "accepted" until the requester
+  // also confirms (or the action is repeated through chat). Hiding the
+  // button after the owner already confirmed prevents double-clicks.
+  const canMarkComplete =
+    handshake.status === 'accepted'
+    && !handshake.provider_confirmed_complete
+    && Boolean(onMarkComplete)
 
   const profileUrl = `/public-profile/${requesterId}`
 
@@ -178,6 +193,23 @@ const InterestRequesterRow = ({ handshake, isOwner, onAccept, onReject }: Props)
             onClick={onReject}
           >
             Decline
+          </Box>
+        )}
+        {/* Mark as Complete — only for accepted status, owner not yet confirmed (#300 / FR-13m) */}
+        {canMarkComplete && (
+          <Box
+            as="button"
+            px="10px"
+            py="5px"
+            borderRadius="7px"
+            fontSize="11px"
+            fontWeight={700}
+            data-testid="mark-as-complete-button"
+            aria-label={`Mark exchange with ${displayName} as complete`}
+            style={{ background: GREEN_LT, border: 'none', cursor: 'pointer', color: GREEN }}
+            onClick={onMarkComplete}
+          >
+            Mark as Complete
           </Box>
         )}
       </Flex>

--- a/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
+++ b/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
@@ -188,13 +188,14 @@ describe('InterestRequesterRow', () => {
 
   // ── #300 / FR-13m: owner-side manual Mark-as-Complete fallback ──────────
 
-  it('shows Mark as Complete on accepted handshakes when owner has not yet confirmed', () => {
+  it('shows Mark as Complete on accepted in-person handshakes when owner has not yet confirmed', () => {
     const onMarkComplete = vi.fn()
     render(
       <Wrapper>
         <InterestRequesterRow
           handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
           isOwner
+          serviceLocationType="In-Person"
           onMarkComplete={onMarkComplete}
         />
       </Wrapper>,
@@ -208,6 +209,7 @@ describe('InterestRequesterRow', () => {
         <InterestRequesterRow
           handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: true })}
           isOwner
+          serviceLocationType="In-Person"
           onMarkComplete={vi.fn()}
         />
       </Wrapper>,
@@ -221,6 +223,7 @@ describe('InterestRequesterRow', () => {
         <InterestRequesterRow
           handshake={makeHandshake({ status: 'pending' })}
           isOwner
+          serviceLocationType="In-Person"
           onMarkComplete={vi.fn()}
         />
       </Wrapper>,
@@ -237,6 +240,39 @@ describe('InterestRequesterRow', () => {
         <InterestRequesterRow
           handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
           isOwner
+          serviceLocationType="In-Person"
+        />
+      </Wrapper>,
+    )
+    expect(screen.queryByTestId('mark-as-complete-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Mark as Complete on Online exchanges (#300 / FR-13m is in-person only)', () => {
+    // Online exchanges already have the chat-based dual-confirmation
+    // path; surfacing a duplicate fallback on the listing for them
+    // would conflict with the SRS scope. The eligibility gate is the
+    // listing's location_type, not just the handshake state.
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
+          isOwner
+          serviceLocationType="Online"
+          onMarkComplete={vi.fn()}
+        />
+      </Wrapper>,
+    )
+    expect(screen.queryByTestId('mark-as-complete-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Mark as Complete when the parent omits serviceLocationType', () => {
+    // Defensive: an unknown location_type must not surface the fallback.
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
+          isOwner
+          onMarkComplete={vi.fn()}
         />
       </Wrapper>,
     )
@@ -250,6 +286,7 @@ describe('InterestRequesterRow', () => {
         <InterestRequesterRow
           handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
           isOwner
+          serviceLocationType="In-Person"
           onMarkComplete={onMarkComplete}
         />
       </Wrapper>,

--- a/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
+++ b/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
@@ -186,6 +186,78 @@ describe('InterestRequesterRow', () => {
     expect(screen.queryByText('Decline')).not.toBeInTheDocument()
   })
 
+  // ── #300 / FR-13m: owner-side manual Mark-as-Complete fallback ──────────
+
+  it('shows Mark as Complete on accepted handshakes when owner has not yet confirmed', () => {
+    const onMarkComplete = vi.fn()
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
+          isOwner
+          onMarkComplete={onMarkComplete}
+        />
+      </Wrapper>,
+    )
+    expect(screen.getByTestId('mark-as-complete-button')).toBeInTheDocument()
+  })
+
+  it('hides Mark as Complete after the owner has already confirmed', () => {
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: true })}
+          isOwner
+          onMarkComplete={vi.fn()}
+        />
+      </Wrapper>,
+    )
+    expect(screen.queryByTestId('mark-as-complete-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Mark as Complete when status is not accepted', () => {
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'pending' })}
+          isOwner
+          onMarkComplete={vi.fn()}
+        />
+      </Wrapper>,
+    )
+    expect(screen.queryByTestId('mark-as-complete-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Mark as Complete when no onMarkComplete handler is provided', () => {
+    // Defensive: avoids rendering a dead button when the parent hasn't
+    // wired the fallback (e.g. event surfaces that route through a
+    // different completion flow).
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
+          isOwner
+        />
+      </Wrapper>,
+    )
+    expect(screen.queryByTestId('mark-as-complete-button')).not.toBeInTheDocument()
+  })
+
+  it('calls onMarkComplete when the button is clicked', () => {
+    const onMarkComplete = vi.fn()
+    render(
+      <Wrapper>
+        <InterestRequesterRow
+          handshake={makeHandshake({ status: 'accepted', provider_confirmed_complete: false })}
+          isOwner
+          onMarkComplete={onMarkComplete}
+        />
+      </Wrapper>,
+    )
+    fireEvent.click(screen.getByTestId('mark-as-complete-button'))
+    expect(onMarkComplete).toHaveBeenCalledTimes(1)
+  })
+
   it('falls back to requester.id when requester_detail is absent', () => {
     const handshake = makeHandshake({
       requester: 'user-fallback',

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -2073,6 +2073,7 @@ export default function ServiceDetailPage() {
                               key={h.id}
                               handshake={h}
                               isOwner={isOwn}
+                              serviceLocationType={service.location_type}
                               onAccept={canDirectlyAcceptHandshake(h.status, service.type)
                                 ? async () => {
                                     try {
@@ -2090,7 +2091,9 @@ export default function ServiceDetailPage() {
                                   }
                                 : undefined}
                               onMarkComplete={
-                                h.status === 'accepted' && !h.provider_confirmed_complete
+                                h.status === 'accepted'
+                                && !h.provider_confirmed_complete
+                                && service.location_type === 'In-Person'
                                   ? () => setMarkCompleteHandshakeId(h.id)
                                   : undefined
                               }

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -522,6 +522,11 @@ export default function ServiceDetailPage() {
   const [eventDetailModalTab, setEventDetailModalTab] = useState<EventDetailModalTab>('details')
   const [completing, setCompleting]         = useState(false)
   const [markingAttendedId, setMarkingAttendedId] = useState<string | null>(null)
+  // #300 / FR-13m — owner-side manual Mark-as-Complete fallback. The
+  // pending-id pins which interest row's modal is open so we can
+  // confirm + dispatch + clear in one place.
+  const [markCompleteHandshakeId, setMarkCompleteHandshakeId] = useState<string | null>(null)
+  const [markingCompleteLoading, setMarkingCompleteLoading] = useState(false)
   const [reportingEventIssue, setReportingEventIssue] = useState(false)
   const [showEvaluationModal, setShowEvaluationModal] = useState(false)
 
@@ -1004,6 +1009,31 @@ export default function ServiceDetailPage() {
       const err = e as { response?: { data?: { detail?: string } } }
       toast.error(err.response?.data?.detail ?? 'Could not cancel event.')
     } finally { setCancelLoading(false) }
+  }
+
+  // #300 / FR-13m — owner-side fallback that records the owner's half of
+  // the dual-confirmation flow without forcing the owner to navigate to
+  // chat. Reuses the existing `handshakeAPI.confirm` endpoint, so no
+  // backend change is needed; the requester still has to confirm on their
+  // side before the time-credit transfer fires.
+  const handleMarkCompleteHandshake = async () => {
+    if (!markCompleteHandshakeId) return
+    setMarkingCompleteLoading(true)
+    try {
+      const updated = await handshakeAPI.confirm(markCompleteHandshakeId)
+      setHandshakes((prev) => prev.map((h) => (h.id === updated.id ? updated : h)))
+      if (updated.status === 'completed') {
+        toast.success('Exchange marked as complete.')
+      } else {
+        toast.info("Marked complete on your side. Awaiting the requester's confirmation.")
+      }
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { detail?: string } } }
+      toast.error(err.response?.data?.detail ?? 'Could not mark as complete. Please try again.')
+    } finally {
+      setMarkingCompleteLoading(false)
+      setMarkCompleteHandshakeId(null)
+    }
   }
 
   const handleRemoveListing = async () => {
@@ -2059,6 +2089,11 @@ export default function ServiceDetailPage() {
                                     } catch { /* errors handled via toast elsewhere */ }
                                   }
                                 : undefined}
+                              onMarkComplete={
+                                h.status === 'accepted' && !h.provider_confirmed_complete
+                                  ? () => setMarkCompleteHandshakeId(h.id)
+                                  : undefined
+                              }
                             />
                           ))}
                         </Stack>
@@ -2549,6 +2584,18 @@ export default function ServiceDetailPage() {
       loading={removeLoading}
       onConfirm={handleRemoveListing}
       onClose={() => setShowRemoveModal(false)}
+    />
+
+    {/* ── Manual Mark-as-Complete fallback modal (#300 / FR-13m) ──────────── */}
+    <AdminConfirmModal
+      isOpen={markCompleteHandshakeId !== null}
+      title="Mark as Complete"
+      description="Mark this exchange as complete? The requester will still need to confirm on their side before the time credits transfer."
+      confirmLabel="Mark Complete"
+      accent={GREEN} accentLt={GREEN_LT}
+      loading={markingCompleteLoading}
+      onConfirm={handleMarkCompleteHandshake}
+      onClose={() => setMarkCompleteHandshakeId(null)}
     />
 
     {/* ── Cancel Event modal with required reason (BUG-03) ───────────────── */}

--- a/frontend/tests/e2e/feature-13/13-fr-13m.spec.ts
+++ b/frontend/tests/e2e/feature-13/13-fr-13m.spec.ts
@@ -1,6 +1,48 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
-test('FR-13m: owner Interests panel includes a manual Mark as Complete fallback for eligible accepted in-person exchanges', async () => {
-  // The current detail page does not expose a manual "Mark as Complete" action for service handshakes yet.
-  test.skip(true, 'Manual service-completion fallback is not implemented in the current detail-page UI.')
+import {
+  createAcceptedOfferExchange,
+  expectToast,
+  loginAs,
+  pickUsersWithBalanceAtLeast,
+  USERS,
+} from '../helpers'
+
+test('FR-13m: owner Interests panel exposes a manual Mark as Complete fallback for accepted exchanges', async ({ page }) => {
+  // #300: when the QR / chat completion path isn't accessible, the owner
+  // should still be able to record their half of the dual-confirmation
+  // directly from the listing's Interests panel. The button reuses the
+  // existing /handshakes/{id}/confirm/ endpoint, so the requester still
+  // needs to confirm before time credits actually transfer.
+  const owner = USERS.elif
+  const [{ user: requester }] = await pickUsersWithBalanceAtLeast(page, 2, 1, [owner.email])
+
+  const { detailUrl } = await createAcceptedOfferExchange(page, {
+    owner,
+    requester,
+    title: `FR-13m Manual Complete ${Date.now()}`,
+    duration: 1,
+  })
+
+  // Owner returns to the detail page; the accepted handshake should now
+  // surface the manual fallback button on the corresponding interest row.
+  await loginAs(page, owner)
+  await page.goto(detailUrl)
+
+  const markCompleteButton = page.getByTestId('mark-as-complete-button').first()
+  await expect(markCompleteButton).toBeVisible({ timeout: 10_000 })
+
+  // Click the row-level button → the modal confirms before dispatching.
+  await markCompleteButton.click()
+  await page.getByRole('button', { name: 'Mark Complete' }).click()
+
+  // The owner has only recorded their half of the confirmation, so the
+  // toast tells them the requester still needs to confirm. The handshake
+  // is also expected to remain in the active list until the requester
+  // confirms, but that follow-up assertion belongs in a multi-user spec.
+  await expectToast(page, /Awaiting the requester|complete/i)
+
+  // After the owner confirms, the button is hidden so a second click can't
+  // double-fire.
+  await expect(page.getByTestId('mark-as-complete-button')).toHaveCount(0, { timeout: 10_000 })
 })

--- a/frontend/tests/e2e/feature-13/13-fr-13m.spec.ts
+++ b/frontend/tests/e2e/feature-13/13-fr-13m.spec.ts
@@ -22,6 +22,10 @@ test('FR-13m: owner Interests panel exposes a manual Mark as Complete fallback f
     requester,
     title: `FR-13m Manual Complete ${Date.now()}`,
     duration: 1,
+    // FR-13m's eligibility gate is in-person — Online listings already
+    // surface the chat-based confirmation and must NOT show the
+    // duplicate row-level fallback.
+    location: 'in-person',
   })
 
   // Owner returns to the detail page; the accepted handshake should now

--- a/frontend/tests/e2e/feature-9/07-fr-09g.spec.ts
+++ b/frontend/tests/e2e/feature-9/07-fr-09g.spec.ts
@@ -1,6 +1,40 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
-test('FR-09g: listing owners have a manual completion fallback when QR scan is not possible', async () => {
-  // The current frontend runtime does not expose a manual service-completion fallback action.
-  test.skip(true, 'Manual service-completion fallback is not implemented in the current frontend.')
+import {
+  createOffer,
+  loginAs,
+  requestOfferFromDetail,
+  switchUser,
+  uniqueTitle,
+  USERS,
+} from '../helpers'
+
+test('FR-09g: manual completion fallback is hidden until the handshake is accepted', async ({ page }) => {
+  // The Mark-as-Complete fallback (#300) is only meaningful once both
+  // sides have agreed to the exchange. While a request is still pending
+  // the owner should see Accept / Decline, not the fallback — surfacing
+  // the button earlier would invite mid-negotiation completions and
+  // leak time credits before any service was actually delivered.
+  // FR-13m covers the positive (accepted-state) path end to end.
+  const owner = USERS.elif
+  const requester = USERS.cem
+  const title = uniqueTitle('FR-09g pending')
+
+  await loginAs(page, owner)
+  const { detailUrl } = await createOffer(page, {
+    title,
+    description: 'Feature 9 FR-09g asserts the fallback is gated on accepted state.',
+  })
+
+  await switchUser(page, requester)
+  await page.goto(detailUrl)
+  await requestOfferFromDetail(page)
+
+  // Pending state — Accept and Decline must be visible, Mark as Complete
+  // must NOT be (the row reads `status === 'pending'`).
+  await switchUser(page, owner)
+  await page.goto(detailUrl)
+  await expect(page.getByText('Accept')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText('Decline')).toBeVisible()
+  await expect(page.getByTestId('mark-as-complete-button')).toHaveCount(0)
 })

--- a/frontend/tests/e2e/helpers/feature7.ts
+++ b/frontend/tests/e2e/helpers/feature7.ts
@@ -265,6 +265,10 @@ export async function createAcceptedOfferExchange(page: Page, options: {
   requester: DemoUser
   title?: string
   duration?: number
+  /** Listing location_type. Defaults to online to preserve every legacy
+   * caller; FR-13m / #300 callers pass `'in-person'` so the manual
+   * Mark-as-Complete fallback's eligibility gate matches. */
+  location?: 'online' | 'in-person'
 }): Promise<{
   title: string
   detailUrl: string
@@ -277,7 +281,7 @@ export async function createAcceptedOfferExchange(page: Page, options: {
     title,
     description: `Playwright creates ${title} for Feature 7 verification.`,
     duration: options.duration ?? 1,
-    online: true,
+    online: options.location !== 'in-person',
   })
   const serviceId = extractServiceId(detailUrl)
 


### PR DESCRIPTION
## Summary

Closes #300 / FR-13m / FR-09g. Adds a "Mark as Complete" button on the owner's interest row so the dual-confirmation flow can be driven from the service detail page without navigating to chat. Reuses the existing `handshakeAPI.confirm` endpoint — the requester still has to confirm on their side before time credits transfer; the fallback only records the owner's half.

## Visibility matrix

| status | provider already confirmed | onMarkComplete passed | Button shown? |
|---|---|---|---|
| accepted | no | yes | yes |
| accepted | yes | yes | no (anti-double-fire) |
| accepted | no | no | no (defensive) |
| pending | — | — | no (Accept/Decline take priority) |
| any other | — | — | no |

## What changed

- `frontend/src/components/service-detail/InterestRequesterRow.tsx` — new `onMarkComplete` prop + conditional button.
- `frontend/src/pages/ServiceDetailPage.tsx` — handler, AdminConfirmModal, optimistic state update on success.
- `frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx` — 5 new vitest cases pinning the visibility matrix.
- `frontend/tests/e2e/feature-13/13-fr-13m.spec.ts` — un-skipped, drives the happy path (owner clicks → modal → toast → button hidden).
- `frontend/tests/e2e/feature-9/07-fr-09g.spec.ts` — un-skipped negative case (hidden in pending state) so a regression surfacing the button mid-negotiation fails fast.

## What's NOT changed

- Backend — the `confirm` endpoint already exists and is unchanged.
- The chat-thread Confirm Completion button (parallel surface, untouched).
- Time-credit transfer logic — still gated on both sides confirming.

## Test plan

- [ ] `cd frontend && npm test -- src/components/service-detail/__tests__/InterestRequesterRow.test.tsx` — 18 green.
- [ ] `cd frontend && npx playwright test feature-9/07-fr-09g feature-13/13-fr-13m` — both pass.
- [ ] Manual: log in as owner, accept a request, click Mark as Complete on the interest row. Modal appears, confirms, toast says "Awaiting the requester's confirmation".
- [ ] Manual: log in as the requester, click Confirm Completion in chat. Time credits transfer, status flips to completed.

Closes #300.