### PR TITLE
feat(frontend): tighten Browse layout for small displays

### DIFF
--- a/frontend/src/components/MainSidebar.tsx
+++ b/frontend/src/components/MainSidebar.tsx
@@ -300,9 +300,22 @@ export function MainSidebar({
                 )
               })}
               {myServices.length > 4 && (
-                <Text fontSize="11px" color={GRAY400} textAlign="center">
-                  +{myServices.length - 4} more
-                </Text>
+                <Box
+                  as="button"
+                  w="full"
+                  py="6px"
+                  borderRadius="9px"
+                  bg="transparent"
+                  border={`1px dashed ${GRAY200}`}
+                  onClick={() => navigate('/profile?tab=offers')}
+                  aria-label="View all my listings"
+                  data-testid="my-listings-show-all"
+                  _hover={{ bg: GRAY50, borderColor: GRAY100 }}
+                >
+                  <Text fontSize="11px" fontWeight={600} color={GRAY500} textAlign="center">
+                    +{myServices.length - 4} more
+                  </Text>
+                </Box>
               )}
             </VStack>
           </Box>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -21,6 +21,8 @@ import {
   FiMenu,
   FiX,
   FiCheck,
+  FiMap,
+  FiChevronUp,
 } from 'react-icons/fi'
 
 // Lazy-load the Mapbox-backed MapView. mapbox-gl is ~1.79 MB / 492 KB gzipped
@@ -445,6 +447,12 @@ const DashboardPage = () => {
   const [distanceKm, setDistanceKm]                 = useState(20)
   const [debouncedDistance, setDebouncedDistance]   = useState(20)
   const [locationEnabled, setLocationEnabled]       = useState(() => localStorage.getItem('locationEnabled') !== 'false')
+  // Discovery feed gets cramped on smaller MacBooks because the 280px-tall
+  // Mapbox panel pushes the first card row well below the fold. Persist the
+  // collapse choice so power users who never look at the map don't have to
+  // dismiss it on every visit. Defaults to expanded so first-time users
+  // still see the location preview.
+  const [mapCollapsed, setMapCollapsed]             = useState(() => localStorage.getItem('dashboardMapCollapsed') === 'true')
   const [locationLoading, setLocationLoading]       = useState(false)
   const [locationError, setLocationError]           = useState<string | null>(null)
   const locationAutoRequested                       = useRef(false)
@@ -890,32 +898,87 @@ const DashboardPage = () => {
 
           </Box>
 
-          {/* Map panel — always visible, fixed height. Lazy-loaded. */}
-          <Box bg={WHITE} borderBottom={`1px solid ${GRAY200}`} flexShrink={0} p={3}>
-            <Suspense
-              fallback={
+          {/* Map panel — responsive height, collapsible to recover the
+              280px above-the-fold cost on smaller MacBook displays. The
+              collapsed banner skips the Mapbox load entirely so the
+              network/CPU savings stack on top of the layout one. */}
+          <Box bg={WHITE} borderBottom={`1px solid ${GRAY200}`} flexShrink={0} p={3} position="relative">
+            {mapCollapsed ? (
+              <Box
+                as="button"
+                w="full"
+                px={3}
+                py="8px"
+                borderRadius="12px"
+                bg={GRAY50}
+                border={`1px solid ${GRAY200}`}
+                onClick={() => {
+                  setMapCollapsed(false)
+                  localStorage.setItem('dashboardMapCollapsed', 'false')
+                }}
+                aria-label="Show map"
+                data-testid="dashboard-map-show"
+                _hover={{ bg: GRAY100 }}
+              >
+                <Flex align="center" justify="center" gap={2} color={GRAY600}>
+                  <FiMap size={14} />
+                  <Text fontSize="12px" fontWeight={600}>Show map</Text>
+                </Flex>
+              </Box>
+            ) : (
+              <>
+                <Box h={{ base: '200px', md: '240px', lg: '280px' }}>
+                  <Suspense
+                    fallback={
+                      <Box
+                        bg={GRAY100}
+                        h="100%"
+                        borderRadius="12px"
+                        border={`1px solid ${GRAY200}`}
+                      />
+                    }
+                  >
+                    <MapView
+                      services={displayServices}
+                      height="100%"
+                      onServiceClick={(id) => navigate(`/service-detail/${id}`)}
+                      userLocation={userLocation}
+                      isRefreshing={isLoading && services.length > 0}
+                    />
+                  </Suspense>
+                </Box>
                 <Box
-                  bg={GRAY100}
-                  h="280px"
-                  borderRadius="12px"
+                  as="button"
+                  position="absolute"
+                  top="14px"
+                  right="14px"
+                  zIndex={2}
+                  px="8px"
+                  py="4px"
+                  borderRadius="9px"
+                  bg="rgba(255,255,255,0.9)"
                   border={`1px solid ${GRAY200}`}
-                />
-              }
-            >
-              <MapView
-                services={displayServices}
-                height="280px"
-                onServiceClick={(id) => navigate(`/service-detail/${id}`)}
-                userLocation={userLocation}
-                isRefreshing={isLoading && services.length > 0}
-              />
-            </Suspense>
+                  onClick={() => {
+                    setMapCollapsed(true)
+                    localStorage.setItem('dashboardMapCollapsed', 'true')
+                  }}
+                  aria-label="Hide map"
+                  data-testid="dashboard-map-hide"
+                  _hover={{ bg: WHITE }}
+                >
+                  <Flex align="center" gap="4px" color={GRAY600}>
+                    <FiChevronUp size={12} />
+                    <Text fontSize="11px" fontWeight={700}>Hide map</Text>
+                  </Flex>
+                </Box>
+              </>
+            )}
           </Box>
 
           {/* YouTube-style filter chips. Click a chip to narrow the feed
               to that Wikidata tag, "All" resets. Chips are derived from
               the viewer's interaction history (skills + handshakes + saved). */}
-          <Box bg={WHITE} borderBottom={`1px solid ${GRAY200}`} flexShrink={0} px={{ base: 3, md: 5 }} py="10px">
+          <Box bg={WHITE} borderBottom={`1px solid ${GRAY200}`} flexShrink={0} px={{ base: 3, md: 5 }} py="6px">
             <TagChipsRow activeQid={activeTagQid} onSelect={setActiveTagQid} />
           </Box>
 

--- a/frontend/src/test/components/MainSidebar.test.tsx
+++ b/frontend/src/test/components/MainSidebar.test.tsx
@@ -1,0 +1,88 @@
+import { ChakraProvider } from '@chakra-ui/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MainSidebar } from '@/components/MainSidebar'
+import system from '@/theme'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: true,
+    user: {
+      id: 'me',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      timebank_balance: 4,
+      achievements: [],
+      badges: [],
+    },
+  }),
+}))
+
+function buildListings(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `s${i + 1}`,
+    title: `Listing ${i + 1}`,
+    type: 'Offer' as const,
+  }))
+}
+
+function renderSidebar(listingCount: number) {
+  render(
+    <ChakraProvider value={system}>
+      <MemoryRouter>
+        <MainSidebar myServices={buildListings(listingCount)} />
+      </MemoryRouter>
+    </ChakraProvider>,
+  )
+}
+
+describe('MainSidebar — My Listings overflow', () => {
+  beforeEach(() => navigateMock.mockReset())
+
+  it('renders all listings without an overflow link when there are 4 or fewer', () => {
+    renderSidebar(4)
+    expect(screen.getByText('Listing 1')).toBeInTheDocument()
+    expect(screen.getByText('Listing 4')).toBeInTheDocument()
+    expect(screen.queryByTestId('my-listings-show-all')).not.toBeInTheDocument()
+  })
+
+  it('shows "+N more" overflow link when there are more than 4 listings', () => {
+    // 6 listings → 4 visible + "+2 more". The overflow control gives the
+    // user a way to reach the rest without redesigning the sidebar to
+    // scroll a long list inline.
+    renderSidebar(6)
+    const overflow = screen.getByTestId('my-listings-show-all')
+    expect(overflow).toBeInTheDocument()
+    expect(overflow).toHaveTextContent('+2 more')
+  })
+
+  it('renders the overflow link as a button with an aria-label', () => {
+    renderSidebar(6)
+    const overflow = screen.getByTestId('my-listings-show-all')
+    // The element is rendered via Chakra `as="button"`; the resulting
+    // DOM is a real <button> so screen readers announce it correctly.
+    expect(overflow.tagName.toLowerCase()).toBe('button')
+    expect(overflow).toHaveAttribute('aria-label', 'View all my listings')
+  })
+
+  it('clicking the overflow link routes to /profile?tab=offers', () => {
+    // Profile page reads ?tab= via UserProfile.tsx:152-186; landing on
+    // the offers tab gives the user the densest of the per-type tabs as
+    // a starting point and they can switch to needs/events from there.
+    renderSidebar(7)
+    fireEvent.click(screen.getByTestId('my-listings-show-all'))
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith('/profile?tab=offers')
+  })
+})

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -196,4 +196,40 @@ describe('DashboardPage (Browse)', () => {
       expect(last?.types).toEqual(expect.arrayContaining(['Offer', 'Need']))
     })
   })
+
+  // ── Map collapse toggle (§9 Win 2) ────────────────────────────────────────
+
+  it('renders the map by default and exposes a Hide map button', async () => {
+    storage = {}
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('map-view')).toBeInTheDocument())
+    expect(screen.getByTestId('dashboard-map-hide')).toBeInTheDocument()
+    expect(screen.queryByTestId('dashboard-map-show')).not.toBeInTheDocument()
+  })
+
+  it('Hide map collapses the panel and persists the choice in localStorage', async () => {
+    storage = {}
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('map-view')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('dashboard-map-hide'))
+
+    await waitFor(() => expect(screen.queryByTestId('map-view')).not.toBeInTheDocument())
+    expect(screen.getByTestId('dashboard-map-show')).toBeInTheDocument()
+    expect(storage.dashboardMapCollapsed).toBe('true')
+  })
+
+  it('initialises collapsed when localStorage says so, and Show map restores it', async () => {
+    storage = { dashboardMapCollapsed: 'true' }
+    renderPage()
+
+    // Collapsed banner is rendered first; map is not in the tree.
+    await waitFor(() => expect(screen.getByTestId('dashboard-map-show')).toBeInTheDocument())
+    expect(screen.queryByTestId('map-view')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('dashboard-map-show'))
+
+    await waitFor(() => expect(screen.getByTestId('map-view')).toBeInTheDocument())
+    expect(storage.dashboardMapCollapsed).toBe('false')
+  })
 })


### PR DESCRIPTION
## Summary

The Browse page felt cramped on smaller MacBook displays — the 280px fixed-height map plus the 10px-padded tag-chips row pushed the first service card row well below the fold. Roll three small layout wins together plus an unrelated affordance fix on the My Listings sidebar overflow.

## What changed

- **Responsive map height** — `frontend/src/pages/DashboardPage.tsx`. `280px` → `{ base: '200px', md: '240px', lg: '280px' }`. Frees up to 80px above the fold on `md` (768–992px) viewports — roughly the 13" MacBook target — without changing the desktop look.
- **Collapsible map** — new "Hide map" / "Show map" toggle anchored top-right of the map block, persisted in `localStorage` so power users who never look at the map don't dismiss it on every visit. The collapsed banner skips the Mapbox component entirely, so the network/CPU savings stack on top of the layout one. Default stays expanded for first-time users.
- **Tag-chips row padding** — `py="10px"` → `py="6px"`. Saves another ~8px above the fold.
- **My Listings overflow link** — `frontend/src/components/MainSidebar.tsx`. The "+N more" hint at the bottom of the sidebar's listing widget was a non-interactive `<Text>`. Convert to a dashed button that routes to `/profile?tab=offers` so users with more than four listings can reach the full set; the profile page already supports `?tab=` query routing via `UserProfile.tsx:152-186`.

## Tests

- **DashboardPage** — three new vitest cases (10 total) pin the collapse contract:
  - default expanded with a Hide button visible
  - Hide collapses + writes `dashboardMapCollapsed=true` to localStorage
  - localStorage `=true` initialises collapsed; Show restores the map
- **MainSidebar** — new test file with four cases:
  - `≤4` listings: no overflow link
  - `>4` listings: overflow link visible with "+N more" copy
  - rendered as a real `<button>` with `aria-label="View all my listings"`
  - click routes to `/profile?tab=offers`

## Out of scope (defer to epic #484 / #579)
- Sidebar redesign (collapse on tablets, accordion sections, drawer pattern).
- Map → full-screen modal pattern.
- Service-card density tuning beyond the existing `xl: repeat(3, 1fr)` grid.

## Test plan

- [ ] `cd frontend && npm test -- src/test/pages/DashboardPage.test.tsx src/test/components/MainSidebar.test.tsx --run` — 14 green.
- [ ] Manual: open `/dashboard` at 1280×800 viewport. Confirm map is ~240px tall by default. Click Hide — banner appears, refresh persists the choice. Click Show — map returns.
- [ ] Manual: log in as a user with 5+ listings. Confirm the dashed "+N more" button hover-styles, and clicking routes to `/profile?tab=offers`.
