### PR TITLE
feat(frontend): diversify smart pills with engagement and newcomer flavours

### DIFF
--- a/frontend/src/components/SmartPill.tsx
+++ b/frontend/src/components/SmartPill.tsx
@@ -1,10 +1,11 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
-import { FiBookmark, FiClock, FiCompass, FiStar, FiSunrise, FiUsers } from 'react-icons/fi'
+import { FiBookmark, FiClock, FiCompass, FiStar, FiSunrise, FiTrendingUp, FiUsers } from 'react-icons/fi'
 
 import { chipForSignals } from '@/utils/forYouChips'
+import { isNearlyFull, spotsLeft } from '@/utils/eventUtils'
 import type { Service } from '@/types'
 
-interface NewcomerFlavour {
+interface FallbackFlavour {
   label: string
   bg: string
   fg: string
@@ -18,12 +19,30 @@ interface NewcomerFlavour {
 // on the listing. When both apply, the newcomer pill takes priority
 // because it's a stronger discovery story (a brand-new face, not just an
 // under-shown listing).
-const NEWCOMER_FLAVOUR: NewcomerFlavour = {
+const NEWCOMER_FLAVOUR: FallbackFlavour = {
   label: 'Rising newcomer',
   bg: 'rgba(244, 114, 182, 0.92)',
   fg: 'white',
   border: 'transparent',
   Icon: FiSunrise,
+}
+
+// Capacity-scarcity pill for multi-seat services in the 75-99% filled
+// window. The `isNearlyFull` helper is reused as-is (already pinned by
+// `frontend/src/test/utils/eventUtils.test.ts`) — single-seat services
+// never trigger because they jump from 0% to 100% without crossing the
+// band. Beats `explore_pool` because scarcity is a time-sensitive
+// "act now" signal, but loses to a real for_you match and to the
+// (rarer) newcomer flag, since both of those are stronger discovery
+// stories than the generic "filling up" cue.
+function buildCapacityFlavour(remaining: number): FallbackFlavour {
+  return {
+    label: remaining === 1 ? '1 spot left' : `${remaining} spots left`,
+    bg: 'rgba(217, 119, 6, 0.95)',
+    fg: 'white',
+    border: 'transparent',
+    Icon: FiTrendingUp,
+  }
 }
 
 interface PoolFlavour {
@@ -55,7 +74,8 @@ interface SmartPillProps {
  * Pill priority:
  *   1. strongest for_you signal (tag / follow / cooccur / engagement)
  *   2. is_newcomer_owner — distinct discovery story for brand-new faces
- *   3. explore-pool flavour as the final fallback
+ *   3. capacity scarcity (`isNearlyFull` 75-99%) — time-sensitive "act now"
+ *   4. explore-pool flavour as the final fallback
  *
  * The earlier order put the pool first, but on demo data every card
  * qualifies as cold_start, which drowned out cards that DID have a real
@@ -80,6 +100,20 @@ export default function SmartPill({ service }: SmartPillProps) {
         fg={NEWCOMER_FLAVOUR.fg}
         border={NEWCOMER_FLAVOUR.border}
         Icon={NEWCOMER_FLAVOUR.Icon}
+      />
+    )
+  }
+  const max = service.max_participants ?? 0
+  const count = service.participant_count ?? 0
+  if (isNearlyFull(max, count)) {
+    const capacityFlavour = buildCapacityFlavour(spotsLeft(max, count))
+    return (
+      <PillBox
+        label={capacityFlavour.label}
+        bg={capacityFlavour.bg}
+        fg={capacityFlavour.fg}
+        border={capacityFlavour.border}
+        Icon={capacityFlavour.Icon}
       />
     )
   }

--- a/frontend/src/components/SmartPill.tsx
+++ b/frontend/src/components/SmartPill.tsx
@@ -1,8 +1,30 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
-import { FiClock, FiCompass, FiStar, FiUsers } from 'react-icons/fi'
+import { FiBookmark, FiClock, FiCompass, FiStar, FiSunrise, FiUsers } from 'react-icons/fi'
 
 import { chipForSignals } from '@/utils/forYouChips'
 import type { Service } from '@/types'
+
+interface NewcomerFlavour {
+  label: string
+  bg: string
+  fg: string
+  border: string
+  Icon: typeof FiStar
+}
+
+// Phase-3 fallback for owners who joined recently. Distinct from the
+// `cold_start` explore pool ("Fresh provider"): newcomer-owner is a
+// recency signal on the user, cold_start is an activity-history signal
+// on the listing. When both apply, the newcomer pill takes priority
+// because it's a stronger discovery story (a brand-new face, not just an
+// under-shown listing).
+const NEWCOMER_FLAVOUR: NewcomerFlavour = {
+  label: 'Rising newcomer',
+  bg: 'rgba(244, 114, 182, 0.92)',
+  fg: 'white',
+  border: 'transparent',
+  Icon: FiSunrise,
+}
 
 interface PoolFlavour {
   label: string
@@ -30,18 +52,36 @@ interface SmartPillProps {
  * engine elevated the card by some signal. Same restraint pattern YouTube
  * uses with "New to you" / "Watched" badges -- contextual, not always-on.
  *
- * Pill priority: strongest for_you signal first (tag / follow / cooccur),
- * then the explore-pool flavour as a fallback. The earlier order put the
- * pool first, but on demo data every card qualifies as cold_start, so the
- * "Fresh provider" pill drowned out cards that DID have a real for_you
- * signal. cold_start specifically renders as an outline pill so it never
- * dominates over a saturated for_you pill.
+ * Pill priority:
+ *   1. strongest for_you signal (tag / follow / cooccur / engagement)
+ *   2. is_newcomer_owner — distinct discovery story for brand-new faces
+ *   3. explore-pool flavour as the final fallback
+ *
+ * The earlier order put the pool first, but on demo data every card
+ * qualifies as cold_start, which drowned out cards that DID have a real
+ * for_you signal. cold_start specifically renders as an outline pill so
+ * it never dominates over a saturated for_you pill.
  */
 export default function SmartPill({ service }: SmartPillProps) {
   const chip = chipForSignals(service.for_you_signals)
   if (chip.name !== 'default') {
-    const Icon = chip.name === 'follow' ? FiUsers : chip.name === 'cooccur' ? FiClock : FiStar
+    const Icon =
+      chip.name === 'follow' ? FiUsers
+      : chip.name === 'cooccur' ? FiClock
+      : chip.name === 'engagement' ? FiBookmark
+      : FiStar
     return <PillBox label={chip.label} bg={chip.bg} fg={chip.fg} border="transparent" Icon={Icon} />
+  }
+  if (service.is_newcomer_owner) {
+    return (
+      <PillBox
+        label={NEWCOMER_FLAVOUR.label}
+        bg={NEWCOMER_FLAVOUR.bg}
+        fg={NEWCOMER_FLAVOUR.fg}
+        border={NEWCOMER_FLAVOUR.border}
+        Icon={NEWCOMER_FLAVOUR.Icon}
+      />
+    )
   }
   if (service.explore_pool && POOL_FLAVOUR[service.explore_pool]) {
     const flavour = POOL_FLAVOUR[service.explore_pool]

--- a/frontend/src/test/components/SmartPill.test.tsx
+++ b/frontend/src/test/components/SmartPill.test.tsx
@@ -169,4 +169,86 @@ describe('SmartPill', () => {
     renderPill(makeService({ explore_pool: 'cold_start' }))
     expect(screen.getByText('Fresh provider')).toBeInTheDocument()
   })
+
+  // ── capacity scarcity ("N spots left") ────────────────────────────────────
+
+  it('renders capacity-scarcity pill at 75-99% filled with the remaining count', () => {
+    // 8/10 = 80%, in the nearly-full band; 2 spots left.
+    renderPill(makeService({ max_participants: 10, participant_count: 8 }))
+    expect(screen.getByText('2 spots left')).toBeInTheDocument()
+  })
+
+  it('uses singular copy when exactly one spot remains', () => {
+    renderPill(makeService({ max_participants: 4, participant_count: 3 }))
+    expect(screen.getByText('1 spot left')).toBeInTheDocument()
+  })
+
+  it('does NOT render capacity pill below 75%', () => {
+    // 7/10 = 70%, below the band — the helper returns false; nothing renders.
+    const { container } = renderPill(
+      makeService({ max_participants: 10, participant_count: 7 }),
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does NOT render capacity pill at 100%', () => {
+    // The helper deliberately excludes full services — at that point the
+    // CTA is "join the waitlist" not "act now". Nothing renders here.
+    const { container } = renderPill(
+      makeService({ max_participants: 10, participant_count: 10 }),
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does NOT render capacity pill on single-seat services', () => {
+    // 1-seat services jump from 0% to 100% without crossing the 75-99 band;
+    // pin this so the chip never accidentally appears on Need handshakes.
+    const { container } = renderPill(
+      makeService({ max_participants: 1, participant_count: 0 }),
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('for_you signal beats capacity scarcity', () => {
+    // Personalization wins over the generic time-pressure cue so a card
+    // that matches the viewer's interests still gets the more informative
+    // pill even when the listing is filling up.
+    renderPill(
+      makeService({
+        max_participants: 10,
+        participant_count: 9,
+        for_you_signals: { tag: 0.6, follow: 0, cooccur: 0, recency_penalty: 0 },
+      }),
+    )
+    expect(screen.getByText('Matches your interests')).toBeInTheDocument()
+    expect(screen.queryByText(/spots? left/)).not.toBeInTheDocument()
+  })
+
+  it('newcomer beats capacity scarcity', () => {
+    // Discovery > scarcity. A newcomer event that's also filling up still
+    // surfaces "Rising newcomer" — the brand-new face is the headline.
+    renderPill(
+      makeService({
+        is_newcomer_owner: true,
+        max_participants: 10,
+        participant_count: 9,
+      }),
+    )
+    expect(screen.getByText('Rising newcomer')).toBeInTheDocument()
+    expect(screen.queryByText(/spots? left/)).not.toBeInTheDocument()
+  })
+
+  it('capacity scarcity beats explore_pool', () => {
+    // Time pressure wins over generic explore-pool fallbacks: a nearly-
+    // full cold_start event gets "spots left", not "Fresh provider".
+    renderPill(
+      makeService({
+        explore_pool: 'cold_start',
+        max_participants: 10,
+        participant_count: 9,
+      }),
+    )
+    expect(screen.getByText('1 spot left')).toBeInTheDocument()
+    expect(screen.queryByText('Fresh provider')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/test/components/SmartPill.test.tsx
+++ b/frontend/src/test/components/SmartPill.test.tsx
@@ -83,4 +83,90 @@ describe('SmartPill', () => {
     )
     expect(screen.getByText('From your network')).toBeInTheDocument()
   })
+
+  // ── engagement signal ("Saved by others") ─────────────────────────────────
+
+  it('renders the engagement chip when it is the strongest for_you signal', () => {
+    renderPill(
+      makeService({
+        for_you_signals: {
+          tag: 0,
+          follow: 0,
+          cooccur: 0,
+          recency_penalty: 0,
+          engagement: 0.6,
+        },
+      }),
+    )
+    expect(screen.getByText('Saved by others')).toBeInTheDocument()
+  })
+
+  it('engagement loses to a stronger weighted tag overlap', () => {
+    // tag * 0.5 = 0.3 beats engagement * 0.15 = 0.075 even though engagement
+    // is the larger raw value. Pin the weighting so a future weights tweak
+    // that flips this ordering is caught.
+    renderPill(
+      makeService({
+        for_you_signals: {
+          tag: 0.6,
+          follow: 0,
+          cooccur: 0,
+          recency_penalty: 0,
+          engagement: 0.5,
+        },
+      }),
+    )
+    expect(screen.getByText('Matches your interests')).toBeInTheDocument()
+    expect(screen.queryByText('Saved by others')).not.toBeInTheDocument()
+  })
+
+  it('treats missing engagement as zero (back-compat with older payloads)', () => {
+    // Older backend responses do not carry the engagement key. Picker must
+    // not crash on `undefined` and must not emit "Saved by others" for them.
+    renderPill(
+      makeService({
+        for_you_signals: { tag: 0.4, follow: 0, cooccur: 0, recency_penalty: 0 },
+      }),
+    )
+    expect(screen.getByText('Matches your interests')).toBeInTheDocument()
+  })
+
+  // ── is_newcomer_owner fallback ("Rising newcomer") ────────────────────────
+
+  it('renders the Rising newcomer pill when the owner is a newcomer and no for_you signal applies', () => {
+    renderPill(makeService({ is_newcomer_owner: true }))
+    expect(screen.getByText('Rising newcomer')).toBeInTheDocument()
+  })
+
+  it('newcomer pill takes priority over the cold_start explore pool', () => {
+    // Both signals frequently coexist on demo data. Newcomer is the
+    // stronger discovery story (a new face) so it wins over the generic
+    // "Fresh provider" pool flavour.
+    renderPill(
+      makeService({ is_newcomer_owner: true, explore_pool: 'cold_start' }),
+    )
+    expect(screen.getByText('Rising newcomer')).toBeInTheDocument()
+    expect(screen.queryByText('Fresh provider')).not.toBeInTheDocument()
+  })
+
+  it('for_you signal still beats is_newcomer_owner', () => {
+    // The pillar of the priority order: a real for_you signal trumps
+    // every fallback, including newcomer. Otherwise newcomers would
+    // never get credit for their tag matches.
+    renderPill(
+      makeService({
+        is_newcomer_owner: true,
+        for_you_signals: { tag: 0.6, follow: 0, cooccur: 0, recency_penalty: 0 },
+      }),
+    )
+    expect(screen.getByText('Matches your interests')).toBeInTheDocument()
+    expect(screen.queryByText('Rising newcomer')).not.toBeInTheDocument()
+  })
+
+  it('cold_start still renders Fresh provider when owner is not a newcomer', () => {
+    // Sanity: removing the newcomer flag must not regress the existing
+    // cold_start pill — both flavours coexist, just at different priority.
+    renderPill(makeService({ explore_pool: 'cold_start' }))
+    expect(screen.getByText('Fresh provider')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -1,7 +1,7 @@
 import type { ForYouSignals, Service } from '@/types'
 
 export interface SignalChip {
-  name: 'tag' | 'follow' | 'cooccur' | 'default'
+  name: 'tag' | 'follow' | 'cooccur' | 'engagement' | 'default'
   label: string
   bg: string
   fg: string
@@ -11,7 +11,20 @@ export interface SignalChip {
 // Argmax on raw values made follow (flat 1.0) always win over Jaccard tag
 // overlap (typically a small float); weighting matches the actual ranking blend
 // so the chip reflects what moved the score.
-export const FOR_YOU_WEIGHTS = { tag: 0.5, follow: 0.3, cooccur: 0.2 } as const
+//
+// `engagement` (Jaccard overlap with the viewer's saved-services tags) is
+// already computed at backend/api/ranking_personalized.py:393 and shipped on
+// the ForYouSignals payload, but never previously surfaced as a chip. It
+// rounds out the pill set with a pure interest-axis signal that is
+// orthogonal to the social graph (`follow`) and the co-occurrence prior
+// (`cooccur`). Weight is intentionally below `cooccur` so it doesn't crowd
+// out the established signals on cards that score similarly across axes.
+export const FOR_YOU_WEIGHTS = {
+  tag: 0.5,
+  follow: 0.3,
+  cooccur: 0.2,
+  engagement: 0.15,
+} as const
 
 export const DEFAULT_CHIP: SignalChip = {
   name: 'default',
@@ -26,6 +39,7 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
     ['tag', signals.tag * FOR_YOU_WEIGHTS.tag],
     ['follow', signals.follow * FOR_YOU_WEIGHTS.follow],
     ['cooccur', signals.cooccur * FOR_YOU_WEIGHTS.cooccur],
+    ['engagement', (signals.engagement ?? 0) * FOR_YOU_WEIGHTS.engagement],
   ]
   const [topName, topValue] = entries.reduce(
     (best, current) => (current[1] > best[1] ? current : best),
@@ -38,7 +52,10 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
   if (topName === 'follow') {
     return { name: 'follow', label: 'From your network', bg: 'rgba(245, 158, 11, 0.95)', fg: 'white' }
   }
-  return { name: 'cooccur', label: 'Popular with people like you', bg: 'rgba(59, 130, 246, 0.95)', fg: 'white' }
+  if (topName === 'cooccur') {
+    return { name: 'cooccur', label: 'Popular with people like you', bg: 'rgba(59, 130, 246, 0.95)', fg: 'white' }
+  }
+  return { name: 'engagement', label: 'Saved by others', bg: 'rgba(20, 184, 166, 0.95)', fg: 'white' }
 }
 
 // Reorder so two consecutive cards rarely share a chip. Walks left to right;


### PR DESCRIPTION
## Summary

Adds three new "why this card?" pills using signals that are already shipped on the backend payload but were never surfaced as per-card chips. Renders against the existing priority order so the established pills are unaffected.

### New pills

- **Saved by others** — the `engagement` for-you signal (Jaccard overlap with the viewer's saved-services tags). Already computed at `backend/api/ranking_personalized.py:393` and shipped on the payload. Weight 0.15 (deliberately below `cooccur`) so it doesn't crowd out the established signals.
- **Rising newcomer** — the `is_newcomer_owner` flag (already serialized at `backend/api/serializers.py:555`). Renders as a Phase-3 fallback when no for_you signal applies. Takes priority over `cold_start` because a brand-new face is a stronger discovery story than the generic under-shown-listing flag.
- **N spots left** — capacity scarcity in the 75-99% filled band, reusing the existing `isNearlyFull` helper at `frontend/src/utils/eventUtils.ts:29`. The featured carousel already had a "Nearly Full" *tab* driven by the same helper; this brings the same signal down to per-card pills on the For-You and Browse feeds. Singular copy at one remaining ("1 spot left").

### Render priority (after this PR)
1. Strongest for_you signal — `tag` / `follow` / `cooccur` / **`engagement`**
2. **`is_newcomer_owner`** — distinct discovery story
3. **Capacity scarcity** (`isNearlyFull`, 75-99%) — time-sensitive "act now"
4. `explore_pool` flavour — generic fallback

Personalization and discovery still beat scarcity, so a card with a real for_you match or a newcomer owner keeps its more informative pill even when filling up. Capacity beats `explore_pool` because time pressure is a stronger CTA than the generic "under-shown listing" cue. Single-seat services never trigger the capacity pill (0% jumps straight to 100% without crossing the band), so this stays an event / group-offer surface only.

### Tests
21 vitest cases on `SmartPill` (5 existing + 16 new), pinning the full priority matrix:
- engagement strongest, weighted comparison, missing-engagement back-compat
- newcomer fallback alone, newcomer + cold_start, for_you vs newcomer, cold_start standalone
- capacity at 75-99% (plural / singular), below-band hidden, full hidden, single-seat hidden
- for_you wins over capacity, newcomer wins over capacity, capacity wins over explore_pool

`ForYouCarousel.chip.test.tsx` (5 cases) still passes — the diversify helper consumes the picker's `chip.name` and is unaffected by the new branches.

### Out of scope (deferred to epic #579)
- "Trending with you" — replace the ambiguous `stale_recurring` pool with active-trending velocity.
- Reconsidering whether `cold_start` is still useful now that "Rising newcomer" covers most of its intent.

## Test plan

- [ ] `cd frontend && npm test -- src/test/components/SmartPill.test.tsx --run` — 21 green.
- [ ] `cd frontend && npm test -- src/test/components/ForYouCarousel.chip.test.tsx --run` — 5 green.
- [ ] Manual: log in as a user with a saved-services tag match, view For-You feed, confirm "Saved by others" renders on the matching card.
- [ ] Manual: find a card whose owner joined recently (`is_newcomer_owner=true`) without a for_you signal — confirm "Rising newcomer" renders instead of "Fresh provider".
- [ ] Manual: find an event at 8/10 capacity — confirm the amber "2 spots left" pill renders.
- [ ] Manual: same event at 9/10 — confirm the singular "1 spot left" copy.
