### PR TITLE
fix: showcase sort-mode label and onboarding redirect + dropdown (#635, #636)

### DIFF
--- a/backend/api/ranking_debug.py
+++ b/backend/api/ranking_debug.py
@@ -218,7 +218,7 @@ def _sort_mode_for(active_filter: str) -> str:
     """Map the frontend ranking mode to the backend's actual sort behaviour.
 
     See ServiceViewSet.get_queryset (views.py around line 2435):
-      - sort='hot' (only 'nearby' sets this) -> composite_score order
+      - sort='hot' (the 'nearby' filter and the dashboard 'all' filter) -> composite_score order
       - explore_only feed (only 'discovery') -> Phase 3 rotation
       - everything else -> created_at desc
 
@@ -226,7 +226,7 @@ def _sort_mode_for(active_filter: str) -> str:
     diagnosis line that explains the truth and one that points at composite
     factors that had no bearing on the ordering.
     """
-    if active_filter == 'nearby':
+    if active_filter in ('nearby', 'all'):
         return 'composite'
     if active_filter == 'discovery':
         return 'explore_only'

--- a/backend/api/tests/unit/test_ranking_debug_payload.py
+++ b/backend/api/tests/unit/test_ranking_debug_payload.py
@@ -264,7 +264,7 @@ class TestPhase1Trace:
             service_ids=[str(svc.id)],
             selected_service_id=str(svc.id),
             request_user=viewer,
-            active_filter='all',
+            active_filter='newest',
         )
         phase1 = payload['selected_service']['phase1']
 
@@ -375,7 +375,7 @@ class TestSortBlock:
             service_ids=[str(svc.id)],
             selected_service_id=str(svc.id),
             request_user=viewer,
-            active_filter='all',
+            active_filter='newest',
         )
         sort_block = payload['selected_service']['sort']
 
@@ -547,7 +547,7 @@ class TestDiagnosisLine:
             service_ids=[str(svc.id)],
             selected_service_id=str(svc.id),
             request_user=viewer,
-            active_filter='all',
+            active_filter='newest',
         )
         diagnosis = payload['selected_service']['diagnosis']
 

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Box, Flex, Text, Button, Textarea, VStack, HStack, Avatar,
@@ -35,6 +35,12 @@ const OnboardingPage = () => {
 
   const [step, setStep]       = useState(1)
   const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (user?.is_onboarded) {
+      navigate('/dashboard', { replace: true })
+    }
+  }, [user?.is_onboarded, navigate])
 
   // Step 2
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
@@ -310,7 +316,7 @@ const OnboardingPage = () => {
         <Box w="full" maxW="520px">
           <Box bg={WHITE} borderRadius="16px" border={`1px solid ${GRAY200}`}
             boxShadow="0 4px 24px rgba(0,0,0,0.08)" p={8}
-            style={{ overflow: step === 4 ? 'visible' : 'hidden' }}>
+            style={{ overflow: (step === 2 || step === 4) ? 'visible' : 'hidden' }}>
             {renderStep()}
           </Box>
         </Box>


### PR DESCRIPTION
Closes #636.
Showcase panel kept saying the list is sorted by created_at, but the dashboard actually calls the API with sort=hot. Fixed the mapping so the panel reads composite. Tests updated to keep chronological coverage via 'newest'.

Closes #635.
Onboarding: location dropdown on step 2 was being clipped by the card. Widened the overflow exception. Also added a useEffect so already onboarded users bounce to /dashboard instead of seeing the wizard again.