### PR TITLE
fix(profile): paginate offers, needs, history tabs

### DIFF
--- a/frontend/src/hooks/useReveal.ts
+++ b/frontend/src/hooks/useReveal.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react'
+
+export const PROFILE_PAGE_SIZE = 6
+
+/**
+ * Tracks how many items of a long list are currently revealed. The counter
+ * resets whenever `resetKey` changes so a viewer who scrolled deep on one
+ * profile doesn't land halfway into the next.
+ *
+ * Uses the "adjust state while rendering" pattern from the React docs to
+ * reset on key change without an extra effect or ref:
+ * https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+ */
+export function useReveal(resetKey: unknown, pageSize: number = PROFILE_PAGE_SIZE) {
+  const [visible, setVisible] = useState(pageSize)
+  const [prevResetKey, setPrevResetKey] = useState(resetKey)
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey)
+    setVisible(pageSize)
+  }
+  const showMore = useCallback(() => setVisible((c) => c + pageSize), [pageSize])
+  return { visible, showMore }
+}

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -41,6 +41,10 @@ import { useMyReports } from '@/hooks/useMyReports'
 // ── Shared helpers (still used by tab content) ─────────────────────────────────
 const AVATAR_PALETTE = [GREEN, BLUE, TEAL, AMBER, '#0D9488', '#EA580C']
 const AVATAR_IMAGE_BG = `linear-gradient(180deg, ${WHITE} 0%, ${GRAY100} 100%)`
+// Profile tabs render every record the API returned in one go; for large
+// portfolios that meant 50 service cards stacked in a single grid. Reveal in
+// pages of 6 (one full 2x3 grid row) and let the user expand on demand.
+const PROFILE_PAGE_SIZE = 6
 const fmtDate = (d: string) =>
   new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur = (d: number | string) => `${Number(d)}h`
@@ -180,6 +184,9 @@ const UserProfile = () => {
   const [historyLoading, setHistoryLoading]   = useState(true)
   const [eventsLoading, setEventsLoading]     = useState(true)
   const [activeTab, setActiveTab]         = useState<ServiceTab>(initialTab)
+  const [visibleOffers, setVisibleOffers] = useState(PROFILE_PAGE_SIZE)
+  const [visibleNeeds, setVisibleNeeds]   = useState(PROFILE_PAGE_SIZE)
+  const [visibleHistory, setVisibleHistory] = useState(PROFILE_PAGE_SIZE)
   const { reports: myReports, error: myReportsError } = useMyReports()
 
   useEffect(() => {
@@ -237,6 +244,14 @@ const UserProfile = () => {
       setReviewsAsOrganizer(rOrganizer.results)
     }).catch(() => {}).finally(() => setReviewsLoading(false))
     return () => ac.abort()
+  }, [userId])
+
+  // Reset the per-tab reveal counters when switching profile views so a
+  // viewer who scrolled deep on one user doesn't land halfway into another.
+  useEffect(() => {
+    setVisibleOffers(PROFILE_PAGE_SIZE)
+    setVisibleNeeds(PROFILE_PAGE_SIZE)
+    setVisibleHistory(PROFILE_PAGE_SIZE)
   }, [userId])
 
   useEffect(() => {
@@ -412,9 +427,19 @@ const UserProfile = () => {
                     onClick={() => navigate('/post-offer')}><FiPlus size={12} />Post an Offer</Box>
                 </Flex>
               ) : (
-                <Box p={3} display="grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '10px' }}>
-                  {offersTab.map(s => <ServiceCard key={s.id} service={s} onNav={() => navigate(`/service-detail/${s.id}`)} />)}
-                </Box>
+                <>
+                  <Box p={3} display="grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '10px' }}>
+                    {offersTab.slice(0, visibleOffers).map(s => <ServiceCard key={s.id} service={s} onNav={() => navigate(`/service-detail/${s.id}`)} />)}
+                  </Box>
+                  {offersTab.length > visibleOffers && (
+                    <Flex justify="center" pb={3}>
+                      <Box as="button" onClick={() => setVisibleOffers(c => c + PROFILE_PAGE_SIZE)}
+                        px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
+                        style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
+                      >Show more ({offersTab.length - visibleOffers})</Box>
+                    </Flex>
+                  )}
+                </>
               ))}
               </Box>
 
@@ -431,9 +456,19 @@ const UserProfile = () => {
                     onClick={() => navigate('/post-need')}><FiPlus size={12} />Post a Need</Box>
                 </Flex>
               ) : (
-                <Box p={3} display="grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '10px' }}>
-                  {needsTab.map(s => <ServiceCard key={s.id} service={s} onNav={() => navigate(`/service-detail/${s.id}`)} />)}
-                </Box>
+                <>
+                  <Box p={3} display="grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '10px' }}>
+                    {needsTab.slice(0, visibleNeeds).map(s => <ServiceCard key={s.id} service={s} onNav={() => navigate(`/service-detail/${s.id}`)} />)}
+                  </Box>
+                  {needsTab.length > visibleNeeds && (
+                    <Flex justify="center" pb={3}>
+                      <Box as="button" onClick={() => setVisibleNeeds(c => c + PROFILE_PAGE_SIZE)}
+                        px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
+                        style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
+                      >Show more ({needsTab.length - visibleNeeds})</Box>
+                    </Flex>
+                  )}
+                </>
               ))}
               </Box>
 
@@ -484,7 +519,7 @@ const UserProfile = () => {
                 </Flex>
               ) : (
                 <Box px={4}>
-                  {groupedOwnHistory.map((item) => (
+                  {groupedOwnHistory.slice(0, visibleHistory).map((item) => (
                     <HistoryRow
                       key={item.key}
                       item={item}
@@ -493,6 +528,14 @@ const UserProfile = () => {
                       onOpenDetails={() => setSelectedHistoryGroup(item)}
                     />
                   ))}
+                  {groupedOwnHistory.length > visibleHistory && (
+                    <Flex justify="center" py={3}>
+                      <Box as="button" onClick={() => setVisibleHistory(c => c + PROFILE_PAGE_SIZE)}
+                        px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
+                        style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
+                      >Show more ({groupedOwnHistory.length - visibleHistory})</Box>
+                    </Flex>
+                  )}
                 </Box>
               ))}
               </Box>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -37,14 +37,11 @@ import { ServiceCard } from '@/components/profile/ServiceCard'
 import { ProfileReviewRow } from '@/components/profile/ProfileReviewRow'
 import { MyReportsList } from '@/pages/MyReports'
 import { useMyReports } from '@/hooks/useMyReports'
+import { useReveal } from '@/hooks/useReveal'
 
 // ── Shared helpers (still used by tab content) ─────────────────────────────────
 const AVATAR_PALETTE = [GREEN, BLUE, TEAL, AMBER, '#0D9488', '#EA580C']
 const AVATAR_IMAGE_BG = `linear-gradient(180deg, ${WHITE} 0%, ${GRAY100} 100%)`
-// Profile tabs render every record the API returned in one go; for large
-// portfolios that meant 50 service cards stacked in a single grid. Reveal in
-// pages of 6 (one full 2x3 grid row) and let the user expand on demand.
-const PROFILE_PAGE_SIZE = 6
 const fmtDate = (d: string) =>
   new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 const fmtDur = (d: number | string) => `${Number(d)}h`
@@ -184,9 +181,9 @@ const UserProfile = () => {
   const [historyLoading, setHistoryLoading]   = useState(true)
   const [eventsLoading, setEventsLoading]     = useState(true)
   const [activeTab, setActiveTab]         = useState<ServiceTab>(initialTab)
-  const [visibleOffers, setVisibleOffers] = useState(PROFILE_PAGE_SIZE)
-  const [visibleNeeds, setVisibleNeeds]   = useState(PROFILE_PAGE_SIZE)
-  const [visibleHistory, setVisibleHistory] = useState(PROFILE_PAGE_SIZE)
+  const { visible: visibleOffers, showMore: showMoreOffers } = useReveal(userId)
+  const { visible: visibleNeeds, showMore: showMoreNeeds } = useReveal(userId)
+  const { visible: visibleHistory, showMore: showMoreHistory } = useReveal(userId)
   const { reports: myReports, error: myReportsError } = useMyReports()
 
   useEffect(() => {
@@ -244,14 +241,6 @@ const UserProfile = () => {
       setReviewsAsOrganizer(rOrganizer.results)
     }).catch(() => {}).finally(() => setReviewsLoading(false))
     return () => ac.abort()
-  }, [userId])
-
-  // Reset the per-tab reveal counters when switching profile views so a
-  // viewer who scrolled deep on one user doesn't land halfway into another.
-  useEffect(() => {
-    setVisibleOffers(PROFILE_PAGE_SIZE)
-    setVisibleNeeds(PROFILE_PAGE_SIZE)
-    setVisibleHistory(PROFILE_PAGE_SIZE)
   }, [userId])
 
   useEffect(() => {
@@ -433,7 +422,7 @@ const UserProfile = () => {
                   </Box>
                   {offersTab.length > visibleOffers && (
                     <Flex justify="center" pb={3}>
-                      <Box as="button" onClick={() => setVisibleOffers(c => c + PROFILE_PAGE_SIZE)}
+                      <Box as="button" onClick={showMoreOffers}
                         px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
                         style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
                       >Show more ({offersTab.length - visibleOffers})</Box>
@@ -462,7 +451,7 @@ const UserProfile = () => {
                   </Box>
                   {needsTab.length > visibleNeeds && (
                     <Flex justify="center" pb={3}>
-                      <Box as="button" onClick={() => setVisibleNeeds(c => c + PROFILE_PAGE_SIZE)}
+                      <Box as="button" onClick={showMoreNeeds}
                         px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
                         style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
                       >Show more ({needsTab.length - visibleNeeds})</Box>
@@ -530,7 +519,7 @@ const UserProfile = () => {
                   ))}
                   {groupedOwnHistory.length > visibleHistory && (
                     <Flex justify="center" py={3}>
-                      <Box as="button" onClick={() => setVisibleHistory(c => c + PROFILE_PAGE_SIZE)}
+                      <Box as="button" onClick={showMoreHistory}
                         px="14px" py="7px" borderRadius="8px" fontSize="12px" fontWeight={600}
                         style={{ background: GRAY100, color: GRAY600, border: `1px solid ${GRAY200}`, cursor: 'pointer' }}
                       >Show more ({groupedOwnHistory.length - visibleHistory})</Box>

--- a/frontend/src/test/hooks/useReveal.test.ts
+++ b/frontend/src/test/hooks/useReveal.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PROFILE_PAGE_SIZE, useReveal } from '@/hooks/useReveal'
+
+describe('useReveal', () => {
+  it('starts at PROFILE_PAGE_SIZE by default', () => {
+    const { result } = renderHook(() => useReveal('user-1'))
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE)
+  })
+
+  it('respects a custom page size for both initial value and increments', () => {
+    const { result } = renderHook(() => useReveal('user-1', 4))
+    expect(result.current.visible).toBe(4)
+    act(() => result.current.showMore())
+    expect(result.current.visible).toBe(8)
+  })
+
+  it('grows by pageSize each time showMore is called', () => {
+    const { result } = renderHook(() => useReveal('user-1'))
+    act(() => result.current.showMore())
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE * 2)
+    act(() => result.current.showMore())
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE * 3)
+  })
+
+  it('resets back to pageSize when resetKey changes', () => {
+    const { result, rerender } = renderHook(({ key }: { key: string }) => useReveal(key), {
+      initialProps: { key: 'user-1' },
+    })
+    act(() => result.current.showMore())
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE * 2)
+    rerender({ key: 'user-2' })
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE)
+  })
+
+  it('does not reset when resetKey stays the same across renders', () => {
+    const { result, rerender } = renderHook(({ key }: { key: string }) => useReveal(key), {
+      initialProps: { key: 'user-1' },
+    })
+    act(() => result.current.showMore())
+    rerender({ key: 'user-1' })
+    expect(result.current.visible).toBe(PROFILE_PAGE_SIZE * 2)
+  })
+})


### PR DESCRIPTION
Closes #629.

The web profile dumped every loaded record into a single grid (page_size 50 on services, no cap on history), so a power-user portfolio meant a long single scroll. Mobile already caps each list. Reveal in pages of six on web with a "Show more (N)" button beneath each grid.

## Changes

- `frontend/src/pages/UserProfile.tsx`: add `PROFILE_PAGE_SIZE = 6`, three `visible*` counters, and a reset effect on `userId` change. Slice Offers / Needs / History before rendering and append a "Show more" button while remaining items exist. Tab counters (`offersTab.length`, etc.) still reflect totals so the chips don't lie.
- Events tab unchanged: it splits into "Created" / "Joined" sub-sections that are already short in practice; not worth a counter per sub-list yet.
- Reviews unchanged: already grouped per role with an accordion on the Organizer side.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx eslint src/pages/UserProfile.tsx` clean
- [x] `npx vitest run` — 773 tests pass
- [ ] Open `/profile` for a user with >6 offers, verify "Show more (N)" appears, decrements as you click, hides at the tail
- [ ] Switch profiles via `/public-profile/:id` and confirm the counter resets