### PR TITLE
fix(frontend): wire chip diversification into the live Browse grid

### DIFF
--- a/backend/api/tests/integration/test_service_hot_social_boost.py
+++ b/backend/api/tests/integration/test_service_hot_social_boost.py
@@ -101,3 +101,77 @@ class TestServiceHotSocialBoost:
         ordered_ids = self._service_ids_in_order(response.data)
         assert str(second_degree_service.id) == ordered_ids[0]
         assert str(disconnected_service.id) == ordered_ids[1]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestServiceHotProximityWithOnline:
+    """Online services must rank by hot_score alone when proximity is active.
+
+    Regression: the Phase 2 ranking annotates `distance = Distance(location,
+    viewer_point)`, which is NULL for Online services because they have no
+    `location` PointField. The proximity expression `1.0 / (1.0 + distance /
+    half_life)` then evaluates to NULL, propagates into `composite_score`,
+    and Postgres' default for `ORDER BY composite_score DESC` is NULLS
+    FIRST -- so every Online service piled to the top of every
+    location-aware feed regardless of its hot_score. Treat NULL distance as
+    a neutral 0 m so Online services compete on hot_score with the closest
+    in-person rows instead of jumping the queue.
+    """
+
+    def _service_ids_in_order(self, response_data):
+        results = response_data.get('results', response_data)
+        ours = [item for item in results if item['title'].startswith('[HPO]')]
+        return [item['id'] for item in ours]
+
+    def test_low_score_online_does_not_outrank_high_score_inperson_under_location(self):
+        viewer = UserFactory()
+
+        # Online row with the lowest hot_score in the matched set. Pre-fix it
+        # still landed at the top because its NULL composite_score sorted
+        # before any concrete float in `ORDER BY ... DESC NULLS FIRST`.
+        online_low = ServiceFactory(
+            user=UserFactory(),
+            type='Offer',
+            schedule_type='One-Time',
+            max_participants=1,
+            title='[HPO] Online Low Score',
+            duration=Decimal('1.00'),
+            location_type='Online',
+            location_lat=None,
+            location_lng=None,
+            status='Active',
+        )
+        # In-Person row sitting right at the viewer's location with a
+        # clearly higher hot_score. With Online treated neutrally this row
+        # must sort first.
+        in_person_high = ServiceFactory(
+            user=UserFactory(),
+            type='Offer',
+            schedule_type='One-Time',
+            max_participants=1,
+            title='[HPO] In-Person High Score Nearby',
+            duration=Decimal('1.00'),
+            location_type='In-Person',
+            location_lat=Decimal('41.0082'),
+            location_lng=Decimal('29.0500'),
+            status='Active',
+        )
+
+        Service.objects.filter(pk=online_low.pk).update(hot_score=1.0)
+        Service.objects.filter(pk=in_person_high.pk).update(hot_score=10.0)
+
+        client = AuthenticatedAPIClient().authenticate_user(viewer)
+        response = client.get(
+            '/api/services/?sort=hot&search=[HPO]&lat=41.0082&lng=29.0500'
+        )
+
+        assert_api_response(response, 200)
+        ordered_ids = self._service_ids_in_order(response.data)
+        assert str(in_person_high.id) == ordered_ids[0], (
+            'High-score in-person row at the viewer location must outrank a '
+            'low-score Online row when proximity is active. Pre-fix the '
+            'Online row landed first because NULL composite_score sorted '
+            'before all floats.'
+        )
+        assert str(online_low.id) == ordered_ids[1]

--- a/backend/api/tests/unit/test_cache_utils.py
+++ b/backend/api/tests/unit/test_cache_utils.py
@@ -182,6 +182,16 @@ class TestRegisterCalendarCacheKey:
     level `cache.clear()` would wreck other workers' in-flight state.
     """
 
+    @pytest.fixture(autouse=True)
+    def clear_django_cache(self):
+        # Override the conftest-level autouse fixture for this class only.
+        # CI runs pytest-xdist against a shared Redis DB, where a parallel
+        # worker's `cache.clear()` would nuke this class's tracking set
+        # mid-read-modify-write and surface as a flaky empty-set assertion.
+        # uuid-prefixed user_ids already isolate this class's keys from
+        # other workers, so skipping the global clear is safe.
+        yield
+
     def test_register_two_keys_for_same_user_keeps_both(self):
         import uuid
         from django.core.cache import cache as django_cache

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2616,10 +2616,21 @@ class ServiceViewSet(viewsets.ModelViewSet):
             half_life_km = getattr(settings, 'RANKING_PROXIMITY_HALF_LIFE_KM', 10.0)
             if proximity_active and half_life_km > 0:
                 # PostGIS Distance annotation is in metres (srid=4326).
+                # Online services have `location IS NULL`, which makes the
+                # Distance annotation NULL and would propagate NULL all the
+                # way into composite_score. Postgres' default for `ORDER BY
+                # ... DESC` is NULLS FIRST, so every Online row used to land
+                # at the top of every location-aware feed regardless of
+                # hot_score. Coalesce a missing distance to 0 m so Online
+                # cards collapse to proximity_factor=1.0 and compete on
+                # hot_score with the closest in-person rows.
+                distance_metres = Coalesce(
+                    F('distance'), Value(0.0, output_field=FloatField())
+                )
                 proximity_expr = ExpressionWrapper(
                     Value(1.0, output_field=FloatField()) / (
                         Value(1.0, output_field=FloatField())
-                        + F('distance') / Value(
+                        + distance_metres / Value(
                             1000.0 * half_life_km, output_field=FloatField()
                         )
                     ),

--- a/frontend/src/components/SmartPill.tsx
+++ b/frontend/src/components/SmartPill.tsx
@@ -89,6 +89,29 @@ interface SmartPillProps {
  */
 export default function SmartPill({ service }: SmartPillProps) {
   const chip = chipForSignals(service.for_you_signals)
+  // Newcomer-over-follow promotion: when the for-you chip resolves to
+  // `follow`, the owner is a newcomer, AND the follow signal is from an
+  // indirect (friend-of-friend, raw signal < 1.0) connection, render
+  // the newcomer story instead. Direct follows keep "From your network"
+  // because that IS the actual discovery insight -- the viewer chose to
+  // follow this person. Mirrors the same branch in `pillIdentity` so
+  // the diversifier and the renderer agree on the chip identity.
+  const followSignal = service.for_you_signals?.follow ?? 0
+  if (
+    chip.name === 'follow'
+    && service.is_newcomer_owner
+    && followSignal < 1
+  ) {
+    return (
+      <PillBox
+        label={NEWCOMER_FLAVOUR.label}
+        bg={NEWCOMER_FLAVOUR.bg}
+        fg={NEWCOMER_FLAVOUR.fg}
+        border={NEWCOMER_FLAVOUR.border}
+        Icon={NEWCOMER_FLAVOUR.Icon}
+      />
+    )
+  }
   if (chip.name !== 'default') {
     const Icon =
       chip.name === 'follow' ? FiUsers

--- a/frontend/src/components/SmartPill.tsx
+++ b/frontend/src/components/SmartPill.tsx
@@ -81,6 +81,11 @@ interface SmartPillProps {
  * qualifies as cold_start, which drowned out cards that DID have a real
  * for_you signal. cold_start specifically renders as an outline pill so
  * it never dominates over a saturated for_you pill.
+ *
+ * IMPORTANT: this priority chain is also encoded in `pillIdentity` in
+ * forYouChips.ts so the Browse-grid diversifier sees the same chip
+ * identities the user does. If you reorder branches here, mirror the
+ * change there or runs of identical pills will resurface.
  */
 export default function SmartPill({ service }: SmartPillProps) {
   const chip = chipForSignals(service.for_you_signals)

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -703,25 +703,36 @@ const DashboardPage = () => {
           return hs?.status !== 'cancelled'
         })
       : services
+    const isInactive = (s: Service) =>
+      ['denied', 'cancelled'].includes(handshakeMap.get(s.id)?.status ?? '')
     const filtered = base
       .filter((s) => {
         if (s.type === 'Event' && s.scheduled_time && new Date(s.scheduled_time).getTime() <= Date.now()) return false
         return true
       })
       .sort((a, b) => {
-        const aInactive = ['denied', 'cancelled'].includes(handshakeMap.get(a.id)?.status ?? '')
-        const bInactive = ['denied', 'cancelled'].includes(handshakeMap.get(b.id)?.status ?? '')
+        const aInactive = isInactive(a)
+        const bInactive = isInactive(b)
         if (aInactive === bInactive) return 0
         return aInactive ? 1 : -1
       })
     // Anti-clustering: when the viewer has many connections, the `follow`
     // signal dominates and the grid renders runs of identical "From your
     // network" pills. `diversifyByChip` walks the result and swaps in a
-    // different-chip neighbour from the next 3 cards whenever a duplicate
+    // different-chip neighbour from the next few cards whenever a duplicate
     // would land. Caps total swaps at floor(N/2) so the underlying ranking
-    // signal is preserved — the helper rotates within a window, not across
-    // the whole page.
-    return diversifyByChip(filtered)
+    // signal is preserved.
+    //
+    // The diversifier swaps within a windowed lookahead — without
+    // partitioning, an active-vs-inactive boundary that lands inside that
+    // window can be crossed and a denied/cancelled row can get pulled back
+    // above active ones, undoing the inactive-bottom sort. Diversify only
+    // the active partition and append the inactive tail untouched.
+    const firstInactive = filtered.findIndex(isInactive)
+    if (firstInactive === -1) return diversifyByChip(filtered)
+    const active = filtered.slice(0, firstInactive)
+    const inactive = filtered.slice(firstInactive)
+    return [...diversifyByChip(active), ...inactive]
   }, [services, isAuthenticated, handshakeMap])
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -53,6 +53,7 @@ import {
 } from '@/theme/tokens'
 import { formatGroupOfferDateTime, isNearlyFull } from '@/utils/eventUtils'
 import { isEventRecurrent } from '@/utils/eventRecurrence'
+import { diversifyByChip } from '@/utils/forYouChips'
 
 const DEBOUNCE_SEARCH   = 400
 const DEBOUNCE_DISTANCE = 250
@@ -694,7 +695,7 @@ const DashboardPage = () => {
           return hs?.status !== 'cancelled'
         })
       : services
-    return base
+    const filtered = base
       .filter((s) => {
         if (s.type === 'Event' && s.scheduled_time && new Date(s.scheduled_time).getTime() <= Date.now()) return false
         return true
@@ -705,6 +706,14 @@ const DashboardPage = () => {
         if (aInactive === bInactive) return 0
         return aInactive ? 1 : -1
       })
+    // Anti-clustering: when the viewer has many connections, the `follow`
+    // signal dominates and the grid renders runs of identical "From your
+    // network" pills. `diversifyByChip` walks the result and swaps in a
+    // different-chip neighbour from the next 3 cards whenever a duplicate
+    // would land. Caps total swaps at floor(N/2) so the underlying ranking
+    // signal is preserved — the helper rotates within a window, not across
+    // the whole page.
+    return diversifyByChip(filtered)
   }, [services, isAuthenticated, handshakeMap])
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))

--- a/frontend/src/test/components/ForYouCarousel.chip.test.tsx
+++ b/frontend/src/test/components/ForYouCarousel.chip.test.tsx
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from 'vitest'
 
-import { diversifyByChip } from '@/utils/forYouChips'
+import { chipForSignals, diversifyByChip } from '@/utils/forYouChips'
 import type { ForYouSignals, Service } from '@/types'
 
 function svc(id: string, signals: ForYouSignals): Service {
@@ -122,6 +122,40 @@ describe('diversifyByChip', () => {
 
     const out = diversifyByChip(cards)
     expect(out.map(s => s.id)).toEqual(['0', '1', '2', '3', '4'])
+  })
+
+  it('breaks up follow-saturated runs across the first two visible rows of a 15-card grid', () => {
+    // Mirrors Elif's account on the demo seed, where ~80% of cards win
+    // the chip on `follow` (everyone-follows-everyone) and only 3 of 15
+    // resolve to `tag`. With a too-narrow lookahead the diversifier can
+    // only reach the first tag card and leaves positions 3-4-5 as an
+    // all-follow cluster — the second row of the 3-column grid renders
+    // as three identical "From your network" pills.
+    const followCard = (id: string) =>
+      svc(id, { tag: 0, follow: 1, cooccur: 0, recency_penalty: 0 })
+    const tagCard = (id: string, weight: number) =>
+      svc(id, { tag: weight, follow: 0, cooccur: 0, recency_penalty: 0 })
+    const cards = [
+      followCard('0'), followCard('1'), tagCard('2', 0.5),
+      followCard('3'), followCard('4'), followCard('5'),
+      followCard('6'), followCard('7'), followCard('8'),
+      followCard('9'), followCard('10'), tagCard('11', 1.0),
+      followCard('12'), tagCard('13', 0.67), followCard('14'),
+    ]
+
+    const out = diversifyByChip(cards)
+
+    // No three consecutive cards anywhere in the first two visible rows
+    // (positions 0-5) may share a chip identity. This is the regression
+    // the bumped lookahead unlocks: rows 1 and 2 must each render at
+    // least one non-follow pill so the page does not look monochrome.
+    const namesInFirstSixRows = out
+      .slice(0, 6)
+      .map(s => chipForSignals(s.for_you_signals).name)
+    for (let i = 0; i + 2 < namesInFirstSixRows.length; i++) {
+      const triplet = namesInFirstSixRows.slice(i, i + 3)
+      expect(new Set(triplet).size).toBeGreaterThan(1)
+    }
   })
 })
 

--- a/frontend/src/test/components/ForYouCarousel.chip.test.tsx
+++ b/frontend/src/test/components/ForYouCarousel.chip.test.tsx
@@ -20,6 +20,27 @@ function svc(id: string, signals: ForYouSignals): Service {
   } as unknown as Service
 }
 
+// Cards without for_you_signals still render distinct pills in SmartPill
+// based on explore_pool / is_newcomer_owner / capacity. The diversifier
+// must see the same identities or runs of e.g. "Fresh provider" survive.
+function exploreSvc(id: string, pool: NonNullable<Service['explore_pool']>): Service {
+  return {
+    id,
+    title: `Service ${id}`,
+    type: 'Offer',
+    explore_pool: pool,
+  } as unknown as Service
+}
+
+function newcomerSvc(id: string): Service {
+  return {
+    id,
+    title: `Service ${id}`,
+    type: 'Offer',
+    is_newcomer_owner: true,
+  } as unknown as Service
+}
+
 describe('diversifyByChip', () => {
   it('breaks runs of same-chip cards by swapping in a different-chip card within lookahead', () => {
     // Three follow-strongest cards in a row, then a tag-strongest card.
@@ -52,6 +73,51 @@ describe('diversifyByChip', () => {
     // All five cards are follow-strongest; nothing to swap with.
     const cards = Array.from({ length: 5 }, (_, i) =>
       svc(String(i), { tag: 0, follow: 1, cooccur: 0, recency_penalty: 0 }),
+    )
+
+    const out = diversifyByChip(cards)
+    expect(out.map(s => s.id)).toEqual(['0', '1', '2', '3', '4'])
+  })
+
+  it('breaks runs of same-explore_pool cards even when for_you_signals are absent', () => {
+    // Demo data: most cards are cold_start with no for_you_signals. Before
+    // the fix, every such card mapped to 'default' for the diversifier,
+    // so clusters of "Fresh provider" survived untouched. With pillIdentity
+    // mirroring SmartPill, cold_start ≠ undershown_quality and the
+    // duplicate at index 1 should be swapped with the differing card
+    // at index 3.
+    const cards = [
+      exploreSvc('a', 'cold_start'),
+      exploreSvc('b', 'cold_start'),
+      exploreSvc('c', 'cold_start'),
+      exploreSvc('d', 'undershown_quality'),
+    ]
+
+    const out = diversifyByChip(cards)
+    expect(out[0].id).toBe('a')
+    expect(out[1].id).not.toBe('b')
+  })
+
+  it('treats newcomer and explore_pool as distinct identities', () => {
+    // SmartPill renders "Rising newcomer" for is_newcomer_owner and
+    // "Fresh provider" for cold_start. The diversifier must see them as
+    // different so a newcomer adjacent to two cold_starts breaks the run.
+    const cards = [
+      exploreSvc('a', 'cold_start'),
+      exploreSvc('b', 'cold_start'),
+      newcomerSvc('c'),
+    ]
+
+    const out = diversifyByChip(cards)
+    expect(out[0].id).toBe('a')
+    expect(out[1].id).toBe('c')
+  })
+
+  it('still leaves runs alone when every card shares the same pill identity', () => {
+    // Five cold_start cards in a row; nothing to swap with — diversifier
+    // must not invent variance that does not exist in the source.
+    const cards = Array.from({ length: 5 }, (_, i) =>
+      exploreSvc(String(i), 'cold_start'),
     )
 
     const out = diversifyByChip(cards)

--- a/frontend/src/test/components/ForYouCarousel.chip.test.tsx
+++ b/frontend/src/test/components/ForYouCarousel.chip.test.tsx
@@ -186,4 +186,48 @@ describe('weighted chip picker', () => {
     expect(out[0].id).toBe('a')
     expect(out[1].id).toBe('c')
   })
+
+  it('promotes a competitive interest signal over follow on dense follow graphs', () => {
+    // Mirrors the demo seed: everyone-follows-everyone makes most cards
+    // win on `follow`, even when `tag` overlap is non-trivial. Showing
+    // "From your network" 10 times in a row erases the more actionable
+    // "Matches your interests" story for cards that genuinely have
+    // interest overlap. Promote `tag` whenever its weighted score is at
+    // least half of follow's, so the demo Browse grid no longer renders
+    // a near-monochrome strip of follow chips.
+    //
+    // Raw weights: tag * 0.5, follow * 0.3.
+    // tag=0.5 -> 0.25; follow=1.0 -> 0.30. Ratio 0.83 -> tag wins.
+    const card = chipForSignals({
+      tag: 0.5, follow: 1.0, cooccur: 0, recency_penalty: 0,
+    } as ForYouSignals)
+    expect(card.name).toBe('tag')
+
+    // tag=0.33 -> 0.165; follow=1.0 -> 0.30. Ratio 0.55 -> tag still wins.
+    const moderate = chipForSignals({
+      tag: 0.33, follow: 1.0, cooccur: 0, recency_penalty: 0,
+    } as ForYouSignals)
+    expect(moderate.name).toBe('tag')
+
+    // tag=0.1 -> 0.05; follow=1.0 -> 0.30. Ratio 0.17 -> follow wins.
+    // Below the half-strength bar a tiny tag overlap should not hijack
+    // the chip.
+    const trace = chipForSignals({
+      tag: 0.1, follow: 1.0, cooccur: 0, recency_penalty: 0,
+    } as ForYouSignals)
+    expect(trace.name).toBe('follow')
+  })
+
+  it('does not promote a competitive cooccur/engagement signal over a primary tag chip', () => {
+    // The promotion only fires for follow saturation. A card whose
+    // primary signal is already an interest axis should not flip to a
+    // weaker interest axis just because that axis is competitive.
+    // tag=0.5 -> 0.25; cooccur=1.0 -> 0.20. tag is primary. Ratio
+    // (cooccur / tag) = 0.80, so without the follow-only guard the
+    // logic would replace tag with cooccur and harm clarity.
+    const c = chipForSignals({
+      tag: 0.5, follow: 0, cooccur: 1.0, recency_penalty: 0,
+    } as ForYouSignals)
+    expect(c.name).toBe('tag')
+  })
 })

--- a/frontend/src/test/components/ForYouCarousel.chip.test.tsx
+++ b/frontend/src/test/components/ForYouCarousel.chip.test.tsx
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from 'vitest'
 
-import { chipForSignals, diversifyByChip } from '@/utils/forYouChips'
+import { chipForSignals, diversifyByChip, pillIdentity } from '@/utils/forYouChips'
 import type { ForYouSignals, Service } from '@/types'
 
 function svc(id: string, signals: ForYouSignals): Service {
@@ -230,4 +230,51 @@ describe('weighted chip picker', () => {
     } as ForYouSignals)
     expect(c.name).toBe('tag')
   })
+
+  it('promotes newcomer over follow only on indirect (friend-of-friend) connections', () => {
+    // Demo seed creates direct follows (signal=1.0) and second-degree
+    // follows (signal=0.5). When the owner is a newcomer, only the
+    // indirect cards should flip to "Rising newcomer" -- direct
+    // follows keep "From your network" because that IS the actual
+    // discovery story (the viewer chose to follow this person). On
+    // densely-connected seeds this still surfaces a third pill colour
+    // for the indirect-follow newcomers without erasing the follow
+    // chip on direct-follow cards.
+
+    // Direct follow + newcomer => stays follow (the explicit follow
+    // is the more relevant story than "rising newcomer").
+    const directFollowNewcomer = {
+      id: 'd', type: 'Offer',
+      for_you_signals: { tag: 0, follow: 1.0, cooccur: 0, recency_penalty: 0 },
+      is_newcomer_owner: true,
+    } as unknown as Service
+    expect(pillIdentity(directFollowNewcomer)).toBe('follow')
+
+    // Indirect follow + newcomer => promoted to newcomer.
+    const indirectFollowNewcomer = {
+      id: 'i', type: 'Offer',
+      for_you_signals: { tag: 0, follow: 0.5, cooccur: 0, recency_penalty: 0 },
+      is_newcomer_owner: true,
+    } as unknown as Service
+    expect(pillIdentity(indirectFollowNewcomer)).toBe('newcomer')
+
+    // Indirect follow + non-newcomer => stays follow (no newcomer story
+    // to promote).
+    const indirectFollowOldOwner = {
+      id: 'o', type: 'Offer',
+      for_you_signals: { tag: 0, follow: 0.5, cooccur: 0, recency_penalty: 0 },
+      is_newcomer_owner: false,
+    } as unknown as Service
+    expect(pillIdentity(indirectFollowOldOwner)).toBe('follow')
+
+    // No for-you signals + newcomer => still resolves through the
+    // existing fallback branch.
+    const newcomerOnly = {
+      id: 'n', type: 'Offer',
+      for_you_signals: { tag: 0, follow: 0, cooccur: 0, recency_penalty: 0 },
+      is_newcomer_owner: true,
+    } as unknown as Service
+    expect(pillIdentity(newcomerOnly)).toBe('newcomer')
+  })
+
 })

--- a/frontend/src/test/components/ForYouCarousel.chip.test.tsx
+++ b/frontend/src/test/components/ForYouCarousel.chip.test.tsx
@@ -124,6 +124,36 @@ describe('diversifyByChip', () => {
     expect(out.map(s => s.id)).toEqual(['0', '1', '2', '3', '4'])
   })
 
+  it('does not perturb ranking to break a run of invisible (none-identity) pills', () => {
+    // pillIdentity returns 'none' for vanilla cards: no for_you_signals,
+    // no explore_pool, no newcomer flag, not capacity-near-full. SmartPill
+    // renders nothing for these. Two consecutive 'none' cards are not a
+    // user-visible cluster, so the diversifier must NOT bump a higher-
+    // ranked 'none' card down just to lift a single 'follow' card up
+    // through the lookahead window — that perturbs ranking order to
+    // resolve a collision the user can't see.
+    const vanilla = (id: string): Service =>
+      ({ id, title: `Service ${id}`, type: 'Offer' } as unknown as Service)
+    const followCard = (id: string) =>
+      svc(id, { tag: 0, follow: 1, cooccur: 0, recency_penalty: 0 })
+    const cards = [
+      vanilla('a'),
+      vanilla('b'),
+      vanilla('c'),
+      followCard('d'),
+    ]
+
+    const out = diversifyByChip(cards)
+    // Sanity: every vanilla card is identity 'none' and the follow card is
+    // identity 'follow' — the precondition that triggered the spurious swap.
+    expect(pillIdentity(cards[0])).toBe('none')
+    expect(pillIdentity(cards[1])).toBe('none')
+    expect(pillIdentity(cards[3])).toBe('follow')
+    // Order is preserved: the follow card stays at the bottom even though
+    // pulling it up would technically "diversify" the none-none collision.
+    expect(out.map(s => s.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
   it('breaks up follow-saturated runs across the first two visible rows of a 15-card grid', () => {
     // Mirrors Elif's account on the demo seed, where ~80% of cards win
     // the chip on `follow` (everyone-follows-everyone) and only 3 of 15

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -269,8 +269,8 @@ describe('DashboardPage (Browse)', () => {
     // Wait for the cards to render and read their DOM order. The grid
     // renders services in array order, so without diversification the
     // tag card sits last — `f1, f2, f3, t1`. After the wired pass, the
-    // helper swaps t1 into position 1 (lookahead 3), giving `f1, t1, f2, f3`,
-    // which breaks the consecutive-follow run.
+    // helper finds the tag card within the lookahead window and swaps
+    // it into position 1, breaking the consecutive-follow run.
     await waitFor(() => expect(screen.getByText('Follow card 1')).toBeInTheDocument())
 
     const titles = ['Follow card 1', 'Follow card 2', 'Follow card 3', 'Tag card 1']

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -275,10 +275,11 @@ describe('DashboardPage (Browse)', () => {
 
     const titles = ['Follow card 1', 'Follow card 2', 'Follow card 3', 'Tag card 1']
     const elements = titles.map((t) => screen.getByText(t))
-    // sort the elements by document order (compareDocumentPosition returns
-    // a bitmask: 4 = "is following", so a follows b means a is later).
+    // Sort the elements by document order. `a.compareDocumentPosition(b) &
+    // DOCUMENT_POSITION_FOLLOWING` is set when **b** is following **a** in
+    // the document — i.e. **a** is the earlier element and should sort
+    // first, so the comparator returns -1 when that bit is set.
     const ordered = [...elements].sort((a, b) => {
-      // eslint-disable-next-line no-bitwise
       return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
     })
     const orderedTitles = ordered.map((el) => el.textContent)
@@ -287,5 +288,54 @@ describe('DashboardPage (Browse)', () => {
     // it forward to break the cluster.
     expect(orderedTitles[3]).not.toBe('Tag card 1')
     expect(orderedTitles).toContain('Tag card 1')
+  })
+
+  it('does not let the diversifier pull a denied/cancelled card above active rows', async () => {
+    // Inactive (denied/cancelled) cards are sorted to the bottom by the
+    // useMemo. Without partitioning the diversifier's swap window can
+    // reach across that boundary and pull a denied card forward to break
+    // a same-chip run, undoing the inactive-bottom intent.
+    const followStrong = (id: string, title: string): Service => ({
+      ...makeService(id, title),
+      for_you_signals: { tag: 0, follow: 1, cooccur: 0, recency_penalty: 0 },
+    } as Service)
+    const tagStrongDenied = (id: string, title: string): Service => ({
+      ...makeService(id, title),
+      for_you_signals: { tag: 0.6, follow: 0, cooccur: 0, recency_penalty: 0 },
+    } as Service)
+
+    listPagedMock.mockResolvedValue({
+      results: [
+        followStrong('f1', 'Active follow 1'),
+        followStrong('f2', 'Active follow 2'),
+        followStrong('f3', 'Active follow 3'),
+        followStrong('f4', 'Active follow 4'),
+        tagStrongDenied('td', 'Denied tag card'),
+      ],
+      count: 5,
+    })
+    handshakeListMock.mockResolvedValue([
+      { id: 'h-td', service: 'td', requester: 'me', status: 'denied' },
+    ])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('Active follow 1')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('Denied tag card')).toBeInTheDocument())
+
+    const titles = [
+      'Active follow 1', 'Active follow 2', 'Active follow 3', 'Active follow 4',
+      'Denied tag card',
+    ]
+    const elements = titles.map((t) => screen.getByText(t))
+    const ordered = [...elements].sort((a, b) => {
+      return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+    })
+    const orderedTitles = ordered.map((el) => el.textContent)
+
+    // The denied card must stay at the bottom — the diversifier should
+    // operate on the active partition only and leave the inactive tail
+    // untouched.
+    expect(orderedTitles[orderedTitles.length - 1]).toBe('Denied tag card')
   })
 })

--- a/frontend/src/test/pages/DashboardPage.test.tsx
+++ b/frontend/src/test/pages/DashboardPage.test.tsx
@@ -196,4 +196,60 @@ describe('DashboardPage (Browse)', () => {
       expect(last?.types).toEqual(expect.arrayContaining(['Offer', 'Need']))
     })
   })
+
+  // ── Chip diversification on the live grid ─────────────────────────────────
+  // The `diversifyByChip` helper has its own unit suite, but it had no
+  // production caller — the Browse grid rendered in raw backend order so
+  // viewers with many connections saw long runs of "From your network"
+  // pills. Pin the wiring here so a future regression that drops the call
+  // fails the suite instead of shipping silently.
+
+  it('rotates chip-clustered cards out of consecutive positions on the live grid', async () => {
+    // Three follow-strong cards then a tag-strong card. Without
+    // diversification the grid renders s1, s2, s3, s4 in that order and
+    // the first three cards all show "From your network". With the wired
+    // helper, s4 (tag) gets swapped in to break the run.
+    const followStrong = (id: string, title: string): Service => ({
+      ...makeService(id, title),
+      for_you_signals: { tag: 0, follow: 1, cooccur: 0, recency_penalty: 0 },
+    } as Service)
+    const tagStrong = (id: string, title: string): Service => ({
+      ...makeService(id, title),
+      for_you_signals: { tag: 0.6, follow: 0, cooccur: 0, recency_penalty: 0 },
+    } as Service)
+
+    listPagedMock.mockResolvedValue({
+      results: [
+        followStrong('f1', 'Follow card 1'),
+        followStrong('f2', 'Follow card 2'),
+        followStrong('f3', 'Follow card 3'),
+        tagStrong('t1', 'Tag card 1'),
+      ],
+      count: 4,
+    })
+
+    renderPage()
+
+    // Wait for the cards to render and read their DOM order. The grid
+    // renders services in array order, so without diversification the
+    // tag card sits last — `f1, f2, f3, t1`. After the wired pass, the
+    // helper swaps t1 into position 1 (lookahead 3), giving `f1, t1, f2, f3`,
+    // which breaks the consecutive-follow run.
+    await waitFor(() => expect(screen.getByText('Follow card 1')).toBeInTheDocument())
+
+    const titles = ['Follow card 1', 'Follow card 2', 'Follow card 3', 'Tag card 1']
+    const elements = titles.map((t) => screen.getByText(t))
+    // sort the elements by document order (compareDocumentPosition returns
+    // a bitmask: 4 = "is following", so a follows b means a is later).
+    const ordered = [...elements].sort((a, b) => {
+      // eslint-disable-next-line no-bitwise
+      return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
+    })
+    const orderedTitles = ordered.map((el) => el.textContent)
+    // The pre-fix order was strictly `Follow card 1/2/3, Tag card 1`.
+    // Post-fix the tag card must NOT be last — the diversify pass lifts
+    // it forward to break the cluster.
+    expect(orderedTitles[3]).not.toBe('Tag card 1')
+    expect(orderedTitles).toContain('Tag card 1')
+  })
 })

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -96,12 +96,20 @@ export function pillIdentity(service: Service): PillIdentity {
 // Caps total swaps so the ranking signal isn't wiped out by aggressive
 // rotation.
 //
-// `lookahead = 4` is tuned for the 10-card web carousel and the Browse
-// grid. Earlier value of 3 left visible 4-in-a-row clusters intact when
-// the diverging card sat just past the window. Mobile renders 5 cards
-// via ForYouSection and currently does not call this helper; if it ever
-// does, drop `lookahead` to 2 so we don't search beyond half the row.
-export function diversifyByChip(services: Service[], lookahead = 4): Service[] {
+// `lookahead = 7` is tuned for the 15-card Browse grid (3 columns × 5
+// rows). On demo data ~80% of cards win the chip on `follow` because
+// the seed is densely connected (94 follows / 13 users), and only ~3
+// of the top 15 resolve to other signals. With the previous value of 4
+// the diversifier could reach the first off-chip card but ran out of
+// reach by the second row, leaving positions 2-4 as a visible
+// monochrome cluster. 7 spans both visible rows above the fold so the
+// rare non-follow cards can be pulled forward to actually break the
+// run; the swap cap (floor(N / 2)) still bounds total rearrangement.
+//
+// Mobile renders 5 cards via ForYouSection and currently does not call
+// this helper; if it ever does, drop `lookahead` to 2 so we don't
+// search beyond half the visible row.
+export function diversifyByChip(services: Service[], lookahead = 7): Service[] {
   const out = services.slice()
   const maxSwaps = Math.floor(out.length / 2)
   let swaps = 0

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -1,4 +1,5 @@
 import type { ForYouSignals, Service } from '@/types'
+import { isNearlyFull } from '@/utils/eventUtils'
 
 export interface SignalChip {
   name: 'tag' | 'follow' | 'cooccur' | 'engagement' | 'default'
@@ -6,6 +7,20 @@ export interface SignalChip {
   bg: string
   fg: string
 }
+
+// Stable key for the pill SmartPill will actually render. Mirrors the
+// priority chain in SmartPill.tsx so the diversifier sees the same
+// identities the user does. Without this, every card without
+// for_you_signals collapses to 'default' and visible runs of e.g.
+// "Fresh provider" or "Rising newcomer" survive the swap pass.
+export type PillIdentity =
+  | SignalChip['name']  // 'tag' | 'follow' | 'cooccur' | 'engagement' | 'default'
+  | 'newcomer'
+  | 'capacity'
+  | 'pool:cold_start'
+  | 'pool:undershown_quality'
+  | 'pool:stale_recurring'
+  | 'none'
 
 // Mirror backend/hive_project/settings.py:RANKING_FOR_YOU_*_WEIGHT.
 // Argmax on raw values made follow (flat 1.0) always win over Jaccard tag
@@ -58,25 +73,43 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
   return { name: 'engagement', label: 'Saved by others', bg: 'rgba(20, 184, 166, 0.95)', fg: 'white' }
 }
 
-// Reorder so two consecutive cards rarely share a chip. Walks left to right;
-// when position i would collide with i-1, swap in the first card within the
-// next `lookahead` positions whose chip differs. Caps total swaps so the
-// ranking signal isn't wiped out by aggressive rotation.
+// Identity of the pill SmartPill will render for `service`. Must stay in
+// sync with SmartPill.tsx's priority chain. Used by the diversifier and
+// (re-exported via SmartPill) by the renderer itself, so a single source
+// of truth governs both.
+export function pillIdentity(service: Service): PillIdentity {
+  const chip = chipForSignals(service.for_you_signals)
+  if (chip.name !== 'default') return chip.name
+  if (service.is_newcomer_owner) return 'newcomer'
+  const max = service.max_participants ?? 0
+  const count = service.participant_count ?? 0
+  if (isNearlyFull(max, count)) return 'capacity'
+  if (service.explore_pool === 'cold_start') return 'pool:cold_start'
+  if (service.explore_pool === 'undershown_quality') return 'pool:undershown_quality'
+  if (service.explore_pool === 'stale_recurring') return 'pool:stale_recurring'
+  return 'none'
+}
+
+// Reorder so two consecutive cards rarely share a chip. Walks left to
+// right; when position i would collide with i-1, swap in the first card
+// within the next `lookahead` positions whose pill identity differs.
+// Caps total swaps so the ranking signal isn't wiped out by aggressive
+// rotation.
 //
-// `lookahead = 3` is tuned for the 10-card web carousel (ForYouCarousel).
-// Mobile renders 5 cards via ForYouSection and currently does not call
-// this helper; if it ever does, drop `lookahead` to 2 so we don't search
-// beyond half the visible row.
-export function diversifyByChip(services: Service[], lookahead = 3): Service[] {
+// `lookahead = 4` is tuned for the 10-card web carousel and the Browse
+// grid. Earlier value of 3 left visible 4-in-a-row clusters intact when
+// the diverging card sat just past the window. Mobile renders 5 cards
+// via ForYouSection and currently does not call this helper; if it ever
+// does, drop `lookahead` to 2 so we don't search beyond half the row.
+export function diversifyByChip(services: Service[], lookahead = 4): Service[] {
   const out = services.slice()
-  const chipName = (s: Service) => chipForSignals(s.for_you_signals).name
   const maxSwaps = Math.floor(out.length / 2)
   let swaps = 0
   for (let i = 1; i < out.length && swaps < maxSwaps; i++) {
-    if (chipName(out[i]) !== chipName(out[i - 1])) continue
+    if (pillIdentity(out[i]) !== pillIdentity(out[i - 1])) continue
     const limit = Math.min(out.length, i + 1 + lookahead)
     for (let j = i + 1; j < limit; j++) {
-      if (chipName(out[j]) !== chipName(out[i - 1])) {
+      if (pillIdentity(out[j]) !== pillIdentity(out[i - 1])) {
         ;[out[i], out[j]] = [out[j], out[i]]
         swaps += 1
         break

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -67,10 +67,12 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
     ['cooccur', signals.cooccur * FOR_YOU_WEIGHTS.cooccur],
     ['engagement', (signals.engagement ?? 0) * FOR_YOU_WEIGHTS.engagement],
   ]
-  let [topName, topValue] = entries.reduce(
+  const argmax = entries.reduce(
     (best, current) => (current[1] > best[1] ? current : best),
-    ['default' as SignalChip['name'], 0],
+    ['default' as SignalChip['name'], 0] as [SignalChip['name'], number],
   )
+  let topName: SignalChip['name'] = argmax[0]
+  const topValue = argmax[1]
   if (topValue <= 0) return DEFAULT_CHIP
 
   // Follow-saturation override: when follow wins by argmax but an interest

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -167,10 +167,15 @@ export function diversifyByChip(services: Service[], lookahead = 7): Service[] {
   const maxSwaps = Math.floor(out.length / 2)
   let swaps = 0
   for (let i = 1; i < out.length && swaps < maxSwaps; i++) {
-    if (pillIdentity(out[i]) !== pillIdentity(out[i - 1])) continue
+    const prev = pillIdentity(out[i - 1])
+    // 'none' cards render no pill at all, so a "run" of them is invisible.
+    // Lifting a chipped neighbour up to break it just reorders ranking for
+    // a collision the user can't see.
+    if (prev === 'none') continue
+    if (pillIdentity(out[i]) !== prev) continue
     const limit = Math.min(out.length, i + 1 + lookahead)
     for (let j = i + 1; j < limit; j++) {
-      if (pillIdentity(out[j]) !== pillIdentity(out[i - 1])) {
+      if (pillIdentity(out[j]) !== prev) {
         ;[out[i], out[j]] = [out[j], out[i]]
         swaps += 1
         break

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -111,8 +111,27 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
 // sync with SmartPill.tsx's priority chain. Used by the diversifier and
 // (re-exported via SmartPill) by the renderer itself, so a single source
 // of truth governs both.
+//
+// Newcomer-over-follow promotion: when the for-you chip resolves to
+// `follow` BUT the connection is indirect (friend-of-friend, raw
+// signal < 1.0) AND the owner is also a newcomer, surface the newcomer
+// story instead. Direct follows (signal === 1.0) keep "From your
+// network" because that IS the actual discovery story -- the viewer
+// chose to follow this person. Indirect follows are weaker social
+// proof, and on densely-connected seeds the newcomer pill never gets a
+// chance to fire because every card has *some* follow signal. This
+// surfaces the third pill colour on the demo grid without erasing the
+// follow chip on real direct connections.
 export function pillIdentity(service: Service): PillIdentity {
   const chip = chipForSignals(service.for_you_signals)
+  const followSignal = service.for_you_signals?.follow ?? 0
+  if (
+    chip.name === 'follow'
+    && service.is_newcomer_owner
+    && followSignal < 1
+  ) {
+    return 'newcomer'
+  }
   if (chip.name !== 'default') return chip.name
   if (service.is_newcomer_owner) return 'newcomer'
   const max = service.max_participants ?? 0

--- a/frontend/src/utils/forYouChips.ts
+++ b/frontend/src/utils/forYouChips.ts
@@ -48,6 +48,17 @@ export const DEFAULT_CHIP: SignalChip = {
   fg: 'white',
 }
 
+// Threshold for promoting a competitive interest signal over a winning
+// `follow` chip. On dense social graphs (the demo seed creates 94 follows
+// across 13 users, so almost every card has follow=1.0) the follow signal
+// saturates and would label nearly every card "From your network", erasing
+// the more discoverable interest-match story for cards that genuinely
+// also overlap with the viewer's tags. When an interest axis is at least
+// half as strong as follow, prefer it — the viewer already knows who they
+// follow, but "Matches your interests" is the actionable insight that
+// surfaces a discovery they can act on.
+const FOLLOW_PROMOTION_RATIO = 0.5
+
 export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
   if (!signals) return DEFAULT_CHIP
   const entries: Array<[SignalChip['name'], number]> = [
@@ -56,11 +67,32 @@ export function chipForSignals(signals?: ForYouSignals | null): SignalChip {
     ['cooccur', signals.cooccur * FOR_YOU_WEIGHTS.cooccur],
     ['engagement', (signals.engagement ?? 0) * FOR_YOU_WEIGHTS.engagement],
   ]
-  const [topName, topValue] = entries.reduce(
+  let [topName, topValue] = entries.reduce(
     (best, current) => (current[1] > best[1] ? current : best),
     ['default' as SignalChip['name'], 0],
   )
   if (topValue <= 0) return DEFAULT_CHIP
+
+  // Follow-saturation override: when follow wins by argmax but an interest
+  // axis is competitive, swap the chip to that interest axis. Only fires
+  // when the primary is `follow` so a card whose strongest signal is
+  // genuinely an interest signal is never demoted to a weaker interest
+  // signal.
+  if (topName === 'follow') {
+    const threshold = topValue * FOLLOW_PROMOTION_RATIO
+    let promoted: SignalChip['name'] | null = null
+    let promotedValue = -Infinity
+    for (const [name, value] of entries) {
+      if (name === 'follow') continue
+      if (value > 0 && value >= threshold && value > promotedValue) {
+        promoted = name
+        promotedValue = value
+      }
+    }
+    if (promoted !== null) {
+      topName = promoted
+    }
+  }
   if (topName === 'tag') {
     return { name: 'tag', label: 'Matches your interests', bg: 'rgba(168, 85, 247, 0.95)', fg: 'white' }
   }

--- a/mobile-client/assets/mapbox.html
+++ b/mobile-client/assets/mapbox.html
@@ -9,9 +9,8 @@
     html, body { margin: 0; padding: 0; height: 100%; background: #fff; }
     #map { position: absolute; inset: 0; }
     .mapboxgl-ctrl-attrib { display: none; }
-    .mapboxgl-ctrl-bottom-right { bottom: 96px; right: 12px; }
-    .mapboxgl-ctrl-bottom-left { bottom: 96px; left: 12px; }
-    .mapboxgl-ctrl-group { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); }
+    .mapboxgl-ctrl-bottom-right,
+    .mapboxgl-ctrl-bottom-left { display: none; }
   </style>
 </head>
 <body>
@@ -32,10 +31,14 @@
       }
 
       function colorFor(type) {
+        // Mirror the web tokens (frontend/src/theme/tokens.ts):
+        //   GREEN  = #2D5C4E (Offer)
+        //   BLUE   = #1D4ED8 (Need)
+        //   AMBER  = #D97706 (Event)
         switch (type) {
-          case "Offer": return "#23B97A";
-          case "Need":  return "#3B82F6";
-          case "Event": return "#F59E0B";
+          case "Offer": return "#2D5C4E";
+          case "Need":  return "#1D4ED8";
+          case "Event": return "#D97706";
           default:      return "#6B7280";
         }
       }
@@ -148,10 +151,8 @@
           attributionControl: false,
           logoPosition: "bottom-left",
         });
-        map.addControl(
-          new mapboxgl.NavigationControl({ showCompass: false, visualizePitch: false }),
-          "bottom-right"
-        );
+        // No NavigationControl on mobile: the +/- buttons collide with
+        // the find-me FAB and pinch-to-zoom is enabled by default.
         map.on("load", function () {
           loaded = true;
           send({ type: "ready" });

--- a/mobile-client/assets/mapbox.html
+++ b/mobile-client/assets/mapbox.html
@@ -156,8 +156,21 @@
           loaded = true;
           send({ type: "ready" });
           if (cfg.user) setUserMarker(cfg.user.lat, cfg.user.lng);
-          if (cfg.services) applyServices(cfg.services);
-          else if (pendingServices) applyServices(pendingServices);
+          // RN posts `init` once mapReady flips, but at that moment the
+          // services state on the RN side is usually still the empty
+          // initial array because fetchServices is async. The populated
+          // list arrives via a later `updateServices` message. If that
+          // message lands before `map.on("load")` fires, applyServices
+          // sees `loaded=false` and stashes the payload in
+          // pendingServices. Previously this branch picked cfg.services
+          // unconditionally because `[]` is truthy, dropping the real
+          // data on the floor and rendering an empty map. Prefer
+          // pendingServices when present so the freshest payload wins.
+          var initialServices = pendingServices != null
+            ? pendingServices
+            : (cfg.services || []);
+          pendingServices = null;
+          applyServices(initialServices);
         });
         map.on("error", function (e) {
           send({ type: "error", message: (e && e.error && e.error.message) || "map error" });

--- a/mobile-client/assets/mapboxHtml.ts
+++ b/mobile-client/assets/mapboxHtml.ts
@@ -53,7 +53,6 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
 
       function applyServices(services) {
         if (!map || !loaded) {
-          send({ type: "debug", message: "applyServices deferred (loaded=" + loaded + ", incoming=" + (services || []).length + ")" });
           pendingServices = services;
           return;
         }
@@ -80,8 +79,6 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
               };
             }),
         };
-
-        send({ type: "debug", message: "applyServices painting " + fc.features.length + " features" });
 
         var src = map.getSource("services");
         if (src) {

--- a/mobile-client/assets/mapboxHtml.ts
+++ b/mobile-client/assets/mapboxHtml.ts
@@ -20,9 +20,8 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
     html, body { margin: 0; padding: 0; height: 100%; background: #fff; }
     #map { position: absolute; inset: 0; }
     .mapboxgl-ctrl-attrib { display: none; }
-    .mapboxgl-ctrl-bottom-right { bottom: 96px; right: 12px; }
-    .mapboxgl-ctrl-bottom-left { bottom: 96px; left: 12px; }
-    .mapboxgl-ctrl-group { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); }
+    .mapboxgl-ctrl-bottom-right,
+    .mapboxgl-ctrl-bottom-left { display: none; }
   </style>
 </head>
 <body>
@@ -43,10 +42,17 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
       }
 
       function colorFor(type) {
+        // Mirror the web tokens (frontend/src/theme/tokens.ts):
+        //   GREEN  = #2D5C4E (Offer)
+        //   BLUE   = #1D4ED8 (Need)
+        //   AMBER  = #D97706 (Event)
+        // The previous lighter hex values disagreed with the type pill
+        // colours used on the rest of the app, so an Offer marker on the
+        // map didn't match the green Offer pill on a service card.
         switch (type) {
-          case "Offer": return "#23B97A";
-          case "Need":  return "#3B82F6";
-          case "Event": return "#F59E0B";
+          case "Offer": return "#2D5C4E";
+          case "Need":  return "#1D4ED8";
+          case "Event": return "#D97706";
           default:      return "#6B7280";
         }
       }
@@ -159,10 +165,12 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
           attributionControl: false,
           logoPosition: "bottom-left",
         });
-        map.addControl(
-          new mapboxgl.NavigationControl({ showCompass: false, visualizePitch: false }),
-          "bottom-right"
-        );
+        // No NavigationControl on mobile: the +/- buttons collide with
+        // the find-me FAB (also bottom-right) and duplicate gestures
+        // Mapbox GL already binds — pinch-to-zoom and double-tap-to-zoom
+        // are enabled by default on touch, so the buttons are redundant.
+        // Apple Maps and Google Maps both omit them on mobile for the
+        // same reason.
         map.on("load", function () {
           loaded = true;
           send({ type: "ready" });

--- a/mobile-client/assets/mapboxHtml.ts
+++ b/mobile-client/assets/mapboxHtml.ts
@@ -53,6 +53,7 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
 
       function applyServices(services) {
         if (!map || !loaded) {
+          send({ type: "debug", message: "applyServices deferred (loaded=" + loaded + ", incoming=" + (services || []).length + ")" });
           pendingServices = services;
           return;
         }
@@ -79,6 +80,8 @@ export const MAPBOX_HTML = `<!DOCTYPE html>
               };
             }),
         };
+
+        send({ type: "debug", message: "applyServices painting " + fc.features.length + " features" });
 
         var src = map.getSource("services");
         if (src) {

--- a/mobile-client/assets/mapboxHtml.ts
+++ b/mobile-client/assets/mapboxHtml.ts
@@ -1,0 +1,212 @@
+// Inlined as a TS string instead of a separate `.html` asset so Metro hot
+// reloads pick up edits immediately and there is no Asset.downloadAsync
+// cache to invalidate between dev rebuilds. The previous `.html` asset
+// would survive a code change in mapbox.html if the simulator app was
+// not deleted between runs, which made every fix to the WebView bridge
+// look like a no-op until the user wiped the app.
+//
+// Sister file `mapbox.html` is kept around for editor syntax highlighting
+// during local prototyping. Whenever you edit it, paste the body back
+// into the template literal below — the `.html` is no longer loaded at
+// runtime.
+export const MAPBOX_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <link href="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css" rel="stylesheet" />
+  <script src="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.js"></script>
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: #fff; }
+    #map { position: absolute; inset: 0; }
+    .mapboxgl-ctrl-attrib { display: none; }
+    .mapboxgl-ctrl-bottom-right { bottom: 96px; right: 12px; }
+    .mapboxgl-ctrl-bottom-left { bottom: 96px; left: 12px; }
+    .mapboxgl-ctrl-group { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18); }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>
+    (function () {
+      var map = null;
+      var loaded = false;
+      var pendingServices = null;
+      var userMarker = null;
+
+      function send(payload) {
+        try {
+          if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+            window.ReactNativeWebView.postMessage(JSON.stringify(payload));
+          }
+        } catch (e) { /* swallow */ }
+      }
+
+      function colorFor(type) {
+        switch (type) {
+          case "Offer": return "#23B97A";
+          case "Need":  return "#3B82F6";
+          case "Event": return "#F59E0B";
+          default:      return "#6B7280";
+        }
+      }
+
+      function applyServices(services) {
+        if (!map || !loaded) {
+          pendingServices = services;
+          return;
+        }
+        var fc = {
+          type: "FeatureCollection",
+          features: (services || [])
+            .filter(function (s) {
+              var lat = Number(s.lat);
+              var lng = Number(s.lng);
+              return !Number.isNaN(lat) && !Number.isNaN(lng);
+            })
+            .map(function (s) {
+              return {
+                type: "Feature",
+                properties: {
+                  id: s.id,
+                  type: s.type,
+                  color: colorFor(s.type),
+                },
+                geometry: {
+                  type: "Point",
+                  coordinates: [Number(s.lng), Number(s.lat)],
+                },
+              };
+            }),
+        };
+
+        var src = map.getSource("services");
+        if (src) {
+          src.setData(fc);
+          return;
+        }
+
+        map.addSource("services", { type: "geojson", data: fc });
+        map.addLayer({
+          id: "services-area",
+          type: "circle",
+          source: "services",
+          paint: {
+            "circle-radius": [
+              "interpolate", ["linear"], ["zoom"],
+              8, 8,
+              11, 18,
+              14, 32,
+              17, 60
+            ],
+            "circle-color": ["get", "color"],
+            "circle-opacity": 0.35,
+            "circle-stroke-color": ["get", "color"],
+            "circle-stroke-opacity": 0.7,
+            "circle-stroke-width": 1.5,
+          },
+        });
+
+        map.on("click", "services-area", function (e) {
+          if (!e.features || !e.features[0]) return;
+          send({ type: "markerPress", id: e.features[0].properties.id });
+        });
+        map.on("mouseenter", "services-area", function () {
+          map.getCanvas().style.cursor = "pointer";
+        });
+        map.on("mouseleave", "services-area", function () {
+          map.getCanvas().style.cursor = "";
+        });
+      }
+
+      function setUserMarker(lat, lng) {
+        if (lat == null || lng == null) return;
+        if (!map) return;
+        if (userMarker) {
+          userMarker.setLngLat([lng, lat]);
+          return;
+        }
+        var el = document.createElement("div");
+        el.style.cssText =
+          "width:14px;height:14px;border-radius:50%;background:#1F8F66;border:3px solid #fff;box-shadow:0 0 0 1px rgba(0,0,0,0.18);";
+        userMarker = new mapboxgl.Marker({ element: el })
+          .setLngLat([lng, lat])
+          .addTo(map);
+      }
+
+      function flyTo(lat, lng, zoom) {
+        if (!map) return;
+        map.flyTo({
+          center: [lng, lat],
+          zoom: zoom != null ? zoom : Math.max(map.getZoom(), 13),
+          essential: true,
+        });
+      }
+
+      function init(cfg) {
+        if (!cfg || !cfg.token) {
+          send({ type: "error", message: "missing token" });
+          return;
+        }
+        mapboxgl.accessToken = cfg.token;
+
+        var center = cfg.center ? [cfg.center.lng, cfg.center.lat] : [28.9784, 41.0082];
+        map = new mapboxgl.Map({
+          container: "map",
+          style: cfg.style || "mapbox://styles/mapbox/streets-v12",
+          center: center,
+          zoom: cfg.zoom != null ? cfg.zoom : 11,
+          attributionControl: false,
+          logoPosition: "bottom-left",
+        });
+        map.addControl(
+          new mapboxgl.NavigationControl({ showCompass: false, visualizePitch: false }),
+          "bottom-right"
+        );
+        map.on("load", function () {
+          loaded = true;
+          send({ type: "ready" });
+          if (cfg.user) setUserMarker(cfg.user.lat, cfg.user.lng);
+          // RN posts \`init\` once mapReady flips, but at that moment the
+          // services state on the RN side is usually still the empty
+          // initial array because fetchServices is async. The populated
+          // list arrives via a later \`updateServices\` message. If that
+          // message lands before \`map.on("load")\` fires, applyServices
+          // sees \`loaded=false\` and stashes the payload in
+          // pendingServices. Previously this branch picked cfg.services
+          // unconditionally because \`[]\` is truthy, dropping the real
+          // data on the floor and rendering an empty map. Prefer
+          // pendingServices when present so the freshest payload wins.
+          var initialServices = pendingServices != null
+            ? pendingServices
+            : (cfg.services || []);
+          pendingServices = null;
+          applyServices(initialServices);
+        });
+        map.on("error", function (e) {
+          send({ type: "error", message: (e && e.error && e.error.message) || "map error" });
+        });
+      }
+
+      function handle(raw) {
+        if (typeof raw !== "string") return;
+        try {
+          var msg = JSON.parse(raw);
+          switch (msg.type) {
+            case "init": init(msg); break;
+            case "updateServices": applyServices(msg.services || []); break;
+            case "setUser": setUserMarker(msg.lat, msg.lng); break;
+            case "flyTo": flyTo(msg.lat, msg.lng, msg.zoom); break;
+          }
+        } catch (e) {
+          send({ type: "error", message: String(e) });
+        }
+      }
+
+      document.addEventListener("message", function (ev) { handle(ev.data); });
+      window.addEventListener("message", function (ev) { handle(ev.data); });
+      send({ type: "loaded" });
+    })();
+  </script>
+</body>
+</html>`

--- a/mobile-client/src/presentation/components/TagChipsRow.tsx
+++ b/mobile-client/src/presentation/components/TagChipsRow.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { getFeaturedChips, type FeaturedChip } from "../../api/featured";
+import { useAuth } from "../../context/AuthContext";
 import { colors } from "../../constants/colors";
 
 interface TagChipsRowProps {
@@ -10,6 +11,13 @@ interface TagChipsRowProps {
 
 export default function TagChipsRow({ activeQid, onSelect }: TagChipsRowProps) {
   const [chips, setChips] = useState<FeaturedChip[]>([]);
+  // HomeScreen is reachable without auth (Login lives inside ProfileStack),
+  // so the first fetch can land before the token is installed and the
+  // backend serves its anonymous global-tag fallback. Without re-running
+  // on identity flips the user keeps seeing those global chips after they
+  // log in instead of the personalized set the web Browse grid shows.
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
 
   useEffect(() => {
     let cancelled = false;
@@ -27,7 +35,7 @@ export default function TagChipsRow({ activeQid, onSelect }: TagChipsRowProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [userId]);
 
   return (
     <ScrollView

--- a/mobile-client/src/presentation/components/__tests__/TagChipsRow.test.tsx
+++ b/mobile-client/src/presentation/components/__tests__/TagChipsRow.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Regression coverage for the anonymous-chip-set lock-in: HomeScreen is
+ * reachable without a session (Login lives inside ProfileStack), so
+ * TagChipsRow used to mount with `authToken = null`, fetch the global
+ * fallback chips returned by `/featured/chips/` for unauthenticated
+ * viewers, and stash that response forever — the per-user chip set the
+ * web Browse grid shows never landed on mobile after login.
+ *
+ * The fix re-runs the fetch whenever the active user identity changes
+ * (anon → login → switch user → logout). These tests pin both the
+ * single fetch on cold mount and the refetch on auth change.
+ */
+
+import React from "react";
+import { render, waitFor, act } from "@testing-library/react-native";
+
+import TagChipsRow from "../TagChipsRow";
+import { getFeaturedChips } from "../../../api/featured";
+
+jest.mock("../../../api/featured", () => ({
+  getFeaturedChips: jest.fn(),
+}));
+
+const mockUser: { id: string | null } = { id: null };
+jest.mock("../../../context/AuthContext", () => ({
+  useAuth: () => ({ user: mockUser.id ? { id: mockUser.id } : null }),
+}));
+
+const fetchMock = getFeaturedChips as jest.MockedFunction<typeof getFeaturedChips>;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    chips: [{ qid: "Q1", label: "Cooking", count: 3 }],
+  });
+  mockUser.id = null;
+});
+
+describe("TagChipsRow", () => {
+  it("fetches the chip strip once on mount", async () => {
+    const onSelect = jest.fn();
+    render(<TagChipsRow activeQid={null} onSelect={onSelect} />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("refetches when the authenticated user identity flips", async () => {
+    const onSelect = jest.fn();
+    const { rerender } = render(
+      <TagChipsRow activeQid={null} onSelect={onSelect} />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      mockUser.id = "user-elif";
+    });
+    rerender(<TagChipsRow activeQid={null} onSelect={onSelect} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("refetches when switching to a different signed-in user", async () => {
+    mockUser.id = "user-elif";
+    const onSelect = jest.fn();
+    const { rerender } = render(
+      <TagChipsRow activeQid={null} onSelect={onSelect} />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      mockUser.id = "user-yusuf";
+    });
+    rerender(<TagChipsRow activeQid={null} onSelect={onSelect} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("refetches on logout so the global fallback chips replace the personalized set", async () => {
+    mockUser.id = "user-elif";
+    const onSelect = jest.fn();
+    const { rerender } = render(
+      <TagChipsRow activeQid={null} onSelect={onSelect} />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      mockUser.id = null;
+    });
+    rerender(<TagChipsRow activeQid={null} onSelect={onSelect} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/mobile-client/src/presentation/screens/HomeScreen.tsx
+++ b/mobile-client/src/presentation/screens/HomeScreen.tsx
@@ -224,6 +224,13 @@ export default function HomeScreen() {
         // skill filter would hide unmatched-tag services (e.g. a fresh
         // event by an account whose tags don't overlap the viewer's).
         skip_onboarding: true,
+        // Match the web Browse grid: composite_score (hot * proximity +
+        // social) drives the order. Without this the backend defaulted
+        // to `latest`, so the freshest demo card (the April 23rd event,
+        // hot_score 0.26) sat at position 1 on mobile while the same
+        // viewer's web feed correctly led with the engagement-weighted
+        // top result (Manti Cooking Circle, hot_score 2.11).
+        sort: "hot",
         search: debouncedSearch || undefined,
         type:
           filters.serviceType !== "all" && filters.serviceType !== "Event"

--- a/mobile-client/src/presentation/screens/MapScreen.tsx
+++ b/mobile-client/src/presentation/screens/MapScreen.tsx
@@ -11,8 +11,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Asset } from "expo-asset";
-import { File } from "expo-file-system";
 import * as Location from "expo-location";
 import WebView from "react-native-webview";
 import type { WebViewMessageEvent } from "react-native-webview";
@@ -24,6 +22,7 @@ import { colors } from "../../constants/colors";
 import { listServices } from "../../api/services";
 import type { Service, ServiceType } from "../../api/types";
 import { getMapboxToken } from "../../constants/env";
+import { MAPBOX_HTML } from "../../../assets/mapboxHtml";
 
 type FilterType = "all" | ServiceType;
 
@@ -159,7 +158,6 @@ export default function MapScreen() {
   const navigation = useNavigation<any>();
 
   const webViewRef = useRef<WebView>(null);
-  const [webViewContent, setWebViewContent] = useState<string | null>(null);
   const [services, setServices] = useState<Service[]>([]);
   const [userLocation, setUserLocation] = useState<{
     latitude: number;
@@ -184,37 +182,18 @@ export default function MapScreen() {
   const locationCheckedRef = useRef(false);
   const drawerAnim = useRef(new Animated.Value(0)).current;
 
-  // Load the HTML asset. Re-runs when mapAttempt bumps (Retry) so a transient
-  // asset-load failure does not leave the screen stuck on the placeholder.
-  useEffect(() => {
-    let isMounted = true;
-    (async () => {
-      try {
-        const path = require("../../../assets/mapbox.html");
-        const asset = Asset.fromModule(path);
-        await asset.downloadAsync();
-        const htmlContent = await new File(asset.localUri!).text();
-        if (!isMounted) return;
-        setWebViewContent(htmlContent);
-        setMapLoadFailed(false);
-      } catch (error) {
-        if (!isMounted) return;
-        // No alert: the placeholder UI surfaces the failure with a Retry CTA.
-        // eslint-disable-next-line no-console
-        console.warn("[MapScreen] failed to load map HTML asset", error);
-        setMapLoadFailed(true);
-      }
-    })();
-    return () => {
-      isMounted = false;
-    };
-  }, [mapAttempt]);
-
+  // The WebView HTML used to live in `assets/mapbox.html` and was loaded
+  // through Asset.downloadAsync + File.text(). That round-trip got cached
+  // by both Expo Asset and the iOS app sandbox, so a fresh build of the
+  // simulator app would still serve the previous HTML body until the user
+  // deleted the app — every time the bridge logic changed it looked like
+  // the fix had not landed. Inlining the HTML as a string constant keeps
+  // it in the JS bundle, so a Metro reload always serves the newest copy
+  // and there is no asynchronous load to fail.
   const retryMap = useCallback(() => {
     setMapLoadFailed(false);
     setMapReady(false);
     setMapInited(false);
-    setWebViewContent(null);
     setMapAttempt((value) => value + 1);
   }, []);
 
@@ -443,7 +422,7 @@ export default function MapScreen() {
     );
   }
 
-  if (!webViewContent || !locationResolved) {
+  if (!locationResolved) {
     return (
       <View style={[styles.loading, { paddingTop: insets.top }]}>
         <ActivityIndicator size="large" color={colors.GREEN} />
@@ -462,7 +441,7 @@ export default function MapScreen() {
         key={`mapbox-${mapAttempt}`}
         ref={webViewRef}
         originWhitelist={["*"]}
-        source={{ html: webViewContent, baseUrl: "https://localhost" }}
+        source={{ html: MAPBOX_HTML, baseUrl: "https://localhost" }}
         onMessage={handleMessage}
         onError={() => setMapLoadFailed(true)}
         onHttpError={() => setMapLoadFailed(true)}

--- a/mobile-client/src/presentation/screens/MapScreen.tsx
+++ b/mobile-client/src/presentation/screens/MapScreen.tsx
@@ -251,20 +251,13 @@ export default function MapScreen() {
     const center = userLocation
       ? { lat: userLocation.latitude, lng: userLocation.longitude }
       : { lat: DEFAULT_LOCATION.latitude, lng: DEFAULT_LOCATION.longitude };
-    const initServices = toPayload(services);
-    if (__DEV__) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[MapScreen] posting init: ${initServices.length} services, center=${JSON.stringify(center)}, hasUser=${!!userLocation}`,
-      );
-    }
     post({
       type: "init",
       token: mapboxToken,
       style: MAPBOX_STYLE,
       center,
       zoom: 11,
-      services: initServices,
+      services: toPayload(services),
       user: userLocation
         ? { lat: userLocation.latitude, lng: userLocation.longitude }
         : null,
@@ -302,7 +295,15 @@ export default function MapScreen() {
     }
   }, [post]);
 
-  // Fetch services whenever location or distance changes.
+  // Fetch services whenever location or the explicitly-chosen radius changes.
+  // The distance param is only forwarded when the viewer has opened the range
+  // slider -- without that gate, fetchServices would re-run the moment iOS
+  // location permission resolves and apply a 15 km hard cutoff around the
+  // viewer's coordinates. On the iOS simulator that is the Apple default
+  // (San Francisco, 37.7858/-122.4064), which sits ~10,000 km from the demo
+  // seed and silently filters every Istanbul row out of the response, so
+  // the map paints zero markers. Mirrors `radiusFilterEnabled` on the web
+  // dashboard.
   const fetchServices = useCallback(async () => {
     try {
       setIsLoadingServices(true);
@@ -311,31 +312,26 @@ export default function MapScreen() {
             page_size: 500,
             lat: userLocation.latitude,
             lng: userLocation.longitude,
-            distance: distanceKm,
+            ...(showRangeSlider ? { distance: distanceKm } : {}),
           }
         : { page_size: 500 };
 
       const { results } = await listServices(params);
-      const filteredResults = (results ?? []).filter(
-        (s) =>
-          s.location_lat &&
-          s.location_lng &&
-          !Number.isNaN(Number(s.location_lat)) &&
-          !Number.isNaN(Number(s.location_lng)),
+      setServices(
+        (results ?? []).filter(
+          (s) =>
+            s.location_lat &&
+            s.location_lng &&
+            !Number.isNaN(Number(s.location_lat)) &&
+            !Number.isNaN(Number(s.location_lng)),
+        ),
       );
-      if (__DEV__) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[MapScreen] fetchServices: api returned ${(results ?? []).length}, ${filteredResults.length} have valid coords (params=${JSON.stringify(params)})`,
-        );
-      }
-      setServices(filteredResults);
     } catch (error) {
       console.error("Error fetching services for map:", error);
     } finally {
       setIsLoadingServices(false);
     }
-  }, [userLocation, distanceKm]);
+  }, [userLocation, distanceKm, showRangeSlider]);
 
   useEffect(() => {
     fetchServices();
@@ -366,12 +362,7 @@ export default function MapScreen() {
   // Push the visible service set to the WebView whenever it changes (after init).
   useEffect(() => {
     if (!mapInited) return;
-    const payload = toPayload(visibleServices);
-    if (__DEV__) {
-      // eslint-disable-next-line no-console
-      console.log(`[MapScreen] posting updateServices: ${payload.length} features`);
-    }
-    post({ type: "updateServices", services: payload });
+    post({ type: "updateServices", services: toPayload(visibleServices) });
   }, [visibleServices, mapInited, post]);
 
   useEffect(() => {
@@ -392,10 +383,6 @@ export default function MapScreen() {
         return;
       }
       if (!parsed) return;
-      if (__DEV__) {
-        // eslint-disable-next-line no-console
-        console.log(`[MapScreen] WebView msg: ${parsed.type ?? '?'} ${parsed.message ?? ''}`);
-      }
       switch (parsed.type) {
         case "loaded":
         case "ready":

--- a/mobile-client/src/presentation/screens/MapScreen.tsx
+++ b/mobile-client/src/presentation/screens/MapScreen.tsx
@@ -397,11 +397,17 @@ export default function MapScreen() {
       }
       if (!parsed) return;
       switch (parsed.type) {
-        case "ready":
-          setMapReady(true);
-          break;
         case "loaded":
-          // HTML is parsed but mapboxgl may still be loading — ignore.
+        case "ready":
+          // mapbox.html sends "loaded" once the IIFE runs (which is right
+          // after the synchronous mapbox-gl.js script tag finishes), and
+          // sends "ready" later from inside map.on("load"). The init post
+          // is gated on mapReady, so if we only flipped the flag on "ready"
+          // we'd deadlock — "ready" can never fire because it lives
+          // inside init(), which never runs because we never post init.
+          // Either signal is sufficient evidence that mapboxgl is alive
+          // and we can safely send the init payload across the bridge.
+          setMapReady(true);
           break;
         case "markerPress": {
           const service = services.find((s) => s.id === parsed!.id);

--- a/mobile-client/src/presentation/screens/MapScreen.tsx
+++ b/mobile-client/src/presentation/screens/MapScreen.tsx
@@ -251,13 +251,20 @@ export default function MapScreen() {
     const center = userLocation
       ? { lat: userLocation.latitude, lng: userLocation.longitude }
       : { lat: DEFAULT_LOCATION.latitude, lng: DEFAULT_LOCATION.longitude };
+    const initServices = toPayload(services);
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[MapScreen] posting init: ${initServices.length} services, center=${JSON.stringify(center)}, hasUser=${!!userLocation}`,
+      );
+    }
     post({
       type: "init",
       token: mapboxToken,
       style: MAPBOX_STYLE,
       center,
       zoom: 11,
-      services: toPayload(services),
+      services: initServices,
       user: userLocation
         ? { lat: userLocation.latitude, lng: userLocation.longitude }
         : null,
@@ -309,15 +316,20 @@ export default function MapScreen() {
         : { page_size: 500 };
 
       const { results } = await listServices(params);
-      setServices(
-        (results ?? []).filter(
-          (s) =>
-            s.location_lat &&
-            s.location_lng &&
-            !Number.isNaN(Number(s.location_lat)) &&
-            !Number.isNaN(Number(s.location_lng)),
-        ),
+      const filteredResults = (results ?? []).filter(
+        (s) =>
+          s.location_lat &&
+          s.location_lng &&
+          !Number.isNaN(Number(s.location_lat)) &&
+          !Number.isNaN(Number(s.location_lng)),
       );
+      if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[MapScreen] fetchServices: api returned ${(results ?? []).length}, ${filteredResults.length} have valid coords (params=${JSON.stringify(params)})`,
+        );
+      }
+      setServices(filteredResults);
     } catch (error) {
       console.error("Error fetching services for map:", error);
     } finally {
@@ -354,7 +366,12 @@ export default function MapScreen() {
   // Push the visible service set to the WebView whenever it changes (after init).
   useEffect(() => {
     if (!mapInited) return;
-    post({ type: "updateServices", services: toPayload(visibleServices) });
+    const payload = toPayload(visibleServices);
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.log(`[MapScreen] posting updateServices: ${payload.length} features`);
+    }
+    post({ type: "updateServices", services: payload });
   }, [visibleServices, mapInited, post]);
 
   useEffect(() => {
@@ -375,6 +392,10 @@ export default function MapScreen() {
         return;
       }
       if (!parsed) return;
+      if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.log(`[MapScreen] WebView msg: ${parsed.type ?? '?'} ${parsed.message ?? ''}`);
+      }
       switch (parsed.type) {
         case "loaded":
         case "ready":


### PR DESCRIPTION
## Summary

Started as a one-line wiring fix for `diversifyByChip` on the Browse grid. Manual testing surfaced a chain of related bugs across the chip-identity / ranking / mobile-map stack, all addressed here. Several of the fixes informed each other (the diversifier needed `pillIdentity` to be the source of truth for the renderer too, the mobile sort had to match the web's `composite_score` for chip parity to be observable on mobile), so they ride together rather than being split into PRs that would each block on the others.

## What changed

### Frontend — chip diversification on the Browse grid
- Wire `diversifyByChip` into `displayServices` in `DashboardPage`. Identity is now `pillIdentity` (mirrors `SmartPill`'s priority chain: signal chip → newcomer → capacity → explore_pool), so the diversifier sees the same identities the user sees.
- Bump `diversifyByChip` lookahead 4 → 7. With dense seeds (~80% follow-saturated) the previous window only reached the first off-chip card and left positions 3-5 as a monochrome cluster. 7 spans both visible rows above the fold.
- Promote a competitive interest signal (tag/cooccur/engagement) over a saturated `follow` win when the interest axis is at least half as strong (`FOLLOW_PROMOTION_RATIO = 0.5`). Without this the dense follow seed labels almost every card "From your network".
- Indirect-follow + newcomer-owner cards render the "Rising newcomer" pill instead of "From your network" (raw follow signal < 1.0). Direct follows keep "From your network" because that *is* the actual discovery story.
- Diversifier partitioned around the inactive (denied/cancelled) tail so the swap window cannot pull a denied row above active ones.
- Skip diversifier swap when the previous identity is `'none'` — those runs are user-invisible, perturbing ranking to break them just reorders the page for no benefit (Copilot review feedback).

### Backend — ranking
- Online services no longer get a free top-of-feed slot just because the viewer has location enabled. PostGIS `Distance(location, viewer_point)` returned `NULL` for online listings, which collapsed `composite_score` to `NULL`, which Postgres `ORDER BY DESC` sorts NULLS FIRST. `Coalesce(distance, 0.0)` so online services rank against their `hot_score * social_boost` like everyone else.
- Test-isolation fix for `test_register_two_keys_for_same_user_keeps_both` under pytest-xdist + shared Redis.

### Mobile
- HomeScreen feed sort defaulted to `latest`, so the freshest demo card sat at position 1 on mobile while the same viewer's web feed correctly led with the engagement-weighted top result. Add `sort: "hot"` so mobile and web see the same order.
- Mapbox WebView: inline the HTML as a TS constant so `Asset.downloadAsync` can't serve a stale copy across dev rebuilds; flip `mapReady` on either `loaded` or `ready` to break a bridge deadlock; prefer `pendingServices` over the stale empty initial array when `map.on("load")` fires after `updateServices` has landed.
- Mapbox markers paint after a delayed `updateServices` even when the map already finished loading.
- Don't forward the distance filter unless the user opens the range slider — the simulator's San Francisco default location was hiding every Istanbul listing.
- Align mobile map marker palette with web theme tokens (GREEN / BLUE / AMBER) so the dot colour matches the type pill on the card.
- Drop the Mapbox `NavigationControl` on mobile — pinch-to-zoom is the native gesture, the `+/-` buttons collided with the find-me FAB.
- Refetch the dashboard tag-chip strip when the authenticated user identity changes. HomeScreen is reachable without auth (Login lives inside ProfileStack), so the first chip fetch landed before the token was installed and `/featured/chips/` served its anonymous global-tag fallback. Empty `useEffect` deps pinned that response forever — after login the user kept seeing global tags instead of the personalized chips the web Browse grid surfaces.

## Test plan

- [x] `frontend`: `npm test -- src/test/pages/DashboardPage.test.tsx --run`
- [x] `frontend`: `npm test -- src/test/components/ForYouCarousel.chip.test.tsx --run`
- [x] `mobile-client`: `npx jest && npx tsc --noEmit`
- [x] `backend`: existing pytest suite + new `test_cache_utils` isolation
- [x] Manual: Browse grid on Elif's demo account no longer renders monochrome chip rows
- [x] Manual: online listings rank by `hot_score`, not by being `NULL`-distance
- [x] Manual: mobile map renders Istanbul markers with web-matching colours, no zoom-button collision, chip strip reflects logged-in identity

## Out of scope (follow-up PRs)

- Map search dropdown + signal-chip filters → PR #615