### PR TITLE
Fix/txpage group offer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -188,11 +188,17 @@ function App() {
 
   // Allow the long create-topic form to use normal document scrolling.
   const isForumCreateTopicPage = location.pathname === '/forum/new'
+  // Service detail pages use document scroll — inner Box scroll feels slow
+  // on macOS wheel/touch because it bypasses the platform's fast-scroll path.
+  const isServiceDetailPage = location.pathname.startsWith('/service-detail/')
 
   // Lock/unlock body + html scroll for full-screen pages
-  const isFullScreenPage = !isForumCreateTopicPage && FULL_SCREEN_PREFIXES.some((p) =>
-    location.pathname === p || location.pathname.startsWith(p + '/')
-  )
+  const isFullScreenPage =
+    !isForumCreateTopicPage &&
+    !isServiceDetailPage &&
+    FULL_SCREEN_PREFIXES.some((p) =>
+      location.pathname === p || location.pathname.startsWith(p + '/')
+    )
   useEffect(() => {
     const el = document.documentElement
     const body = document.body

--- a/frontend/src/components/service-detail/InterestRequesterRow.tsx
+++ b/frontend/src/components/service-detail/InterestRequesterRow.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { Link } from 'react-router-dom'
-import { FiArrowRight } from 'react-icons/fi'
+import { FiCheck, FiMessageSquare, FiUser, FiX } from 'react-icons/fi'
 import type { Handshake } from '@/services/handshakeAPI'
 import { HS_BADGE, STATUS_FALLBACK } from '@/constants/handshakeBadges'
 import {
@@ -87,10 +87,12 @@ const InterestRequesterRow = ({
     <Flex
       align="center"
       gap={3}
+      rowGap={2}
       px={3}
       py="10px"
       borderBottom={`1px solid ${GRAY200}`}
       opacity={isActive ? 1 : 0.65}
+      flexWrap="wrap"
       style={{ transition: 'background 0.1s' }}
       onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = GRAY50 }}
       onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = '' }}
@@ -99,7 +101,7 @@ const InterestRequesterRow = ({
       <Link
         to={profileUrl}
         aria-label={`View ${displayName}'s public profile`}
-        style={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0, textDecoration: 'none' }}
+        style={{ display: 'flex', alignItems: 'center', gap: '12px', flex: '1 1 160px', minWidth: 0, textDecoration: 'none' }}
       >
         {/* Avatar */}
         <Box flexShrink={0}>
@@ -135,43 +137,43 @@ const InterestRequesterRow = ({
           >
             {displayName}
           </Text>
-          <Flex align="center" gap="6px" mt="1px" flexWrap="wrap">
-            {memberSince && (
-              <Text fontSize="11px" color={GRAY400}>
-                {`Joined ${memberSince}`}
-              </Text>
-            )}
-            {/* Status badge */}
-            <Box
-              px="7px"
-              py="2px"
-              borderRadius="full"
-              fontSize="10px"
-              fontWeight={700}
-              style={{ background: cfg.bg, color: cfg.color }}
-            >
-              {cfg.label}
-            </Box>
-          </Flex>
+          {memberSince && (
+            <Text fontSize="11px" color={GRAY400} mt="1px">
+              {`Joined ${memberSince}`}
+            </Text>
+          )}
         </Box>
       </Link>
 
+      {/* Status badge — pinned to the same slot regardless of name/meta wrapping
+          so the participant's state is always at a predictable position in the row. */}
+      <Box
+        px="8px"
+        py="3px"
+        borderRadius="full"
+        fontSize="10px"
+        fontWeight={700}
+        flexShrink={0}
+        style={{ background: cfg.bg, color: cfg.color, whiteSpace: 'nowrap' }}
+      >
+        {cfg.label}
+      </Box>
+
       {/* Right action group */}
-      <Flex align="center" gap={2} flexShrink={0}>
-        {/* View profile button */}
+      <Flex align="center" gap={2} flexShrink={0} ml="auto" flexWrap="wrap" justifyContent="flex-end">
+        {/* View profile — icon-only to save room in the narrow sidebar */}
         <Link
           to={profileUrl}
           aria-label={`Open ${displayName}'s public profile page`}
+          title="View profile"
           style={{ textDecoration: 'none' }}
         >
           <Flex
             align="center"
-            gap="4px"
-            px="10px"
-            py="5px"
+            justify="center"
+            w="28px"
+            h="28px"
             borderRadius="7px"
-            fontSize="11px"
-            fontWeight={600}
             style={{
               border: `1px solid ${GRAY200}`,
               color: GRAY700,
@@ -179,55 +181,78 @@ const InterestRequesterRow = ({
               background: 'none',
             }}
           >
-            View profile <FiArrowRight size={11} />
+            <FiUser size={13} />
           </Flex>
         </Link>
 
-        {/* Accept button — only for pending status */}
+        {/* Open chat with this participant — direct link, no need to navigate via Messages */}
+        <Link
+          to={`/messages/${handshake.id}`}
+          aria-label={`Open chat with ${displayName}`}
+          title="Open chat"
+          style={{ textDecoration: 'none' }}
+        >
+          <Flex
+            align="center"
+            justify="center"
+            w="28px"
+            h="28px"
+            borderRadius="7px"
+            style={{
+              border: `1px solid ${GRAY200}`,
+              color: GREEN,
+              cursor: 'pointer',
+              background: GREEN_LT,
+            }}
+          >
+            <FiMessageSquare size={13} />
+          </Flex>
+        </Link>
+
+        {/* Accept button — icon-only for pending status */}
         {isPending && onAccept && (
           <Box
             as="button"
-            px="10px"
-            py="5px"
+            w="28px"
+            h="28px"
             borderRadius="7px"
-            fontSize="11px"
-            fontWeight={700}
-            style={{ background: GREEN_LT, border: 'none', cursor: 'pointer', color: GREEN }}
+            aria-label={`Accept request from ${displayName}`}
+            title="Accept"
+            style={{ background: GREEN_LT, border: 'none', cursor: 'pointer', color: GREEN, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
             onClick={onAccept}
           >
-            Accept
+            <FiCheck size={13} />
           </Box>
         )}
-        {/* Reject button — only for pending status */}
+        {/* Reject button — icon-only for pending status */}
         {isPending && onReject && (
           <Box
             as="button"
-            px="10px"
-            py="5px"
+            w="28px"
+            h="28px"
             borderRadius="7px"
-            fontSize="11px"
-            fontWeight={700}
-            style={{ background: '#fee2e2', border: 'none', cursor: 'pointer', color: '#991b1b' }}
+            aria-label={`Decline request from ${displayName}`}
+            title="Decline"
+            style={{ background: '#fee2e2', border: 'none', cursor: 'pointer', color: '#991b1b', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
             onClick={onReject}
           >
-            Decline
+            <FiX size={13} />
           </Box>
         )}
-        {/* Mark as Complete — only for accepted status, owner not yet confirmed (#300 / FR-13m) */}
+        {/* Mark as Complete — icon-only, owner not yet confirmed (#300 / FR-13m) */}
         {canMarkComplete && (
           <Box
             as="button"
-            px="10px"
-            py="5px"
+            w="28px"
+            h="28px"
             borderRadius="7px"
-            fontSize="11px"
-            fontWeight={700}
             data-testid="mark-as-complete-button"
             aria-label={`Mark exchange with ${displayName} as complete`}
-            style={{ background: GREEN_LT, border: 'none', cursor: 'pointer', color: GREEN }}
+            title="Mark as complete"
+            style={{ background: GREEN, border: 'none', cursor: 'pointer', color: WHITE, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
             onClick={onMarkComplete}
           >
-            Mark as Complete
+            <FiCheck size={13} />
           </Box>
         )}
       </Flex>

--- a/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
+++ b/frontend/src/components/service-detail/__tests__/InterestRequesterRow.test.tsx
@@ -142,8 +142,8 @@ describe('InterestRequesterRow', () => {
         />
       </Wrapper>,
     )
-    expect(screen.getByText('Accept')).toBeInTheDocument()
-    expect(screen.getByText('Decline')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Accept request from Alice Smith/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Decline request from Alice Smith/i)).toBeInTheDocument()
   })
 
   it('calls onAccept when Accept button is clicked', () => {
@@ -157,7 +157,7 @@ describe('InterestRequesterRow', () => {
         />
       </Wrapper>,
     )
-    fireEvent.click(screen.getByText('Accept'))
+    fireEvent.click(screen.getByLabelText(/Accept request from Alice Smith/i))
     expect(onAccept).toHaveBeenCalledTimes(1)
   })
 
@@ -172,7 +172,7 @@ describe('InterestRequesterRow', () => {
         />
       </Wrapper>,
     )
-    fireEvent.click(screen.getByText('Decline'))
+    fireEvent.click(screen.getByLabelText(/Decline request from Alice Smith/i))
     expect(onReject).toHaveBeenCalledTimes(1)
   })
 
@@ -182,8 +182,8 @@ describe('InterestRequesterRow', () => {
         <InterestRequesterRow handshake={makeHandshake({ status: 'accepted' })} isOwner />
       </Wrapper>,
     )
-    expect(screen.queryByText('Accept')).not.toBeInTheDocument()
-    expect(screen.queryByText('Decline')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Accept request from Alice Smith/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Decline request from Alice Smith/i)).not.toBeInTheDocument()
   })
 
   // ── #300 / FR-13m: owner-side manual Mark-as-Complete fallback ──────────
@@ -312,9 +312,9 @@ describe('InterestRequesterRow', () => {
       l.getAttribute('href') === '/public-profile/user-fallback',
     )
     expect(profileLinks.length).toBeGreaterThanOrEqual(1)
-    // The "View profile" link specifically
+    // The view-profile icon button specifically (matched by its aria-label)
     const viewProfileLink = links.find((l) =>
-      l.textContent?.includes('View profile') &&
+      l.getAttribute('aria-label')?.startsWith('Open Fallback User') &&
       l.getAttribute('href') === '/public-profile/user-fallback',
     )
     expect(viewProfileLink).toBeDefined()

--- a/frontend/src/pages/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage.tsx
@@ -707,6 +707,19 @@ export default function ServiceDetailPage() {
     ? (isOwn ? evaluationHandshake.requester_name : evaluationHandshake.provider_name)
     : 'counterpart'
   const evaluationWindow = getEvaluationWindowInfo(evaluationHandshake)
+  // For one-time group offers, "You already reviewed this exchange." is
+  // premature while other slots are still in flight — the owner/requester
+  // will have more participants to review when those slots settle. Hold the
+  // message back until every slot reaches `completed`.
+  const isOneTimeGroupOffer =
+    !isEvent &&
+    service?.schedule_type === 'One-Time' &&
+    Number(service?.max_participants ?? 1) > 1
+  const allGroupSlotsCompleted =
+    isOneTimeGroupOffer &&
+    incoming.length > 0 &&
+    incoming.every((h) => h.status === 'completed')
+  const hideAlreadyReviewedNotice = isOneTimeGroupOffer && !allGroupSlotsCompleted
 
   // Event-specific derived value — must come after exId / isEvent
   const myEventHandshake = isEvent
@@ -1085,7 +1098,7 @@ export default function ServiceDetailPage() {
 
   return (
     <>
-    <Box bg={GRAY50} h="calc(100vh - 64px)" overflowY="auto"
+    <Box bg={GRAY50} minH="calc(100vh - 64px)"
       py={{ base: 0, md: '8px' }} px={{ base: 0, md: '12px' }}>
       <Box maxW="1440px" mx="auto" py={{ base: 4, md: 5 }} px={{ base: 4, md: 5 }}>
 
@@ -2207,7 +2220,7 @@ export default function ServiceDetailPage() {
                             {evaluationWindow.label}
                           </Text>
                         </>
-                      ) : (
+                      ) : hideAlreadyReviewedNotice ? null : (
                         <Flex align="center" justify="center" gap={2} py={2} px={3} borderRadius="11px" bg={GRAY100} color={GRAY500}>
                           <FiCheckCircle size={14} color={GREEN} />
                           <Text fontSize="13px" fontWeight={600}>You already reviewed this exchange.</Text>

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -46,12 +46,10 @@ const FILTERS: { key: TransactionDirection; label: string }[] = [
 
 const ACTIVE_HANDSHAKE_STATUSES = new Set<Handshake['status']>(['accepted', 'checked_in', 'attended'])
 
-// One-time group offers settle the provider on the first completion, but the
-// group session is not "done" until every other handshake reaches a terminal
-// state. Keep `completed` handshakes visible alongside the still-active ones
-// so the participant doesn't disappear from the active card the moment they
-// settle. Once every handshake on the service has terminated the group is
-// dropped from the active list as a whole.
+// One-time group offers settle the provider on the first completion. Once
+// that payout has fired, any remaining active siblings cannot move the
+// provider's balance further — render their rows as "No change" so the
+// active card honestly reflects what the provider will still earn.
 function isGroupOneTimeOffer(handshake: Handshake): boolean {
   return (
     handshake.service_type === 'Offer' &&
@@ -214,7 +212,11 @@ function handshakeRequesterId(requester: Handshake['requester']): string {
     : String(requester ?? '')
 }
 
-function toExpectedAgreement(handshake: Handshake, currentUser?: User | null): ExpectedAgreement | null {
+function toExpectedAgreement(
+  handshake: Handshake,
+  currentUser?: User | null,
+  paidOutGroupServiceIds?: Set<string>,
+): ExpectedAgreement | null {
   const hours = Number(handshake.provisioned_hours ?? 0)
   const isEvent = handshake.service_type === 'Event'
   if (hours <= 0 && !isEvent) return null
@@ -228,14 +230,18 @@ function toExpectedAgreement(handshake: Handshake, currentUser?: User | null): E
   const isProvider = isEvent
     ? requesterId !== String(currentUser?.id ?? '')
     : handshake.is_current_user_provider === true
-  // Completed handshakes on a one-time group offer have already settled
-  // (provider was paid on the first completion); show them with a
-  // delta of 0 and a "No change" note so the row is still visible while
-  // siblings settle but doesn't double-count the credit.
-  const isSettledGroupOffer =
-    !isEvent && handshake.status === 'completed' && isGroupOneTimeOffer(handshake)
-  const expectedDelta = isSettledGroupOffer ? 0 : isProvider ? hours : 0
-  const reservedDelta = isSettledGroupOffer ? 0 : isProvider ? 0 : -hours
+  // For one-time group offers, the provider receives a single asymmetric
+  // payout on the first completion. Any still-active sibling on a service
+  // where that payout has already fired can no longer change the provider's
+  // balance, so zero out the expected delta and surface "No change" on it.
+  const providerSettled =
+    isProvider &&
+    !isEvent &&
+    isGroupOneTimeOffer(handshake) &&
+    handshake.service_id != null &&
+    paidOutGroupServiceIds?.has(String(handshake.service_id)) === true
+  const expectedDelta = providerSettled ? 0 : isProvider ? hours : 0
+  const reservedDelta = providerSettled ? 0 : isProvider ? 0 : -hours
 
   return {
     id: handshake.id,
@@ -256,11 +262,12 @@ function toExpectedAgreement(handshake: Handshake, currentUser?: User | null): E
     expected_delta: expectedDelta,
     note: isEvent
       ? 'Event session'
-      : isSettledGroupOffer
-      ? 'Already settled — no further change'
+      : providerSettled
+      ? 'Provider already paid — no further change'
       : isProvider
       ? `Time expected after completion`
       : `Already reserved at acceptance`,
+    provider_settled: providerSettled,
   }
 }
 
@@ -856,31 +863,25 @@ const TransactionHistoryPage = () => {
       if (requestId !== agreementRequestIdRef.current) return
       setHandshakes(handshakes)
 
-      // For one-time group offers, surface completed handshakes too — but
-      // only while at least one sibling on the same service is still active,
-      // so the row drops out cleanly once the whole group has settled.
-      const groupServicesWithActiveSibling = new Set<string>()
+      // One-time group offers pay the provider once on the first completion.
+      // Track services where that payout has already happened so the remaining
+      // active siblings render as "No change" instead of promising further
+      // credit that will never arrive.
+      const paidOutGroupServiceIds = new Set<string>()
       for (const h of handshakes) {
         if (
           h.service_id &&
           isGroupOneTimeOffer(h) &&
-          ACTIVE_HANDSHAKE_STATUSES.has(h.status)
+          h.is_current_user_provider === true &&
+          h.status === 'completed'
         ) {
-          groupServicesWithActiveSibling.add(String(h.service_id))
+          paidOutGroupServiceIds.add(String(h.service_id))
         }
       }
 
       const nextAgreements = handshakes
-        .filter((handshake) => {
-          if (ACTIVE_HANDSHAKE_STATUSES.has(handshake.status)) return true
-          return (
-            handshake.status === 'completed' &&
-            isGroupOneTimeOffer(handshake) &&
-            handshake.service_id != null &&
-            groupServicesWithActiveSibling.has(String(handshake.service_id))
-          )
-        })
-        .map((handshake) => toExpectedAgreement(handshake, user))
+        .filter((handshake) => ACTIVE_HANDSHAKE_STATUSES.has(handshake.status))
+        .map((handshake) => toExpectedAgreement(handshake, user, paidOutGroupServiceIds))
         .filter((item): item is ExpectedAgreement => item !== null)
       const enrichedAgreements = await enrichEventAgreementParticipants(nextAgreements, signal)
       if (requestId !== agreementRequestIdRef.current) return
@@ -1607,11 +1608,11 @@ const TransactionHistoryPage = () => {
                         const showTimeValue = agreement.service_type !== 'Event' || displayDelta !== 0
                         const timeColor = displayDelta > 0 ? GREEN : displayDelta < 0 ? AMBER : GRAY700
                         const timeBg = displayDelta > 0 ? GREEN_LT : displayDelta < 0 ? AMBER_LT : GRAY100
-                        // Settled group-offer participants surface a distinct
-                        // "No change" pill so the row stays informative while
-                        // siblings are still active without implying a future delta.
-                        const isSettledGroupOfferRow =
-                          agreement.status === 'completed' && agreement.expected_delta === 0
+                        // Once the provider has been paid for a one-time group
+                        // session, every still-active sibling surfaces the same
+                        // "No change" pill so the active card honestly mirrors
+                        // what the provider will still earn.
+                        const isSettledGroupOfferRow = agreement.provider_settled === true
                         const timeLabel = isSettledGroupOfferRow
                           ? 'already settled'
                           : agreement.expected_delta !== 0
@@ -2170,7 +2171,6 @@ const TransactionHistoryPage = () => {
               : handshake.requester_name,
             subtitle: 'Completed participant',
             meta: formatDate(handshake.updated_at),
-            value: formatHours(handshake.provisioned_hours),
             avatarUrl: handshake.counterpart?.avatar_url ?? null,
           })),
           (selectedTransactionGroup?.participants ?? []).map((agreement) => ({
@@ -2178,7 +2178,6 @@ const TransactionHistoryPage = () => {
             title: agreement.counterpart_name,
             subtitle: activeHandshakeLabel(agreement.status),
             meta: agreement.note,
-            value: formatAmount(agreement.expected_delta !== 0 ? agreement.expected_delta : agreement.reserved_delta),
             avatarUrl: agreement.counterpart_avatar_url ?? null,
             onClick: agreement.counterpart_id
               ? () => openPublicProfile(agreement.counterpart_id)
@@ -2198,10 +2197,10 @@ const TransactionHistoryPage = () => {
         onClose={() => setSelectedActiveAgreementGroup(null)}
         items={(selectedActiveAgreementGroup?.participants ?? []).map((agreement) => {
           const isEventParticipant = selectedActiveAgreementGroup?.service_type === 'Event' || agreement.service_type === 'Event'
-          // Settled participants in a still-active group offer surface a
-          // "No change" value instead of the reserved/expected delta —
-          // the row is informational, the credit already moved.
-          const settledRow = agreement.status === 'completed' && agreement.expected_delta === 0
+          // Once the provider's payout has fired for this group offer, every
+          // remaining active row inside the modal surfaces "No change" so the
+          // value matches the active card and doesn't promise further credit.
+          const settledRow = agreement.provider_settled === true
           return {
             id: agreement.id,
             title: agreement.counterpart_name,

--- a/frontend/src/test/utils/timeActivityGrouping.test.ts
+++ b/frontend/src/test/utils/timeActivityGrouping.test.ts
@@ -62,6 +62,38 @@ describe('timeActivityGrouping', () => {
     ])
   })
 
+  it('marks a grouped one-time group offer as provider-settled when any participant is already paid out', () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...baseAgreement,
+        id: 'hs-zeynep',
+        counterpart_name: 'Zeynep Arslan',
+        provider_settled: true,
+        expected_delta: 0,
+        reserved_delta: 0,
+        note: 'Provider already paid — no further change',
+      },
+      {
+        ...baseAgreement,
+        id: 'hs-emre',
+        counterpart_name: 'Emre Yilmaz',
+        provider_settled: true,
+        expected_delta: 0,
+        reserved_delta: 0,
+        note: 'Provider already paid — no further change',
+      },
+    ])
+
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]).toMatchObject({
+      counterpart_name: '2 members',
+      participant_count: 2,
+      expected_delta: 0,
+      reserved_delta: 0,
+      provider_settled: true,
+    })
+  })
+
   it('groups active event agreements by event service', () => {
     const grouped = groupActiveAgreements([
       {

--- a/frontend/src/utils/timeActivityGrouping.ts
+++ b/frontend/src/utils/timeActivityGrouping.ts
@@ -22,6 +22,10 @@ export interface TimeActivityAgreement {
   participant_count?: number
   participants?: TimeActivityAgreement[]
   is_grouped_multi_use?: boolean
+  // True when the provider has already received the asymmetric one-time
+  // group-offer payout for this service, so further completions or
+  // cancellations on sibling handshakes do not change the provider's balance.
+  provider_settled?: boolean
 }
 
 export interface TimeActivityTransaction {
@@ -184,6 +188,7 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
     }
 
     const [primary] = participants
+    const groupProviderSettled = participants.some((item) => item.provider_settled === true)
     output.push({
       ...primary,
       id: `group:${key}`,
@@ -193,10 +198,13 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
       counterpart_avatar_url: null,
       expected_delta: representativeDelta(participants.map((item) => item.expected_delta)),
       reserved_delta: representativeDelta(participants.map((item) => item.reserved_delta)),
-      note: `${participants.length} members in this group session`,
+      note: groupProviderSettled
+        ? 'Provider already paid — no further change'
+        : `${participants.length} members in this group session`,
       participant_count: participants.length,
       participants,
       is_grouped_multi_use: true,
+      provider_settled: groupProviderSettled,
     })
   }
 

--- a/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
+++ b/mobile-client/src/api/__tests__/timeActivityGrouping.test.ts
@@ -55,6 +55,38 @@ describe("timeActivityGrouping", () => {
     ]);
   });
 
+  it("marks a grouped one-time group offer as provider-settled when any participant is already paid out", () => {
+    const grouped = groupActiveAgreements([
+      {
+        ...groupOfferAgreement,
+        id: "hs-zeynep",
+        counterpart_name: "Zeynep Arslan",
+        provider_settled: true,
+        expected_delta: 0,
+        reserved_delta: 0,
+        note: "Provider already paid — no further change",
+      },
+      {
+        ...groupOfferAgreement,
+        id: "hs-emre",
+        counterpart_name: "Emre Yilmaz",
+        provider_settled: true,
+        expected_delta: 0,
+        reserved_delta: 0,
+        note: "Provider already paid — no further change",
+      },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]).toMatchObject({
+      counterpart_name: "2 members",
+      participant_count: 2,
+      expected_delta: 0,
+      reserved_delta: 0,
+      provider_settled: true,
+    });
+  });
+
   it("groups active event agreements into one visible row", () => {
     const grouped = groupActiveAgreements([
       {

--- a/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
+++ b/mobile-client/src/presentation/screens/TimeActivityScreen.tsx
@@ -219,10 +219,19 @@ function activeHandshakeLabel(status: Handshake["status"]): string {
   return activeAgreementParticipantLabel(status);
 }
 
+function isGroupOneTimeOffer(handshake: Handshake): boolean {
+  return (
+    handshake.service_type === "Offer" &&
+    handshake.schedule_type === "One-Time" &&
+    Number(handshake.max_participants ?? 1) > 1
+  );
+}
+
 function toExpectedAgreement(
   handshake: Handshake,
   currentUserName?: string,
   currentUserId?: string,
+  paidOutGroupServiceIds?: Set<string>,
 ): ExpectedAgreement | null {
   const hours = Number(handshake.provisioned_hours ?? 0);
   const isEvent = handshake.service_type === "Event";
@@ -235,6 +244,16 @@ function toExpectedAgreement(
   const isProvider = isEvent
     ? requesterId !== String(currentUserId ?? "")
     : handshake.is_current_user_provider === true;
+  // For one-time group offers the provider receives a single asymmetric
+  // payout on the first completion. Any still-active sibling on a service
+  // where that payout has already fired can no longer change the provider's
+  // balance, so zero out the expected delta and surface "No change" on it.
+  const providerSettled =
+    isProvider &&
+    !isEvent &&
+    isGroupOneTimeOffer(handshake) &&
+    handshake.service_id != null &&
+    paidOutGroupServiceIds?.has(String(handshake.service_id)) === true;
 
   return {
     id: handshake.id,
@@ -250,13 +269,16 @@ function toExpectedAgreement(
     counterpart_name: handshakeCounterpartName(handshake, currentUserName),
     counterpart_avatar_url: handshake.counterpart?.avatar_url ?? null,
     status: handshake.status,
-    reserved_delta: isProvider ? 0 : -hours,
-    expected_delta: isProvider ? hours : 0,
+    reserved_delta: providerSettled ? 0 : isProvider ? 0 : -hours,
+    expected_delta: providerSettled ? 0 : isProvider ? hours : 0,
     note: isEvent
       ? "Event session"
+      : providerSettled
+      ? "Provider already paid — no further change"
       : isProvider
       ? "Time expected after completion"
       : "Already reserved at acceptance",
+    provider_settled: providerSettled,
   };
 }
 
@@ -684,8 +706,26 @@ export default function TimeActivityScreen() {
   const loadAgreements = useCallback(async () => {
     try {
       const res = await listHandshakes({ page: 1, page_size: 100 });
-      const allAgreements = (res.results ?? [])
-        .map((handshake) => toExpectedAgreement(handshake, currentUserName, user?.id))
+      const handshakes = res.results ?? [];
+
+      // One-time group offers pay the provider once on the first completion.
+      // Track services where that payout has already happened so the remaining
+      // active siblings render as "No change" instead of promising further
+      // credit that will never arrive.
+      const paidOutGroupServiceIds = new Set<string>();
+      for (const h of handshakes) {
+        if (
+          h.service_id &&
+          isGroupOneTimeOffer(h) &&
+          h.is_current_user_provider === true &&
+          h.status === "completed"
+        ) {
+          paidOutGroupServiceIds.add(String(h.service_id));
+        }
+      }
+
+      const allAgreements = handshakes
+        .map((handshake) => toExpectedAgreement(handshake, currentUserName, user?.id, paidOutGroupServiceIds))
         .filter((item): item is ExpectedAgreement => item !== null);
       const nextAgreements = allAgreements
         .filter((agreement) => ACTIVE_HANDSHAKE_STATUSES.has(agreement.status as Handshake["status"]));
@@ -1309,19 +1349,22 @@ export default function TimeActivityScreen() {
                         {sectionOpen ? section.items.map((agreement, index) => {
                           const accent = roleAccent(agreement.is_current_user_provider);
                           const isGroupedAgreement = agreement.is_grouped_multi_use === true;
+                          const isProviderSettled = agreement.provider_settled === true;
                           const displayDelta =
                             agreement.expected_delta !== 0
                               ? agreement.expected_delta
                               : agreement.reserved_delta;
-                          const showTimeValue = agreement.service_type !== "Event" || displayDelta !== 0;
+                          const showTimeValue =
+                            isProviderSettled || agreement.service_type !== "Event" || displayDelta !== 0;
                           const valueColor =
                             displayDelta > 0
                               ? colors.GREEN
                               : displayDelta < 0
                                 ? colors.AMBER
                                 : colors.GRAY700;
-                          const valueNote =
-                            agreement.expected_delta !== 0
+                          const valueNote = isProviderSettled
+                            ? "Already settled"
+                            : agreement.expected_delta !== 0
                               ? "After completion"
                               : agreement.reserved_delta !== 0
                                 ? "Reserved now"
@@ -1468,7 +1511,11 @@ export default function TimeActivityScreen() {
                               {showTimeValue ? (
                                 <View style={styles.agreementRight}>
                                   <Text style={[styles.agreementValue, { color: valueColor }]}>
-                                    {displayDelta !== 0 ? formatAmount(displayDelta) : "No hours"}
+                                    {isProviderSettled
+                                      ? "No change"
+                                      : displayDelta !== 0
+                                        ? formatAmount(displayDelta)
+                                        : "No hours"}
                                   </Text>
                                   <Text style={styles.agreementNote}>{valueNote}</Text>
                                 </View>
@@ -1829,6 +1876,7 @@ export default function TimeActivityScreen() {
           {(selectedAgreementGroup?.participants ?? []).map((participant) => {
             const isEventParticipant =
               selectedAgreementGroup?.service_type === "Event" || participant.service_type === "Event";
+            const isParticipantSettled = participant.provider_settled === true;
             const delta = participant.expected_delta !== 0
               ? participant.expected_delta
               : participant.reserved_delta;
@@ -1868,7 +1916,11 @@ export default function TimeActivityScreen() {
                 </View>
                 {!isEventParticipant ? (
                   <Text style={styles.participantValue}>
-                    {delta !== 0 ? formatAmount(delta) : "0h"}
+                    {isParticipantSettled
+                      ? "No change"
+                      : delta !== 0
+                        ? formatAmount(delta)
+                        : "0h"}
                   </Text>
                 ) : null}
               </Pressable>
@@ -1915,9 +1967,6 @@ export default function TimeActivityScreen() {
           {(
             selectedTransactionGroup?.participants ?? []
           ).map((participant) => {
-            const delta = participant.expected_delta !== 0
-              ? participant.expected_delta
-              : participant.reserved_delta;
             const initial = participant.counterpart_name.trim().charAt(0).toUpperCase() || "?";
 
             return (
@@ -1952,9 +2001,6 @@ export default function TimeActivityScreen() {
                     {completedTransactionParticipantLabel()}
                   </Text>
                 </View>
-                <Text style={styles.participantValue}>
-                  {delta !== 0 ? formatAmount(delta) : "0h"}
-                </Text>
               </Pressable>
             );
           })}

--- a/mobile-client/src/utils/timeActivityGrouping.ts
+++ b/mobile-client/src/utils/timeActivityGrouping.ts
@@ -17,6 +17,10 @@ export interface TimeActivityAgreement {
   participant_count?: number;
   participants?: TimeActivityAgreement[];
   is_grouped_multi_use?: boolean;
+  // True when the provider has already received the asymmetric one-time
+  // group-offer payout for this service, so further completions or
+  // cancellations on sibling handshakes do not change the provider's balance.
+  provider_settled?: boolean;
 }
 
 export interface TimeActivityTransaction {
@@ -177,6 +181,7 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
     }
 
     const [primary] = participants;
+    const groupProviderSettled = participants.some((item) => item.provider_settled === true);
     output.push({
       ...primary,
       id: `group:${key}`,
@@ -185,10 +190,13 @@ export function groupActiveAgreements<T extends TimeActivityAgreement>(agreement
       counterpart_avatar_url: null,
       expected_delta: representativeDelta(participants.map((item) => item.expected_delta)),
       reserved_delta: representativeDelta(participants.map((item) => item.reserved_delta)),
-      note: `${participants.length} members in this group session`,
+      note: groupProviderSettled
+        ? "Provider already paid — no further change"
+        : `${participants.length} members in this group session`,
       participant_count: participants.length,
       participants,
       is_grouped_multi_use: true,
+      provider_settled: groupProviderSettled,
     });
   }
 


### PR DESCRIPTION
## Summary

Closes #610 

Follow-up to #571 that closes the remaining group-offer UX gaps surfaced in #610, plus a couple of service-detail polish items.

### Time activity page (web + mobile)
- Completed handshakes on a one-time group offer no longer linger in **Active Agreements** — they move to history as expected.
- Once the provider's asymmetric payout has fired (any one participant completed), every still-active sibling row renders as **"No change · already settled"** so the active card honestly reflects what the provider will still earn. The grouped row picks this up via a new `provider_settled` flag on `TimeActivityAgreement` that `groupActiveAgreements` propagates.
- History-side grouped transaction modal drops the per-member hour value — the total is on the parent row, the member list just identifies who participated.

### Service detail — owner side
- `InterestRequesterRow` redesigned for the narrow sidebar:
  - View profile, Chat, Accept, Decline, and Mark-as-Complete are uniform 28×28 icon buttons (chat icon opens `/messages/<handshake-id>`).
  - Status badge (Accepted / Completed / …) lives in its own fixed slot so it doesn't drift as the meta line wraps.
- One-time group offer with mixed participant states no longer shows **"You already reviewed this exchange."** until every slot reaches `completed` (the message was premature while other participants are still active).
- Service detail page now uses document scroll (added to the `FULL_SCREEN_PREFIXES` exception alongside `/forum/new`) and the page Box switches from `h: calc(100vh - 64px); overflowY: auto` to `minH: calc(100vh - 64px)` — wheel/touch get native platform scroll speed, sticky sidebar tracks the viewport.

## Test plan

- [x] `cd frontend && npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npx vitest run --environment node src/test/utils/timeActivityGrouping.test.ts` — 13/13
- [x] `cd frontend && npx vitest run src/components/service-detail/__tests__/InterestRequesterRow.test.tsx` — 20/20
- [x] `cd mobile-client && npx tsc --noEmit` — clean
- [x] `cd mobile-client && npm test -- src/api/__tests__/timeActivityGrouping.test.ts` — 14/14
- [ ] Manual: provider with a 3-seat one-time group offer — after the first receiver completes, active card shows the remaining seats as "No change", first completion lands in history, sticky sidebar + body scroll feel native on the service detail page.
