### PR TITLE
Fix QR 404, #618 hot_score regression, Online proximity, follow boost

### DIFF
--- a/backend/api/ranking_personalized.py
+++ b/backend/api/ranking_personalized.py
@@ -397,8 +397,16 @@ def score_for_you(services, viewer) -> list[tuple]:
         seconds_since = (now - last_seen) if last_seen else None
         recency = recency_penalty(seconds_since, half_life_hours)
 
+        # When the viewer enabled location, the candidate queryset annotates
+        # `proximity_factor` on each row (1.0 at the viewer's coordinates,
+        # 0.5 at the half-life distance, 0.5 flat for Online services so
+        # they stay proximity-neutral instead of out-ranking nearby
+        # in-person rows). Bake it into the hot_score input so proximity
+        # carries into the personalized blend; without this an Online
+        # service with high tag-overlap beats every nearby in-person card.
+        proximity_factor = float(getattr(svc, 'proximity_factor', 1.0))
         score, signals = blend_for_you_score(
-            hot_score=float(svc.hot_score or 0.0),
+            hot_score=float(svc.hot_score or 0.0) * proximity_factor,
             tag=tag,
             follow=follow,
             cooccur=cooccur,

--- a/backend/api/search_filters.py
+++ b/backend/api/search_filters.py
@@ -13,7 +13,7 @@ from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.db.models import (
     Q, QuerySet, Case, When, Value, FloatField, Sum, Exists, OuterRef,
-    Subquery,
+    Subquery, F,
 )
 
 
@@ -119,9 +119,13 @@ class LocationStrategy(SearchStrategy):
                 | Q(location__distance_lte=(user_location, D(km=distance_km)))
             )
 
+        # Online services (location IS NULL) produce a NULL distance. PostgreSQL
+        # sorts NULLs FIRST under ASC by default, which used to put every Online
+        # row above every in-person row. Force NULLs to the end so the location
+        # filter actually surfaces the closest in-person services first.
         return queryset.annotate(
             distance=Distance('location', user_location)
-        ).order_by('distance')
+        ).order_by(F('distance').asc(nulls_last=True))
 
 
 def expand_tag_qids(tag_ids):

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -311,6 +311,13 @@ _HOT_SCORE_RELEVANT_STATUSES = {
     'completed', 'accepted', 'checked_in', 'attended', 'no_show',
 }
 
+# Handshake fields that actually feed the hot_score formula. Saves that touch
+# only fields outside this set (e.g. evaluation_window_* timestamps written by
+# process_feedback_windows or test helpers) must not trigger a recompute,
+# because the formula has time-sensitive components and would produce a
+# different score even though no ranking input changed (#618).
+_HOT_SCORE_RELEVANT_FIELDS = {'status', 'provisioned_hours'}
+
 
 @receiver([post_save, post_delete], sender=Handshake)
 def update_hot_score_on_handshake_change(sender, instance, **kwargs):
@@ -323,6 +330,14 @@ def update_hot_score_on_handshake_change(sender, instance, **kwargs):
     every Phase 2 input feeds the persisted score in real time.
     """
     if instance.status not in _HOT_SCORE_RELEVANT_STATUSES:
+        return
+    # If the caller passed an explicit `update_fields`, only recompute when
+    # one of the fields that actually feeds the formula is in the set.
+    # Post-delete doesn't have update_fields, so this branch is post_save-only.
+    update_fields = kwargs.get('update_fields')
+    if update_fields is not None and not (
+        set(update_fields) & _HOT_SCORE_RELEVANT_FIELDS
+    ):
         return
     service = getattr(instance, 'service', None)
     if service is None:

--- a/backend/api/tests/integration/test_discovery_api.py
+++ b/backend/api/tests/integration/test_discovery_api.py
@@ -4,7 +4,7 @@ Integration tests for Discovery API — FR-19c, FR-19e, FR-19h (blur), NFR-19a.
 Test classes and their status:
   TestAdminPinEvent             — green  (pin endpoint is implemented)
   TestAdminShowcaseFeatured     — xfail  (FR-19c: no showcase/featured concept)
-  TestFollowSystem              — xfail  (FR-19e: no follow model or endpoints)
+  TestFollowSystem              — green  (FR-19e: follow + default-sort boost landed)
   TestDiscoveryFeedPerformance  — xfail  (NFR-19a: no SLA test enforced)
   TestLocationBlurInFeed        — xfail  (FR-19h: feed distance values are not blurred)
 """
@@ -172,21 +172,16 @@ class TestAdminShowcaseFeatured:
 
 
 # ---------------------------------------------------------------------------
-# FR-19e — Follow system (xfail — not implemented)
+# FR-19e — Follow system (green — UserFollow + endpoints + default-sort boost)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db
 @pytest.mark.integration
-@pytest.mark.xfail(
-    reason="FR-19e: no Follow model, no follow endpoints, no feed boost implemented",
-    strict=False,
-)
 class TestFollowSystem:
     """
-    FR-19e requires users to follow each other and for followed-user content to
-    receive a boost in the discovery feed.
-
-    These tests are xfail because no follow infrastructure exists in the codebase.
+    FR-19e: users can follow each other via POST /api/users/{id}/follow/.
+    UserFollow (migration 0051), follow endpoints, and the discovery-feed
+    boost (default sort tiebreaker after `-is_pinned`) are all wired up.
     """
 
     def test_user_can_follow_another_user(self):

--- a/backend/api/tests/integration/test_event_qr_api.py
+++ b/backend/api/tests/integration/test_event_qr_api.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from api.tests.helpers.factories import UserFactory, ServiceFactory
+from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
 def _make_qr_event(organizer, hours_from_now=6):
@@ -47,7 +48,7 @@ class TestGenerateQRTokenEndpoint:
         client.force_authenticate(user=organizer)
         resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
 
-        assert resp.status_code == 200, resp.content
+        assert_api_response(resp, 200)
         body = resp.json()
         assert body['token']
         assert body['attendance_code']
@@ -62,7 +63,7 @@ class TestGenerateQRTokenEndpoint:
         client.force_authenticate(user=other)
         resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
 
-        assert resp.status_code == 403
+        assert_problem_detail(resp, 403)
 
     def test_anonymous_gets_401(self):
         organizer = UserFactory()
@@ -71,7 +72,7 @@ class TestGenerateQRTokenEndpoint:
         client = APIClient()
         resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
 
-        assert resp.status_code == 401
+        assert_problem_detail(resp, 401)
 
     def test_offer_service_gets_400(self):
         organizer = UserFactory()
@@ -81,7 +82,7 @@ class TestGenerateQRTokenEndpoint:
         client.force_authenticate(user=organizer)
         resp = client.post(f'/api/services/{offer.id}/generate-qr-token/')
 
-        assert resp.status_code == 400
+        assert_problem_detail(resp, 400)
 
     def test_outside_lockdown_window_gets_400(self):
         """Far-future event must be rejected with 400, not 404."""
@@ -92,7 +93,7 @@ class TestGenerateQRTokenEndpoint:
         client.force_authenticate(user=organizer)
         resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
 
-        assert resp.status_code == 400
+        assert_problem_detail(resp, 400)
 
     def test_missing_event_returns_404(self):
         """Sanity: a genuinely missing pk still 404s."""
@@ -104,7 +105,7 @@ class TestGenerateQRTokenEndpoint:
             '/api/services/00000000-0000-0000-0000-000000000000/generate-qr-token/'
         )
 
-        assert resp.status_code == 404
+        assert_problem_detail(resp, 404)
 
 
 @pytest.mark.django_db
@@ -123,7 +124,7 @@ class TestGetQRTokenEndpoint:
 
         resp = client.get(f'/api/services/{event.id}/qr-token/')
 
-        assert resp.status_code == 200, resp.content
+        assert_api_response(resp, 200)
         body = resp.json()
         assert body['token']
         assert body['attendance_code']

--- a/backend/api/tests/integration/test_event_qr_api.py
+++ b/backend/api/tests/integration/test_event_qr_api.py
@@ -13,7 +13,8 @@ import pytest
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from api.tests.helpers.factories import UserFactory, ServiceFactory
+from api.models import Tag
+from api.tests.helpers.factories import UserFactory, ServiceFactory, TagFactory
 from api.tests.helpers.assertions import assert_api_response, assert_problem_detail
 
 
@@ -106,6 +107,28 @@ class TestGenerateQRTokenEndpoint:
         )
 
         assert_problem_detail(resp, 404)
+
+    def test_onboarded_organizer_with_mismatched_skills_can_still_generate(self):
+        """Regression for the actual prod bug. The organizer is onboarded with
+        skills that do NOT match the event's tags. Under the old code path,
+        apply_onboarding_fallback() filtered the queryset down to services
+        tagged with the viewer's skills, dropping the organizer's own event
+        — self.get_object() then raised Http404 and the UI showed
+        'Resource not found.' Once feed-shaping filters are gated to
+        self.action == 'list', this path stays clean."""
+        organizer = UserFactory(is_onboarded=True)
+        skill_tag = TagFactory()
+        organizer.skills.add(skill_tag)
+
+        event_tag = TagFactory()
+        event = _make_qr_event(organizer)
+        event.tags.add(event_tag)  # different tag from the organizer's skill
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        assert_api_response(resp, 200)
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/integration/test_event_qr_api.py
+++ b/backend/api/tests/integration/test_event_qr_api.py
@@ -1,0 +1,129 @@
+"""Integration tests for the event QR attendance endpoints.
+
+Covers the viewset-level wiring that was previously untested — the unit tests
+in test_event_service.py exercise EventHandshakeService.generate_qr_token
+directly, but the HTTP path through ServiceViewSet.generate_qr_token was
+unexercised, which let the queryset-narrowing regression (the "Resource not
+found." 404 on the organizer's Show Attendance QR button) ship to dev.
+"""
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.tests.helpers.factories import UserFactory, ServiceFactory
+
+
+def _make_qr_event(organizer, hours_from_now=6):
+    """Active Event that requires QR check-in, scheduled inside the 24h
+    lockdown window so generate_qr_token's lockdown check passes."""
+    return ServiceFactory(
+        user=organizer,
+        type='Event',
+        status='Active',
+        max_participants=10,
+        schedule_type='One-Time',
+        scheduled_time=timezone.now() + timedelta(hours=hours_from_now),
+        duration=Decimal('1.00'),
+        location_type='In-Person',
+        location_lat=Decimal('41.012345'),
+        location_lng=Decimal('28.974321'),
+        requires_qr_checkin=True,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestGenerateQRTokenEndpoint:
+    """POST /api/services/{id}/generate-qr-token/"""
+
+    def test_organizer_can_generate_qr_token(self):
+        organizer = UserFactory()
+        event = _make_qr_event(organizer)
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body['token']
+        assert body['attendance_code']
+        assert body['qr_payload']
+
+    def test_non_organizer_gets_403(self):
+        organizer = UserFactory()
+        other = UserFactory()
+        event = _make_qr_event(organizer)
+
+        client = APIClient()
+        client.force_authenticate(user=other)
+        resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        assert resp.status_code == 403
+
+    def test_anonymous_gets_401(self):
+        organizer = UserFactory()
+        event = _make_qr_event(organizer)
+
+        client = APIClient()
+        resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        assert resp.status_code == 401
+
+    def test_offer_service_gets_400(self):
+        organizer = UserFactory()
+        offer = ServiceFactory(user=organizer, type='Offer', status='Active')
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        resp = client.post(f'/api/services/{offer.id}/generate-qr-token/')
+
+        assert resp.status_code == 400
+
+    def test_outside_lockdown_window_gets_400(self):
+        """Far-future event must be rejected with 400, not 404."""
+        organizer = UserFactory()
+        event = _make_qr_event(organizer, hours_from_now=48)
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        resp = client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        assert resp.status_code == 400
+
+    def test_missing_event_returns_404(self):
+        """Sanity: a genuinely missing pk still 404s."""
+        organizer = UserFactory()
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        resp = client.post(
+            '/api/services/00000000-0000-0000-0000-000000000000/generate-qr-token/'
+        )
+
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+class TestGetQRTokenEndpoint:
+    """GET /api/services/{id}/qr-token/"""
+
+    def test_organizer_can_fetch_current_token(self):
+        organizer = UserFactory()
+        event = _make_qr_event(organizer)
+
+        client = APIClient()
+        client.force_authenticate(user=organizer)
+        # Generate one first so there's something to fetch.
+        client.post(f'/api/services/{event.id}/generate-qr-token/')
+
+        resp = client.get(f'/api/services/{event.id}/qr-token/')
+
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body['token']
+        assert body['attendance_code']

--- a/backend/api/tests/integration/test_reputation_api.py
+++ b/backend/api/tests/integration/test_reputation_api.py
@@ -1856,14 +1856,24 @@ class TestFR16eWindowCloseHotScoreContract:
 
     def test_offer_hot_score_unchanged_when_no_writes_before_close(self):
         """
-        Window closes with zero evaluations — batch must not alter hot_score,
-        leaving it at the default 0.  Validates closure-only semantics for Offer.
+        Window closes with zero evaluations — the batch must not alter
+        hot_score. Validates closure-only semantics for Offer.
+
+        Note: the Offer's hot_score is set when the handshake reaches
+        'completed' (via the handshake post_save signal that feeds
+        hours_exchanged into the formula). We capture that value as the
+        baseline and assert the close command does not move it. Touching
+        only eval-window fields on the handshake (via _expire_window) is
+        also a no-op for hot_score per #618.
         """
         provider = UserFactory()
         requester = UserFactory()
         service, handshake = self._open_offer_handshake(provider, requester)
 
-        baseline = service.hot_score  # 0 — no evaluations written
+        # Capture the DB-side hot_score after the handshake-creation signal
+        # has run, not the stale in-memory value from before the signal.
+        service.refresh_from_db()
+        baseline = service.hot_score
 
         self._expire_window(handshake)
         self._run_close_command()

--- a/backend/api/tests/unit/test_proximity_ranking.py
+++ b/backend/api/tests/unit/test_proximity_ranking.py
@@ -140,7 +140,6 @@ class TestProximityComposite:
         above every in-person row, regardless of how close the in-person row
         was to the viewer. Online should be proximity-neutral instead."""
         from datetime import timedelta
-        from decimal import Decimal as Dec
 
         from django.utils import timezone
 

--- a/backend/api/tests/unit/test_proximity_ranking.py
+++ b/backend/api/tests/unit/test_proximity_ranking.py
@@ -131,3 +131,55 @@ class TestProximityComposite:
             ordered_ids = list(qs.values_list('id', flat=True))
 
         assert ordered_ids.index(higher.id) < ordered_ids.index(lower.id)
+
+    def test_online_service_does_not_outrank_close_inperson_at_equal_hot_score(
+        self,
+    ):
+        """Regression: Coalesce(NULL distance, 0) used to give Online services
+        proximity_factor=1.0 — the maximum boost — so every Online row floated
+        above every in-person row, regardless of how close the in-person row
+        was to the viewer. Online should be proximity-neutral instead."""
+        from datetime import timedelta
+        from decimal import Decimal as Dec
+
+        from django.utils import timezone
+
+        from api.models import Service
+        from api.tests.helpers.factories import ServiceFactory, UserFactory
+        from api.views import ServiceViewSet
+
+        viewer = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+        owner = UserFactory(date_joined=timezone.now() - timedelta(days=200))
+
+        close_inperson = self._make_service_with(
+            owner, lat=0.001, lng=0.0, hot_score=5.0,
+        )
+        # Online: no coordinates, location field is NULL.
+        online = ServiceFactory(
+            user=owner, type='Offer', status='Active',
+            location_type='Online',
+            location_lat=None, location_lng=None,
+        )
+        Service.objects.filter(pk=online.id).update(hot_score=5.0)
+        online.refresh_from_db()
+
+        request = self._make_authenticated_request(
+            viewer,
+            {'sort': 'hot', 'lat': '0.0', 'lng': '0.0'},
+        )
+        viewset = ServiceViewSet()
+        viewset.action = 'list'
+        viewset.request = request
+        with override_settings(RANKING_PROXIMITY_HALF_LIFE_KM=10.0):
+            qs = viewset.get_queryset()
+            ordered_ids = list(qs.values_list('id', flat=True))
+
+        assert close_inperson.id in ordered_ids
+        assert online.id in ordered_ids
+        assert (
+            ordered_ids.index(close_inperson.id)
+            < ordered_ids.index(online.id)
+        ), (
+            'A close in-person service should outrank an equally-hot Online '
+            'service when location is enabled.'
+        )

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2421,11 +2421,16 @@ class ServiceViewSet(viewsets.ModelViewSet):
 
     @track_performance
     def get_queryset(self):
-        # Owner edits/deletes must work for services in any status
-        # (Agreed/Completed/Cancelled/hidden). The list-time visibility filter
-        # below would otherwise hide them and produce a misleading 404.
-        # Authorization is enforced in perform_update / destroy.
-        if self.action in ('update', 'partial_update', 'destroy'):
+        # Owner edits/deletes and owner-only event management actions must
+        # work for services in any status (Agreed/Completed/Cancelled/hidden)
+        # and regardless of the list-time visibility/search filters below,
+        # which would otherwise hide the resource and produce a misleading
+        # 404. Authorization is enforced in the respective action methods
+        # (perform_update / destroy / EventHandshakeService.* checks).
+        if self.action in (
+            'update', 'partial_update', 'destroy',
+            'generate_qr_token', 'get_qr_token',
+        ):
             return (
                 Service.objects
                 .select_related('user', 'event_evaluation_summary')
@@ -2616,24 +2621,30 @@ class ServiceViewSet(viewsets.ModelViewSet):
             half_life_km = getattr(settings, 'RANKING_PROXIMITY_HALF_LIFE_KM', 10.0)
             if proximity_active and half_life_km > 0:
                 # PostGIS Distance annotation is in metres (srid=4326).
-                # Online services have `location IS NULL`, which makes the
-                # Distance annotation NULL and would propagate NULL all the
-                # way into composite_score. Postgres' default for `ORDER BY
-                # ... DESC` is NULLS FIRST, so every Online row used to land
-                # at the top of every location-aware feed regardless of
-                # hot_score. Coalesce a missing distance to 0 m so Online
-                # cards collapse to proximity_factor=1.0 and compete on
-                # hot_score with the closest in-person rows.
-                distance_metres = Coalesce(
-                    F('distance'), Value(0.0, output_field=FloatField())
-                )
-                proximity_expr = ExpressionWrapper(
+                # Online services have `location IS NULL` and therefore a
+                # NULL distance. The previous fix here Coalesced NULL → 0 m
+                # which gave Online rows proximity_factor=1.0 (the maximum)
+                # so they out-ranked legitimately-nearby in-person rows.
+                # Treat Online as proximity-neutral instead: a factor of 0.5
+                # (the value an in-person row at the half-life distance
+                # would get) so Online competes on hot_score without an
+                # unearned proximity boost, and without being banished to
+                # the bottom either.
+                inperson_proximity = ExpressionWrapper(
                     Value(1.0, output_field=FloatField()) / (
                         Value(1.0, output_field=FloatField())
-                        + distance_metres / Value(
+                        + F('distance') / Value(
                             1000.0 * half_life_km, output_field=FloatField()
                         )
                     ),
+                    output_field=FloatField(),
+                )
+                proximity_expr = Case(
+                    When(
+                        location__isnull=True,
+                        then=Value(0.5, output_field=FloatField()),
+                    ),
+                    default=inperson_proximity,
                     output_field=FloatField(),
                 )
             else:
@@ -2673,8 +2684,24 @@ class ServiceViewSet(viewsets.ModelViewSet):
             # Non-hot sorts with a location: distance-only ordering, as before.
             queryset = queryset.order_by('-is_pinned', *queryset.query.order_by)
         else:
-            # Default: sort by latest (created_at descending)
-            queryset = queryset.order_by('-is_pinned', '-created_at')
+            # Default: pinned first, then a small boost for services from
+            # users the viewer follows (FR-19e), then newest. The follow
+            # boost only kicks in for authenticated viewers; anonymous
+            # viewers fall back to plain pinned + recency.
+            if self.request.user.is_authenticated:
+                from .models import UserFollow
+                queryset = queryset.annotate(
+                    is_from_followed_user=Exists(
+                        UserFollow.objects.filter(
+                            follower=self.request.user,
+                            following=OuterRef('user_id'),
+                        )
+                    ),
+                ).order_by(
+                    '-is_pinned', '-is_from_followed_user', '-created_at',
+                )
+            else:
+                queryset = queryset.order_by('-is_pinned', '-created_at')
 
         return queryset
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -2524,50 +2524,60 @@ class ServiceViewSet(viewsets.ModelViewSet):
             # Surface the field-level error instead of swallowing it.
             raise drf_serializers.ValidationError({exc.field: exc.message})
 
-        # Onboarding tag fallback (#478): when an onboarded viewer with
-        # declared skills hits the feed without an explicit tag filter,
-        # prefer services tagged with their skills and top up from the
-        # explore pool when too few match. Annotates `source` for the UI.
-        # Skipped when ?user= is set: profile pages must show every active
-        # service the owner has, regardless of whether the tags overlap the
-        # viewer's declared skills.
-        explicit_tag = (
-            self.request.query_params.get('tag')
-            or self.request.query_params.getlist('tags')
-        )
-        # Browse's "All" mode opts out of the implicit skills filter so the
-        # viewer sees the full active catalog instead of a skill-aware slice.
-        skip_onboarding_raw = self.request.query_params.get('skip_onboarding', '')
-        skip_onboarding = (
-            str(skip_onboarding_raw).strip().lower() in {'1', 'true', 'yes'}
-        )
-        if not explicit_tag and not user_param and not skip_onboarding:
-            from .ranking import apply_onboarding_fallback
-            queryset, _ = apply_onboarding_fallback(
-                queryset,
-                self.request.user,
-                getattr(settings, 'RANKING_ONBOARDING_MIN_RESULTS', 10),
+        # The feed-shaping filters below (onboarding tag fallback,
+        # explore_only, exclude_own) only make sense for the list view —
+        # they reshape the public catalogue. Detail actions like retrieve
+        # or @action(detail=True) endpoints (generate_qr_token,
+        # complete_event, cancel_event, …) target a specific pk and must
+        # not have their target silently dropped by feed shaping, or the
+        # caller sees a misleading 404. Status + is_visible filtering
+        # above still applies so genuinely non-public services 404 as they
+        # should.
+        if self.action == 'list':
+            # Onboarding tag fallback (#478): when an onboarded viewer with
+            # declared skills hits the feed without an explicit tag filter,
+            # prefer services tagged with their skills and top up from the
+            # explore pool when too few match. Annotates `source` for the UI.
+            # Skipped when ?user= is set: profile pages must show every active
+            # service the owner has, regardless of whether the tags overlap the
+            # viewer's declared skills.
+            explicit_tag = (
+                self.request.query_params.get('tag')
+                or self.request.query_params.getlist('tags')
             )
+            # Browse's "All" mode opts out of the implicit skills filter so the
+            # viewer sees the full active catalog instead of a skill-aware slice.
+            skip_onboarding_raw = self.request.query_params.get('skip_onboarding', '')
+            skip_onboarding = (
+                str(skip_onboarding_raw).strip().lower() in {'1', 'true', 'yes'}
+            )
+            if not explicit_tag and not user_param and not skip_onboarding:
+                from .ranking import apply_onboarding_fallback
+                queryset, _ = apply_onboarding_fallback(
+                    queryset,
+                    self.request.user,
+                    getattr(settings, 'RANKING_ONBOARDING_MIN_RESULTS', 10),
+                )
 
-        # explore_only=true (#480): restrict the feed to Phase 3 eligible
-        # services (cold-start, undershown quality, stale recurring) so the
-        # mobile "Try something new" carousel can fetch them in one call.
-        explore_only_raw = self.request.query_params.get('explore_only', '')
-        if str(explore_only_raw).strip().lower() in {'1', 'true', 'yes'}:
-            from .ranking import _eligible_exploration
-            sample = list(queryset[:200])
-            cold, under, stale = _eligible_exploration(sample)
-            eligible_ids = [s.id for s in (*cold, *under, *stale)]
-            queryset = queryset.filter(id__in=eligible_ids)
+            # explore_only=true (#480): restrict the feed to Phase 3 eligible
+            # services (cold-start, undershown quality, stale recurring) so the
+            # mobile "Try something new" carousel can fetch them in one call.
+            explore_only_raw = self.request.query_params.get('explore_only', '')
+            if str(explore_only_raw).strip().lower() in {'1', 'true', 'yes'}:
+                from .ranking import _eligible_exploration
+                sample = list(queryset[:200])
+                cold, under, stale = _eligible_exploration(sample)
+                eligible_ids = [s.id for s in (*cold, *under, *stale)]
+                queryset = queryset.filter(id__in=eligible_ids)
 
-        # Optional `exclude_own` toggle — Browse uses this so the viewer
-        # never sees their own services in the discovery feed.
-        exclude_own_raw = self.request.query_params.get('exclude_own', '')
-        if (
-            str(exclude_own_raw).strip().lower() in {'1', 'true', 'yes'}
-            and self.request.user.is_authenticated
-        ):
-            queryset = queryset.exclude(user=self.request.user)
+            # Optional `exclude_own` toggle — Browse uses this so the viewer
+            # never sees their own services in the discovery feed.
+            exclude_own_raw = self.request.query_params.get('exclude_own', '')
+            if (
+                str(exclude_own_raw).strip().lower() in {'1', 'true', 'yes'}
+                and self.request.user.is_authenticated
+            ):
+                queryset = queryset.exclude(user=self.request.user)
 
         # Filter by owner user (for profile pages)
         if user_param:


### PR DESCRIPTION
Four real bugs that came up while finalizing #579.

## QR Show Attendance returned "Resource not found."

The organizer's own active event was getting filtered out of `self.get_object()` on the QR endpoint, so they got a 404 toast instead of a token. `get_queryset()` narrows visibility for everything that isn't `update`/`partial_update`/`destroy`, and `generate_qr_token` / `get_qr_token` weren't in that list — so the search-engine + onboarding-skills filters could drop the organizer's own event.

Added both QR actions to the exemption tuple. Authorization stays at the service layer: `EventHandshakeService.generate_qr_token` already raises `PermissionError` for non-organizers and `ValueError` for wrong type/state/window.

Also added `api/tests/integration/test_event_qr_api.py` with 7 tests covering the ViewSet HTTP path — this whole layer was previously untested (unit tests only hit the service method directly), which is exactly why this regression shipped.

## #618 — Offer hot_score recomputed on no-op handshake save

`process_feedback_windows` uses `_expire_window()` to flip the evaluation-window timestamps. That `handshake.save(update_fields=[...])` triggered the post_save signal, which recomputed `service.hot_score` with time-sensitive components — drifting the value even though no ranking input actually changed.

Short-circuited the signal when `update_fields` is explicit and contains no hot_score-relevant fields (status / provisioned_hours). Also corrected `test_offer_hot_score_unchanged_when_no_writes_before_close` to capture the baseline from the DB after the handshake-creation signal has run; the old test was comparing a stale in-memory value, which masked the real semantics.

Closes #618.

## Online services ranked #1 once location was enabled

PostGIS `Distance()` returns NULL when the service has no location point. The previous fix `Coalesce(NULL, 0)`'d the distance — which gave Online services `proximity_factor = 1.0`, the maximum boost — so every Online row floated above every in-person row regardless of how close the in-person row was.

Switched to a `Case`: if `location IS NULL`, use 0.5 (the half-life value — proximity-neutral, neither boosted nor penalized). Also fixed the non-hot location-sorted branch in `search_filters.py` to `nulls_last=True` so Online rows don't sit at the top of distance-ordered results either.

Added a regression test under `test_proximity_ranking.py`:
`test_online_service_does_not_outrank_close_inperson_at_equal_hot_score`.

## Follow boost was only wired into sort=hot

The discovery feed defaults to "latest" (`-is_pinned, -created_at`). A service from someone you follow looked exactly like a stranger's. Added an `is_from_followed_user` Exists annotation (for authenticated viewers only) as a tiebreaker between `-is_pinned` and `-created_at`. The follow boost lives at the same priority level as pinned: pinned first, then services from people you follow, then newest.

Unxfailed `TestFollowSystem` since all six tests now pass. Note: PR #619 also touches the same `TestFollowSystem` xfail markers; whichever lands first wins, the other will need a trivial rebase.

## Verification

- Targeted suites (`test_event_qr_api`, `TestFR16eWindowCloseHotScoreContract`, `test_proximity_ranking`, `TestFollowSystem`) all pass.
- Full backend integration suite: 852 passed, 3 xfailed, 8 xpassed (the 8 XPASSes are the same stale-xfail markers PR #619 cleans up; harmless under `strict=False`).