### PR TITLE
Unxfail features that landed, file hot_score regression as #618

### DIFF
--- a/backend/api/tests/integration/test_discovery_api.py
+++ b/backend/api/tests/integration/test_discovery_api.py
@@ -192,7 +192,7 @@ class TestFollowSystem:
 
         resp = client.post(f'/api/users/{followed.id}/follow/')
 
-        assert resp.status_code in (200, 201)
+        assert_api_response(resp, 201)
 
     def test_user_can_unfollow(self):
         """DELETE /api/users/{id}/follow/ should remove the follow relationship."""
@@ -204,7 +204,7 @@ class TestFollowSystem:
 
         resp = client.delete(f'/api/users/{followed.id}/follow/')
 
-        assert resp.status_code in (200, 204)
+        assert_api_response(resp, 200)
 
     def test_follow_is_idempotent(self):
         """Following the same user twice should not create a duplicate entry."""
@@ -226,7 +226,7 @@ class TestFollowSystem:
 
         resp = client.post(f'/api/users/{user.id}/follow/')
 
-        assert resp.status_code in (400, 403)
+        assert_problem_detail(resp, 400)
 
     @pytest.mark.xfail(
         reason="Follow boost in ranking is not wired up; ranking stays as-is per #579 scope",
@@ -275,7 +275,7 @@ class TestFollowSystem:
 
 
 # ---------------------------------------------------------------------------
-# NFR-19a — Discovery feed 2-second SLA (xfail — no benchmark enforced)
+# NFR-19a — Discovery feed 2-second SLA (green on the local test corpus)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db

--- a/backend/api/tests/integration/test_discovery_api.py
+++ b/backend/api/tests/integration/test_discovery_api.py
@@ -4,8 +4,8 @@ Integration tests for Discovery API — FR-19c, FR-19e, FR-19h (blur), NFR-19a.
 Test classes and their status:
   TestAdminPinEvent             — green  (pin endpoint is implemented)
   TestAdminShowcaseFeatured     — xfail  (FR-19c: no showcase/featured concept)
-  TestFollowSystem              — xfail  (FR-19e: no follow model or endpoints)
-  TestDiscoveryFeedPerformance  — xfail  (NFR-19a: no SLA test enforced)
+  TestFollowSystem              — green  (FR-19e: follow model + endpoints landed)
+  TestDiscoveryFeedPerformance  — green  (NFR-19a: 2s SLA holding on the test corpus)
   TestLocationBlurInFeed        — xfail  (FR-19h: feed distance values are not blurred)
 """
 import time
@@ -172,21 +172,15 @@ class TestAdminShowcaseFeatured:
 
 
 # ---------------------------------------------------------------------------
-# FR-19e — Follow system (xfail — not implemented)
+# FR-19e — Follow system (green — UserFollow + follow endpoints implemented)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db
 @pytest.mark.integration
-@pytest.mark.xfail(
-    reason="FR-19e: no Follow model, no follow endpoints, no feed boost implemented",
-    strict=False,
-)
 class TestFollowSystem:
     """
-    FR-19e requires users to follow each other and for followed-user content to
-    receive a boost in the discovery feed.
-
-    These tests are xfail because no follow infrastructure exists in the codebase.
+    FR-19e: users can follow each other via POST /api/users/{id}/follow/.
+    The UserFollow model (migration 0051) and follow endpoints are wired up.
     """
 
     def test_user_can_follow_another_user(self):
@@ -234,6 +228,10 @@ class TestFollowSystem:
 
         assert resp.status_code in (400, 403)
 
+    @pytest.mark.xfail(
+        reason="Follow boost in ranking is not wired up; ranking stays as-is per #579 scope",
+        strict=False,
+    )
     def test_followed_user_listings_rank_higher_in_feed(self):
         """
         Services from a followed user should rank above equivalent-score services
@@ -282,17 +280,12 @@ class TestFollowSystem:
 
 @pytest.mark.django_db
 @pytest.mark.integration
-@pytest.mark.xfail(
-    reason="NFR-19a: no performance SLA test exists; 2s threshold not enforced",
-    strict=False,
-)
 class TestDiscoveryFeedPerformance:
     """
     The discovery feed (including serialization and pagination) must return
     the first page within 2 seconds for a catalogue of ~1 000 active services.
-
-    Xfail because no benchmark guard exists and the threshold has not been
-    validated under load.
+    Holds in the local test corpus; load testing under realistic data is
+    tracked separately in the perf track.
     """
 
     FEED_SLA_SECONDS = 2.0

--- a/backend/api/tests/integration/test_event_browse_api.py
+++ b/backend/api/tests/integration/test_event_browse_api.py
@@ -87,13 +87,11 @@ class TestEventFeedAnonymousAccess:
 
 
 # ---------------------------------------------------------------------------
-# FR-12c — Date range filtering
-# (These tests will FAIL until DateRangeStrategy is implemented)
+# FR-12c — Date range filtering (green at the event-browse API surface)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db
 @pytest.mark.integration
-@pytest.mark.xfail(reason="FR-12c: date_from/date_to filter not yet implemented", strict=False)
 class TestEventDateRangeFilter:
     """FR-12c: users can filter events by date_from and date_to."""
 

--- a/backend/api/tests/integration/test_event_browse_api.py
+++ b/backend/api/tests/integration/test_event_browse_api.py
@@ -8,8 +8,10 @@ Covers the public event browsing and discovery requirements:
   FR-12f  Unauthenticated join attempt returns 401
   FR-12g  Cancelled events excluded from browse; detail page exposes cancellation state
 
-Tests for date-range filtering (FR-12c) will fail red until DateRangeStrategy is
-implemented in search_filters.py and wired into ServiceViewSet.
+FR-12c is wired up — `date_from` / `date_to` filtering on the event feed
+is handled in `DateRangeStrategy` (search_filters.py) and surfaces through
+`ServiceViewSet`. The tests in `TestEventDateRangeFilter` exercise that
+end-to-end and run green.
 """
 import pytest
 from datetime import timedelta

--- a/backend/api/tests/integration/test_reputation_api.py
+++ b/backend/api/tests/integration/test_reputation_api.py
@@ -1854,6 +1854,10 @@ class TestFR16eWindowCloseHotScoreContract:
         # Batch must not touch Offer hot_score.
         assert service.hot_score == score_after_write
 
+    @pytest.mark.xfail(
+        reason="Regression: hot_score recomputes during _expire_window save — tracked in #618",
+        strict=False,
+    )
     def test_offer_hot_score_unchanged_when_no_writes_before_close(self):
         """
         Window closes with zero evaluations — batch must not alter hot_score,

--- a/backend/api/tests/unit/test_location_privacy.py
+++ b/backend/api/tests/unit/test_location_privacy.py
@@ -10,12 +10,12 @@ FR-19h requires:
 
 Current codebase status:
   - _fuzzy_coords() in serializers.py applies a deterministic FNV-1a ~500m offset.
-  - The blur is applied to ALL non-owner users regardless of handshake status.
-  - Conditional reveal on handshake ACCEPTED is NOT yet implemented.
+  - Owners always see exact coordinates.
+  - Requesters with an ACCEPTED handshake see exact coordinates; others see fuzzed.
 
 Test classes:
-  TestLocationBlurDeterminism   — green (current behaviour, already works)
-  TestLocationBlurConditional   — xfail (FR-19h conditional reveal not implemented)
+  TestLocationBlurDeterminism   — green
+  TestLocationBlurConditional   — green
 """
 import math
 import pytest
@@ -112,10 +112,6 @@ class TestLocationBlurDeterminism:
             "Two different services produced identical fuzz — hash is not service-specific."
         )
 
-    @pytest.mark.xfail(
-        reason="Owner bypass currently returns blurred coordinates; tracked in FR-19h implementation",
-        strict=False,
-    )
     def test_owner_sees_exact_coordinates(self):
         """Service owner must receive the real unblurred coordinates."""
         provider = UserFactory()
@@ -149,22 +145,16 @@ class TestLocationBlurDeterminism:
 
 
 # ---------------------------------------------------------------------------
-# xfail tests — FR-19h conditional reveal on ACCEPTED handshake (not yet implemented)
+# FR-19h — conditional reveal on ACCEPTED handshake (green)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db
 @pytest.mark.unit
-@pytest.mark.xfail(
-    reason="FR-19h: blur is always-on; conditional reveal on ACCEPTED handshake not implemented",
-    strict=False,
-)
 class TestLocationBlurConditional:
     """
     Once a handshake between the requester and provider reaches status='accepted',
-    the requester should receive the exact (unblurred) service coordinates.
-
-    These tests are xfail because the serializer currently blurs for all non-owners
-    regardless of handshake status.
+    the requester receives the exact (unblurred) service coordinates. Non-owners
+    without an accepted handshake continue to see fuzzed coordinates.
     """
 
     def _fetch_coords(self, service, user):

--- a/backend/api/tests/unit/test_location_privacy.py
+++ b/backend/api/tests/unit/test_location_privacy.py
@@ -126,6 +126,9 @@ class TestLocationBlurDeterminism:
         assert float(lat) == pytest.approx(float(real_lat), abs=1e-4), (
             "Owner received fuzzed latitude — owner bypass is broken."
         )
+        assert float(lng) == pytest.approx(float(real_lng), abs=1e-4), (
+            "Owner received fuzzed longitude — owner bypass is broken."
+        )
 
     def test_online_service_coordinates_not_fuzzed(self):
         """Online services have no physical location — no blur should be applied."""
@@ -195,7 +198,14 @@ class TestLocationBlurConditional:
 
         lat, lng = self._fetch_coords(service, requester)
 
-        assert float(lat) != pytest.approx(float(real_lat), abs=1e-4), (
+        # 2D offset — lat alone can be near-zero when the fuzz angle puts
+        # all the offset into longitude (or vice versa); compare combined
+        # distance so the assertion doesn't flake on hash angle.
+        total_offset = math.sqrt(
+            (float(lat) - float(real_lat)) ** 2
+            + (float(lng) - float(real_lng)) ** 2
+        )
+        assert total_offset > 1e-3, (
             "Requester with pending handshake received exact coordinates before acceptance."
         )
 
@@ -211,7 +221,11 @@ class TestLocationBlurConditional:
 
         lat, lng = self._fetch_coords(service, unrelated)
 
-        assert float(lat) != pytest.approx(float(real_lat), abs=1e-4)
+        total_offset = math.sqrt(
+            (float(lat) - float(real_lat)) ** 2
+            + (float(lng) - float(real_lng)) ** 2
+        )
+        assert total_offset > 1e-3
 
     def test_provider_always_sees_exact_coords_regardless_of_handshake(self):
         """Service owner should always see exact coordinates — handshake status is irrelevant."""
@@ -229,3 +243,4 @@ class TestLocationBlurConditional:
         lng = resp.data.get('location_lng')
 
         assert float(lat) == pytest.approx(float(real_lat), abs=1e-4)
+        assert float(lng) == pytest.approx(float(real_lng), abs=1e-4)


### PR DESCRIPTION
Part of #579 — the bug-hunt slice.

Ran the full backend test suite to inventory current state. Three things needed addressing.

## Stale xfails (18 markers removed)

These were marked xfail when the feature wasn't built yet, then the feature shipped and nobody removed the marker. Now they're regular passing tests:

- **TestFollowSystem** (FR-19e) — UserFollow model + endpoints exist since migration 0051; 5 of 6 tests pass cleanly.
- **TestDiscoveryFeedPerformance** (NFR-19a) — 2s SLA holds on the local test corpus.
- **TestEventDateRangeFilter** (FR-12c) — `date_from` / `date_to` filtering on `/api/services/?type=Event` works; 6 tests.
- **TestLocationBlurConditional** (FR-19h) — conditional reveal on accepted handshake is implemented; 4 tests. Also dropped the individual xfail on `test_owner_sees_exact_coordinates`.

I left the mixed-result xfails alone (FR-17c/d in `test_ranking.py`, FR-19i in `test_event_service.py`, FR-12c unit in `test_search_filters.py`) — those classes have some passing and some legitimately-failing tests for the unbuilt portions, the class-level `strict=False` is doing its job.

## Real failure — followed-user feed ranking

`test_followed_user_listings_rank_higher_in_feed` (the one out of six TestFollowSystem tests that was actually failing under the class xfail mask): follow boost in the feed is not wired up. Per the #579 scope decision that ranking stays as-is, xfailed this individual test with that reason.

## Real failure — reputation hot_score regression → #618

`test_offer_hot_score_unchanged_when_no_writes_before_close` fails reproducibly (3/3 local runs). The test's class contract is explicit that `process_feedback_windows` must not touch Offer hot_score, but it does — looks like a signal recomputes on the handshake save inside the test helper rather than the batch command itself. Filed **#618** with the diagnosis; xfailed the test against that issue.

## Results after the changes

| Suite | Before | After |
|---|---|---|
| Backend unit | 862 passed, 23 xfail, 9 xpass | 867 passed, 23 xfail, 4 xpass |
| Backend integration | 840 passed, 1 fail, 4 xfail, 13 xpass | 853 passed, 5 xfail, 0 xpass |
| Frontend vitest | 779 passed | 779 passed (no changes) |
| Mobile jest | passed | passed (no changes) |

Zero unexpected failures. Frontend Playwright wasn't run in this slice (needs full stack and is in the nightly path); will get its own pass when we land Phase 3.